### PR TITLE
refactor: extract lending quote math into server lib and /api/quote (#181)

### DIFF
--- a/app/api/quote/route.test.ts
+++ b/app/api/quote/route.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { POST } from "./route";
+
+describe("POST /api/quote", () => {
+  it("returns a lending quote for valid input", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/quote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "lend",
+          data: {
+            asset: "XLM",
+            amount: 1000,
+            interestRate: 10,
+            duration: 30,
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      result: { dailyEarnings: number; totalEarnings: number };
+    };
+
+    expect(json.result.dailyEarnings).toBeCloseTo(0.273972602739726, 10);
+    expect(json.result.totalEarnings).toBeCloseTo(8.21917808219178, 10);
+  });
+
+  it("returns a borrowing quote for valid input", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/quote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "borrow",
+          data: {
+            asset: "XLM",
+            amount: 1000,
+            interestRate: 12,
+            duration: 30,
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      result: {
+        monthlyPayment: number;
+        totalRepayment: number;
+        totalEarnings: number;
+        dailyEarnings: number;
+      };
+    };
+
+    expect(json.result.monthlyPayment).toBeCloseTo(1010, 10);
+    expect(json.result.totalRepayment).toBeCloseTo(1010, 10);
+    expect(json.result.totalEarnings).toBeCloseTo(10, 10);
+    expect(json.result.dailyEarnings).toBeCloseTo(10 / 30, 10);
+  });
+
+  it("rejects invalid input", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/quote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "lend",
+          data: {
+            asset: "XLM",
+            amount: 0,
+            interestRate: 10,
+            duration: 30,
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.code).toBe("INVALID_INPUT");
+  });
+});
+

--- a/app/api/quote/route.ts
+++ b/app/api/quote/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import type { LendingData } from "@/lib/lending/types";
+import { calculateQuote, type LendingQuoteType } from "@/lib/lending/quote";
+
+export const runtime = "nodejs";
+
+type QuoteRequestBody = {
+  type: LendingQuoteType;
+  data: LendingData;
+};
+
+const invalidBody = () =>
+  NextResponse.json(
+    { error: { code: "INVALID_INPUT", message: "Invalid request body." } },
+    { status: 400 }
+  );
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return invalidBody();
+  }
+
+  const payload = body as Partial<QuoteRequestBody>;
+
+  if (!payload || typeof payload !== "object") return invalidBody();
+
+  if (
+    payload.type !== "lend" &&
+    payload.type !== "borrow"
+  ) {
+    return invalidBody();
+  }
+
+  if (!payload.data || typeof payload.data !== "object") return invalidBody();
+
+  const outcome = calculateQuote(payload.type, payload.data as LendingData);
+
+  if (!outcome.ok) {
+    return NextResponse.json({ error: outcome.error }, { status: 400 });
+  }
+
+  return NextResponse.json({ result: outcome.result }, { status: 200 });
+}
+

--- a/app/lending/page.tsx
+++ b/app/lending/page.tsx
@@ -9,21 +9,8 @@ import ConfirmModal from '@/components/features/lending/components/ConfirmModal'
 import TabSelector from '@/components/features/lending/components/TabSelector';
 import { PageHeader } from '@/components/shared/common';
 
-export interface LendingData {
-  asset: string;
-  amount: number;
-  interestRate: number;
-  duration?: number;
-  collateral?: string;
-  collateralAmount?: number;
-}
-
-export interface CalculationResult {
-  totalEarnings: number;
-  dailyEarnings: number;
-  totalRepayment?: number;
-  monthlyPayment?: number;
-}
+export type { LendingData, CalculationResult } from '@/lib/lending/types';
+import type { LendingData, CalculationResult } from '@/lib/lending/types';
 
 export default function LendingPage() {
   const [activeTab, setActiveTab] = useState<'lend' | 'borrow'>('lend');

--- a/components/features/lending/components/InterestCalculator.tsx
+++ b/components/features/lending/components/InterestCalculator.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { LendingData, CalculationResult } from '@/app/lending/page';
+import type { LendingData, CalculationResult } from '@/lib/lending/types';
+import { calculateQuote } from '@/lib/lending/quote';
 
 interface InterestCalculatorProps {
   data: LendingData;
@@ -13,51 +14,21 @@ export default function InterestCalculator({ data, type, onCalculate }: Interest
   const [calculation, setCalculation] = useState<CalculationResult | null>(null);
 
   useEffect(() => {
-    if (data.amount > 0 && data.interestRate > 0) {
-      calculateInterest();
+    if (data.amount <= 0 || data.interestRate <= 0) {
+      setCalculation(null);
+      return;
     }
-  }, [data.amount, data.interestRate, data.duration, type]);
 
-  const calculateInterest = () => {
-    const { amount, interestRate, duration = 30 } = data;
+    const outcome = calculateQuote(type, data);
 
-    if (type === 'lend') {
-      // Lending calculations
-      const dailyRate = interestRate / 365 / 100;
-      const dailyEarnings = amount * dailyRate;
-      const totalEarnings = dailyEarnings * duration;
-
-      const result: CalculationResult = {
-        totalEarnings,
-        dailyEarnings,
-      };
-
-      setCalculation(result);
-      onCalculate(result);
-    } else {
-      // Borrowing calculations
-      const monthlyRate = interestRate / 12 / 100;
-      const numberOfPayments = Math.ceil(duration / 30);
-
-      const monthlyPayment = numberOfPayments > 0
-        ? (amount * monthlyRate * Math.pow(1 + monthlyRate, numberOfPayments)) /
-          (Math.pow(1 + monthlyRate, numberOfPayments) - 1)
-        : 0;
-
-      const totalRepayment = monthlyPayment * numberOfPayments;
-      const totalInterest = totalRepayment - amount;
-
-      const result: CalculationResult = {
-        totalEarnings: totalInterest,
-        dailyEarnings: totalInterest / duration,
-        totalRepayment,
-        monthlyPayment,
-      };
-
-      setCalculation(result);
-      onCalculate(result);
+    if (!outcome.ok) {
+      setCalculation(null);
+      return;
     }
-  };
+
+    setCalculation(outcome.result);
+    onCalculate(outcome.result);
+  }, [data.amount, data.interestRate, data.duration, type, onCalculate]);
 
   if (!calculation && data.amount > 0) {
     return (

--- a/docs/lending-quote-api.md
+++ b/docs/lending-quote-api.md
@@ -1,0 +1,52 @@
+# Lending quote API
+
+## Endpoint
+
+`POST /api/quote`
+
+## Request body
+
+```json
+{
+  "type": "lend",
+  "data": {
+    "asset": "XLM",
+    "amount": 1000,
+    "interestRate": 10,
+    "duration": 30
+  }
+}
+```
+
+- `type`: `"lend"` or `"borrow"`
+- `data.amount`: positive number
+- `data.interestRate`: positive number (percent)
+- `data.duration`: optional days (defaults to 30 for borrow)
+
+## Response
+
+```json
+{
+  "result": {
+    "totalEarnings": 8.22,
+    "dailyEarnings": 0.27,
+    "totalRepayment": 1010,
+    "monthlyPayment": 1010
+  }
+}
+```
+
+Borrow responses include `monthlyPayment` and `totalRepayment`. Lend responses include `totalEarnings` and `dailyEarnings`.
+
+## Errors
+
+```json
+{
+  "error": {
+    "code": "INVALID_INPUT",
+    "message": "Invalid input for quote calculation."
+  }
+}
+```
+
+Shared calculation logic lives in `lib/lending/quote.ts` and is used by `InterestCalculator` and this route.

--- a/lib/lending/quote.test.ts
+++ b/lib/lending/quote.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { calculateQuote } from "./quote";
+
+describe("lending quote lib", () => {
+  it("calculates lend quote with daily compounding model", () => {
+    const outcome = calculateQuote("lend", {
+      asset: "XLM",
+      amount: 1000,
+      interestRate: 10,
+      duration: 30,
+    });
+
+    if (!outcome.ok) throw new Error(outcome.error.message);
+
+    expect(outcome.result.dailyEarnings).toBeCloseTo(
+      0.273972602739726,
+      10
+    );
+    expect(outcome.result.totalEarnings).toBeCloseTo(8.21917808219178, 10);
+  });
+
+  it("calculates borrow quote with amortized monthly payment", () => {
+    const outcome = calculateQuote("borrow", {
+      asset: "XLM",
+      amount: 1000,
+      interestRate: 12,
+      duration: 30,
+    });
+
+    if (!outcome.ok) throw new Error(outcome.error.message);
+
+    expect(outcome.result.monthlyPayment).toBeCloseTo(1010, 10);
+    expect(outcome.result.totalRepayment).toBeCloseTo(1010, 10);
+    expect(outcome.result.totalEarnings).toBeCloseTo(10, 10);
+    expect(outcome.result.dailyEarnings).toBeCloseTo(10 / 30, 10);
+  });
+
+  it("defaults borrow duration to 30 days when omitted", () => {
+    const outcome = calculateQuote("borrow", {
+      asset: "XLM",
+      amount: 1000,
+      interestRate: 12,
+    });
+
+    if (!outcome.ok) throw new Error(outcome.error.message);
+
+    expect(outcome.result.monthlyPayment).toBeCloseTo(1010, 10);
+    expect(outcome.result.totalRepayment).toBeCloseTo(1010, 10);
+  });
+
+  it("rejects non-positive input", () => {
+    const outcome = calculateQuote("lend", {
+      asset: "XLM",
+      amount: 0,
+      interestRate: 10,
+      duration: 30,
+    });
+
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) throw new Error("expected failure");
+    expect(outcome.error.code).toBe("INVALID_INPUT");
+  });
+});
+

--- a/lib/lending/quote.ts
+++ b/lib/lending/quote.ts
@@ -1,0 +1,133 @@
+import type { CalculationResult, LendingData } from "@/lib/lending/types";
+
+export type LendingQuoteType = "lend" | "borrow";
+
+export type QuoteErrorCode =
+  | "INVALID_INPUT"
+  | "DIVIDE_BY_ZERO"
+  | "NON_FINITE_RESULT";
+
+export type QuoteError = {
+  code: QuoteErrorCode;
+  message: string;
+};
+
+export type QuoteOutcome =
+  | { ok: true; result: CalculationResult }
+  | { ok: false; error: QuoteError };
+
+const DEFAULT_DURATION_DAYS = 30;
+
+const isPositiveFinite = (value: number) =>
+  Number.isFinite(value) && value > 0;
+
+const assertValidType = (type: unknown): type is LendingQuoteType =>
+  type === "lend" || type === "borrow";
+
+export function calculateQuote(
+  type: LendingQuoteType,
+  data: LendingData
+): QuoteOutcome {
+  const amount = data.amount;
+  const interestRate = data.interestRate;
+  const durationDays = data.duration ?? DEFAULT_DURATION_DAYS;
+
+  if (
+    !isPositiveFinite(amount) ||
+    !isPositiveFinite(interestRate) ||
+    !isPositiveFinite(durationDays) ||
+    !assertValidType(type)
+  ) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_INPUT",
+        message: "Invalid input for quote calculation.",
+      },
+    };
+  }
+
+  if (type === "lend") {
+    const dailyRate = interestRate / 365 / 100;
+    const dailyEarnings = amount * dailyRate;
+    const totalEarnings = dailyEarnings * durationDays;
+
+    if (
+      !Number.isFinite(dailyEarnings) ||
+      !Number.isFinite(totalEarnings)
+    ) {
+      return {
+        ok: false,
+        error: { code: "NON_FINITE_RESULT", message: "Non-finite result." },
+      };
+    }
+
+    return {
+      ok: true,
+      result: {
+        totalEarnings,
+        dailyEarnings,
+      },
+    };
+  }
+
+  const monthlyRate = interestRate / 12 / 100;
+  const numberOfPayments = Math.ceil(durationDays / 30);
+
+  if (!isPositiveFinite(monthlyRate) || numberOfPayments <= 0) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_INPUT",
+        message: "Invalid input for borrowing quote.",
+      },
+    };
+  }
+
+  const growth = Math.pow(1 + monthlyRate, numberOfPayments);
+  const denominator = growth - 1;
+
+  if (!Number.isFinite(growth) || !Number.isFinite(denominator)) {
+    return {
+      ok: false,
+      error: { code: "NON_FINITE_RESULT", message: "Non-finite result." },
+    };
+  }
+
+  if (denominator === 0) {
+    return {
+      ok: false,
+      error: { code: "DIVIDE_BY_ZERO", message: "Denominator is zero." },
+    };
+  }
+
+  const monthlyPayment =
+    (amount * monthlyRate * growth) / denominator;
+
+  const totalRepayment = monthlyPayment * numberOfPayments;
+  const totalInterest = totalRepayment - amount;
+  const dailyEarnings = totalInterest / durationDays;
+
+  if (
+    !Number.isFinite(monthlyPayment) ||
+    !Number.isFinite(totalRepayment) ||
+    !Number.isFinite(totalInterest) ||
+    !Number.isFinite(dailyEarnings)
+  ) {
+    return {
+      ok: false,
+      error: { code: "NON_FINITE_RESULT", message: "Non-finite result." },
+    };
+  }
+
+  return {
+    ok: true,
+    result: {
+      totalEarnings: totalInterest,
+      dailyEarnings,
+      totalRepayment,
+      monthlyPayment,
+    },
+  };
+}
+

--- a/lib/lending/types.ts
+++ b/lib/lending/types.ts
@@ -1,0 +1,15 @@
+export interface LendingData {
+  asset: string;
+  amount: number;
+  interestRate: number;
+  duration?: number;
+  collateral?: string;
+  collateralAmount?: number;
+}
+
+export interface CalculationResult {
+  totalEarnings: number;
+  dailyEarnings: number;
+  totalRepayment?: number;
+  monthlyPayment?: number;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,11 @@ const dirname =
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.join(dirname, "."),
+    },
+  },
   test: {
     projects: [
       {
@@ -30,6 +35,18 @@ export default defineConfig({
             instances: [{ browser: "chromium" }],
           },
           setupFiles: [".storybook/vitest.setup.ts"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          environment: "node",
+          include: [
+            "lib/**/*.test.ts",
+            "app/api/**/*.test.ts",
+            "components/**/*.test.tsx",
+          ],
         },
       },
       {


### PR DESCRIPTION
## Summary

- Extracted lend/borrow quote math from `InterestCalculator.tsx` into `lib/lending/quote.ts` so client and server share one calculation path.
- Added `POST /api/quote` to return validated quotes from `LendingData`, with checks for positive amount/rate/duration and divide-by-zero protection.
- Refactored `InterestCalculator` to call `calculateQuote()` instead of duplicating formulas; moved shared types to `lib/lending/types.ts`.

Closes #181

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [x] Refactor (no functional change)
- [x] Documentation only

---

## What changed

| Area | Change |
|------|--------|
| `lib/lending/quote.ts` | Shared lend/borrow quote logic |
| `lib/lending/types.ts` | `LendingData`, `CalculationResult` |
| `app/api/quote/route.ts` | Server quote endpoint |
| `InterestCalculator.tsx` | Uses shared lib (no inline math) |
| `docs/lending-quote-api.md` | API documentation |
| Tests | `lib/lending/quote.test.ts`, `app/api/quote/route.test.ts` |

## Test plan

- [x] `npm test -- --project unit --run lib/lending/quote.test.ts app/api/quote/route.test.ts`
- [x] `npm run type-check`
- [ ] Manual: open `/lending`, enter lend/borrow amounts, confirm calculator matches prior behavior
- [ ] Manual: `POST /api/quote` with valid/invalid payloads returns 200/400 as expected

## Notes

- Lend: daily earnings = `amount * (rate/365/100)`, total = daily × duration days.
- Borrow: amortized monthly payment; duration defaults to 30 days when omitted.
- `package-lock.json` / `yarn.lock` were not committed (install-only churn, no dependency changes).
