### PR TITLE
feat: add Stellar Horizon transaction indexer

### DIFF
--- a/lib/indexer/__tests__/horizon.test.ts
+++ b/lib/indexer/__tests__/horizon.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchAccountOperations, HorizonError } from '../horizon';
+import { normalizeOperation, normalizeOperations } from '../normalizer';
+import { IndexerCache } from '../cache';
+import { indexAccountTransactions, invalidateAccountCache } from '../index';
+import type { HorizonOperation, HorizonPage } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ACCOUNT = 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890ABCDEFGH';
+const OTHER   = 'GXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890ABCDEFGH';
+
+function makeOp(overrides: Partial<HorizonOperation> = {}): HorizonOperation {
+  return {
+    id: 'op-001',
+    type: 'payment',
+    created_at: '2024-03-15T14:30:00Z',
+    transaction_successful: true,
+    from: OTHER,
+    to: ACCOUNT,
+    amount: '100.0000000',
+    asset_type: 'native',
+    ...overrides,
+  };
+}
+
+function makeHorizonPage(records: HorizonOperation[], nextHref?: string): HorizonPage {
+  return {
+    _embedded: { records },
+    _links: {
+      self: { href: 'https://horizon-testnet.stellar.org/accounts/GA.../operations' },
+      ...(nextHref ? { next: { href: nextHref } } : {}),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// normalizeOperation
+// ---------------------------------------------------------------------------
+
+describe('normalizeOperation', () => {
+  it('maps an incoming payment to a Deposit with positive amount', () => {
+    const op = makeOp({ to: ACCOUNT, from: OTHER, amount: '250.5', asset_type: 'native' });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.type).toBe('Deposit');
+    expect(tx!.amount).toBeCloseTo(250.5);
+    expect(tx!.asset).toBe('XLM');
+    expect(tx!.status).toBe('Completed');
+  });
+
+  it('maps an outgoing payment to a Withdrawal with negative amount', () => {
+    const op = makeOp({ from: ACCOUNT, to: OTHER, amount: '50.0', asset_type: 'native' });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.type).toBe('Withdrawal');
+    expect(tx!.amount).toBeCloseTo(-50.0);
+  });
+
+  it('maps a payment in a supported non-native asset', () => {
+    const op = makeOp({
+      to: ACCOUNT,
+      from: OTHER,
+      amount: '10.0',
+      asset_type: 'credit_alphanum4',
+      asset_code: 'USDC',
+      asset_issuer: 'GABCISSUER',
+    });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.asset).toBe('USDC');
+  });
+
+  it('returns null for an unsupported asset code', () => {
+    const op = makeOp({
+      to: ACCOUNT,
+      asset_type: 'credit_alphanum4',
+      asset_code: 'AQUA',
+    });
+    expect(normalizeOperation(op, ACCOUNT)).toBeNull();
+  });
+
+  it('maps a failed payment to status Failed', () => {
+    const op = makeOp({ transaction_successful: false });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.status).toBe('Failed');
+  });
+
+  it('returns null for a payment with zero amount', () => {
+    const op = makeOp({ amount: '0.0000000' });
+    expect(normalizeOperation(op, ACCOUNT)).toBeNull();
+  });
+
+  it('maps create_account (incoming) to a Deposit in XLM', () => {
+    const op = makeOp({
+      type: 'create_account',
+      account: ACCOUNT,
+      funder: OTHER,
+      starting_balance: '1000.0',
+      amount: undefined,
+      from: undefined,
+      to: undefined,
+    });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.type).toBe('Deposit');
+    expect(tx!.asset).toBe('XLM');
+    expect(tx!.amount).toBeCloseTo(1000.0);
+  });
+
+  it('maps create_account (outgoing funder) to a Withdrawal in XLM', () => {
+    const op = makeOp({
+      type: 'create_account',
+      account: OTHER,
+      funder: ACCOUNT,
+      starting_balance: '500.0',
+      amount: undefined,
+      from: undefined,
+      to: undefined,
+    });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.type).toBe('Withdrawal');
+    expect(tx!.amount).toBeCloseTo(-500.0);
+  });
+
+  it('maps incoming path_payment_strict_send to a Deposit', () => {
+    const op = makeOp({
+      type: 'path_payment_strict_send',
+      to: ACCOUNT,
+      from: OTHER,
+      asset_type: 'native',
+      destination_amount: '75.0',
+    });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.type).toBe('Deposit');
+    expect(tx!.amount).toBeCloseTo(75.0);
+  });
+
+  it('maps outgoing path_payment_strict_receive to a Withdrawal', () => {
+    const op = makeOp({
+      type: 'path_payment_strict_receive',
+      from: ACCOUNT,
+      to: OTHER,
+      source_asset_type: 'native',
+      source_amount: '30.0',
+    });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.type).toBe('Withdrawal');
+    expect(tx!.amount).toBeCloseTo(-30.0);
+  });
+
+  it('returns null for unhandled operation types like change_trust', () => {
+    const op = makeOp({ type: 'change_trust' });
+    expect(normalizeOperation(op, ACCOUNT)).toBeNull();
+  });
+
+  it('returns null for manage_sell_offer', () => {
+    const op = makeOp({ type: 'manage_sell_offer' });
+    expect(normalizeOperation(op, ACCOUNT)).toBeNull();
+  });
+
+  it('formats date and time correctly from ISO timestamp', () => {
+    const op = makeOp({ created_at: '2024-03-15T14:30:00Z' });
+    const tx = normalizeOperation(op, ACCOUNT);
+
+    expect(tx).not.toBeNull();
+    expect(tx!.date).toBe('2024-03-15');
+    expect(tx!.time).toBe('02:30PM');
+  });
+
+  it('preserves the Horizon operation id as the transaction id', () => {
+    const op = makeOp({ id: 'horizon-op-99999' });
+    const tx = normalizeOperation(op, ACCOUNT);
+    expect(tx!.id).toBe('horizon-op-99999');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeOperations
+// ---------------------------------------------------------------------------
+
+describe('normalizeOperations', () => {
+  it('filters out null results and returns only mappable operations', () => {
+    const ops: HorizonOperation[] = [
+      makeOp({ id: 'op-1', to: ACCOUNT, amount: '100.0' }),
+      makeOp({ id: 'op-2', type: 'change_trust' }),
+      makeOp({ id: 'op-3', to: ACCOUNT, amount: '200.0' }),
+    ];
+    const txs = normalizeOperations(ops, ACCOUNT);
+    expect(txs).toHaveLength(2);
+    expect(txs.map((t) => t.id)).toEqual(['op-1', 'op-3']);
+  });
+
+  it('returns an empty array when no operations are mappable', () => {
+    const ops = [makeOp({ type: 'set_options' }), makeOp({ type: 'manage_data' })];
+    expect(normalizeOperations(ops, ACCOUNT)).toHaveLength(0);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(normalizeOperations([], ACCOUNT)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IndexerCache
+// ---------------------------------------------------------------------------
+
+describe('IndexerCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns null for a missing key', () => {
+    const c = new IndexerCache<string>();
+    expect(c.get('missing')).toBeNull();
+  });
+
+  it('returns the stored value before TTL expires', () => {
+    const c = new IndexerCache<string>();
+    c.set('k', 'hello', 5_000);
+    expect(c.get('k')).toBe('hello');
+  });
+
+  it('returns null after TTL expires', () => {
+    const c = new IndexerCache<string>();
+    c.set('k', 'hello', 5_000);
+    vi.advanceTimersByTime(5_001);
+    expect(c.get('k')).toBeNull();
+  });
+
+  it('invalidate removes the entry immediately', () => {
+    const c = new IndexerCache<string>();
+    c.set('k', 'value', 60_000);
+    c.invalidate('k');
+    expect(c.get('k')).toBeNull();
+  });
+
+  it('clear removes all entries', () => {
+    const c = new IndexerCache<number>();
+    c.set('a', 1);
+    c.set('b', 2);
+    c.clear();
+    expect(c.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchAccountOperations (mocked fetch)
+// ---------------------------------------------------------------------------
+
+describe('fetchAccountOperations', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns operations from a single-page response', async () => {
+    const ops = [makeOp({ id: 'op-1' }), makeOp({ id: 'op-2' })];
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeHorizonPage(ops),
+    } as Response);
+
+    const result = await fetchAccountOperations(ACCOUNT, { limit: 200 });
+    expect(result).toHaveLength(2);
+  });
+
+  it('paginates through multiple pages until a partial page is returned', async () => {
+    const page1Ops = Array.from({ length: 2 }, (_, i) => makeOp({ id: `op-${i}` }));
+    const page2Ops = [makeOp({ id: 'op-last' })];
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeHorizonPage(page1Ops, 'https://horizon-testnet.stellar.org/next'),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeHorizonPage(page2Ops),
+      } as Response);
+
+    const result = await fetchAccountOperations(ACCOUNT, { limit: 2 });
+    expect(result).toHaveLength(3);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws HorizonError on a 404 response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as Response);
+
+    await expect(fetchAccountOperations(ACCOUNT)).rejects.toThrow(HorizonError);
+  });
+
+  it('throws HorizonError on a 503 response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    } as Response);
+
+    await expect(fetchAccountOperations(ACCOUNT)).rejects.toThrow(HorizonError);
+  });
+
+  it('throws HorizonError when fetch rejects (network failure)', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('network error'));
+    await expect(fetchAccountOperations(ACCOUNT)).rejects.toThrow(HorizonError);
+  });
+
+  it('throws HorizonError on an abort (timeout)', async () => {
+    vi.mocked(fetch).mockImplementationOnce(() => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      return Promise.reject(err);
+    });
+
+    await expect(fetchAccountOperations(ACCOUNT, { timeoutMs: 100 })).rejects.toThrow(
+      HorizonError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// indexAccountTransactions (end-to-end with mocked fetch)
+// ---------------------------------------------------------------------------
+
+describe('indexAccountTransactions', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    invalidateAccountCache(ACCOUNT);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns normalized transactions from Horizon operations', async () => {
+    const ops = [
+      makeOp({ id: 'op-1', to: ACCOUNT, amount: '100.0', asset_type: 'native' }),
+      makeOp({ id: 'op-2', type: 'change_trust' }), // should be filtered
+    ];
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeHorizonPage(ops),
+    } as Response);
+
+    const txs = await indexAccountTransactions(ACCOUNT, { bypassCache: true });
+
+    expect(txs).toHaveLength(1);
+    expect(txs[0].id).toBe('op-1');
+    expect(txs[0].type).toBe('Deposit');
+  });
+
+  it('returns cached result on second call without hitting fetch again', async () => {
+    const ops = [makeOp({ id: 'op-1', to: ACCOUNT, amount: '50.0' })];
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => makeHorizonPage(ops),
+    } as Response);
+
+    await indexAccountTransactions(ACCOUNT, { bypassCache: true });
+    await indexAccountTransactions(ACCOUNT);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('bypasses the cache when bypassCache is true', async () => {
+    const ops = [makeOp({ id: 'op-1', to: ACCOUNT, amount: '50.0' })];
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => makeHorizonPage(ops),
+    } as Response);
+
+    await indexAccountTransactions(ACCOUNT, { bypassCache: true });
+    await indexAccountTransactions(ACCOUNT, { bypassCache: true });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates HorizonError so callers can apply their own fallback', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as Response);
+
+    await expect(
+      indexAccountTransactions(ACCOUNT, { bypassCache: true }),
+    ).rejects.toThrow(HorizonError);
+  });
+});

--- a/lib/indexer/cache.ts
+++ b/lib/indexer/cache.ts
@@ -1,0 +1,43 @@
+export const DEFAULT_TTL_MS = 60_000;
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+/**
+ * Lightweight in-process TTL cache.
+ *
+ * Entries expire passively on read; no background sweep is run, which keeps
+ * the implementation dependency-free and suitable for a serverless edge
+ * runtime where timer-based cleanup is unreliable.
+ */
+export class IndexerCache<T> {
+  private readonly store = new Map<string, CacheEntry<T>>();
+
+  get(key: string): T | null {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: T, ttlMs = DEFAULT_TTL_MS): void {
+    this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+
+  invalidate(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+}

--- a/lib/indexer/horizon.ts
+++ b/lib/indexer/horizon.ts
@@ -1,0 +1,95 @@
+import config from '@/lib/config';
+import { logger } from '@/lib/logger';
+import type { HorizonOperation, HorizonPage, IndexerOptions } from './types';
+
+const ROUTE = 'lib/indexer/horizon';
+const DEFAULT_LIMIT = 200;
+const DEFAULT_MAX_PAGES = 5;
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+export class HorizonError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly accountId?: string,
+  ) {
+    super(message);
+    this.name = 'HorizonError';
+  }
+}
+
+async function fetchPage(url: string, timeoutMs: number): Promise<HorizonPage> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new HorizonError(
+        `Horizon responded with ${response.status}: ${response.statusText}`,
+        response.status,
+      );
+    }
+
+    return (await response.json()) as HorizonPage;
+  } catch (err) {
+    if (err instanceof HorizonError) throw err;
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new HorizonError(`Horizon request timed out after ${timeoutMs}ms`);
+    }
+    throw new HorizonError(`Horizon fetch failed: ${String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetches all relevant operations for a Stellar account from Horizon.
+ *
+ * Paginates automatically up to `maxPages` pages (default 5 × 200 = 1 000
+ * operations per call). Stops early when Horizon returns fewer records than
+ * `limit`, indicating the last page has been reached.
+ *
+ * Throws `HorizonError` on non-2xx responses or network timeouts.
+ */
+export async function fetchAccountOperations(
+  accountId: string,
+  options: IndexerOptions = {},
+): Promise<HorizonOperation[]> {
+  const {
+    limit = DEFAULT_LIMIT,
+    order = 'desc',
+    cursor,
+    maxPages = DEFAULT_MAX_PAGES,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = options;
+
+  const base = `${config.stellar.horizonUrl}/accounts/${encodeURIComponent(accountId)}/operations`;
+  const params = new URLSearchParams({ limit: String(Math.min(limit, 200)), order });
+  if (cursor) params.set('cursor', cursor);
+
+  let url: string = `${base}?${params.toString()}`;
+  const operations: HorizonOperation[] = [];
+  let page = 0;
+
+  while (url && page < maxPages) {
+    logger.debug(`Fetching Horizon page ${page + 1} for account`, ROUTE, { accountId });
+
+    const data = await fetchPage(url, timeoutMs);
+    const records = data._embedded?.records ?? [];
+    operations.push(...records);
+    page++;
+
+    // Stop paginating when the response is a partial page (last page).
+    const nextHref = data._links?.next?.href;
+    url = nextHref && records.length >= limit ? nextHref : '';
+  }
+
+  logger.info(`Fetched ${operations.length} Horizon operations`, ROUTE, {
+    accountId,
+    pages: page,
+  });
+
+  return operations;
+}

--- a/lib/indexer/index.ts
+++ b/lib/indexer/index.ts
@@ -1,0 +1,60 @@
+import type { Transaction } from '@/types/Transaction';
+import { logger } from '@/lib/logger';
+import type { IndexerOptions } from './types';
+import { fetchAccountOperations } from './horizon';
+import { normalizeOperations } from './normalizer';
+import { IndexerCache, DEFAULT_TTL_MS } from './cache';
+
+const ROUTE = 'lib/indexer';
+
+const cache = new IndexerCache<Transaction[]>();
+
+export interface IndexAccountOptions extends IndexerOptions {
+  /** TTL for cached results in milliseconds (default 60 000). */
+  cacheTtlMs?: number;
+  /** Skip the cache and force a fresh Horizon fetch. */
+  bypassCache?: boolean;
+}
+
+/**
+ * Fetches and normalizes on-chain operations for a Stellar account.
+ *
+ * Results are cached per account for `cacheTtlMs` milliseconds (default 60 s)
+ * so that repeated calls within the same window do not hammer Horizon.
+ *
+ * Errors from Horizon propagate as `HorizonError` instances; callers are
+ * responsible for deciding whether to surface them or fall back to stale data.
+ */
+export async function indexAccountTransactions(
+  accountId: string,
+  options: IndexAccountOptions = {},
+): Promise<Transaction[]> {
+  const { cacheTtlMs = DEFAULT_TTL_MS, bypassCache = false, ...fetchOptions } = options;
+
+  if (!bypassCache) {
+    const hit = cache.get(accountId);
+    if (hit) {
+      logger.debug('Returning cached transactions for account', ROUTE, { accountId });
+      return hit;
+    }
+  }
+
+  const operations = await fetchAccountOperations(accountId, fetchOptions);
+  const transactions = normalizeOperations(operations, accountId);
+
+  cache.set(accountId, transactions, cacheTtlMs);
+  logger.info(`Indexed ${transactions.length} transactions for account`, ROUTE, { accountId });
+
+  return transactions;
+}
+
+/** Removes cached results for the given account (e.g. after a new transaction is posted). */
+export function invalidateAccountCache(accountId: string): void {
+  cache.invalidate(accountId);
+  logger.debug('Cache invalidated for account', ROUTE, { accountId });
+}
+
+export type { IndexerOptions, IndexAccountOptions };
+export { HorizonError } from './horizon';
+export { normalizeOperation, normalizeOperations } from './normalizer';
+export { IndexerCache } from './cache';

--- a/lib/indexer/normalizer.ts
+++ b/lib/indexer/normalizer.ts
@@ -1,0 +1,119 @@
+import type { Transaction } from '@/types/Transaction';
+import type { AssetSymbol, TransactionType, TransactionStatus } from '@/types/enums';
+import { ASSET_SYMBOLS } from '@/types/enums';
+import type { HorizonOperation } from './types';
+
+function resolveAsset(assetType?: string, assetCode?: string): AssetSymbol | null {
+  if (assetType === 'native') return 'XLM';
+  if (!assetCode) return null;
+  const upper = assetCode.toUpperCase() as AssetSymbol;
+  return (ASSET_SYMBOLS as readonly string[]).includes(upper) ? upper : null;
+}
+
+function parseAmount(raw?: string): number | null {
+  if (raw === undefined || raw === null) return null;
+  const n = parseFloat(raw);
+  return isNaN(n) ? null : n;
+}
+
+function formatDateParts(isoString: string): { date: string; time: string } {
+  const d = new Date(isoString);
+  const date = d.toISOString().slice(0, 10);
+
+  let hours = d.getUTCHours();
+  const minutes = String(d.getUTCMinutes()).padStart(2, '0');
+  const meridiem = hours >= 12 ? 'PM' : 'AM';
+  hours = hours % 12 || 12;
+  const time = `${String(hours).padStart(2, '0')}:${minutes}${meridiem}`;
+
+  return { date, time };
+}
+
+function resolveStatus(successful: boolean): TransactionStatus {
+  return successful ? 'Completed' : 'Failed';
+}
+
+/**
+ * Maps a single Horizon operation to the internal Transaction shape.
+ *
+ * Returns null for operation types that have no Transaction equivalent
+ * (e.g. manage_offer, change_trust, set_options) or when required fields
+ * such as asset or amount are missing / unsupported.
+ *
+ * Amount sign convention:
+ *   positive  → funds received by the account (Deposit)
+ *   negative  → funds sent from the account (Withdrawal)
+ */
+export function normalizeOperation(
+  op: HorizonOperation,
+  accountId: string,
+): Transaction | null {
+  const { date, time } = formatDateParts(op.created_at);
+  const status = resolveStatus(op.transaction_successful);
+
+  if (op.type === 'payment') {
+    const asset = resolveAsset(op.asset_type, op.asset_code);
+    if (!asset) return null;
+
+    const raw = parseAmount(op.amount);
+    if (raw === null || raw === 0) return null;
+
+    const isIncoming = op.to === accountId;
+    const type: TransactionType = isIncoming ? 'Deposit' : 'Withdrawal';
+    const amount = isIncoming ? raw : -raw;
+
+    return { id: op.id, type, amount, asset, date, time, status };
+  }
+
+  if (op.type === 'create_account') {
+    const raw = parseAmount(op.starting_balance);
+    if (raw === null || raw === 0) return null;
+
+    const isIncoming = op.account === accountId;
+    const type: TransactionType = isIncoming ? 'Deposit' : 'Withdrawal';
+    const amount = isIncoming ? raw : -raw;
+
+    return { id: op.id, type, amount, asset: 'XLM', date, time, status };
+  }
+
+  if (
+    op.type === 'path_payment_strict_send' ||
+    op.type === 'path_payment_strict_receive'
+  ) {
+    const isIncoming = op.to === accountId;
+
+    const assetType = isIncoming ? op.asset_type : op.source_asset_type;
+    const assetCode = isIncoming ? op.asset_code : op.source_asset_code;
+    const asset = resolveAsset(assetType, assetCode);
+    if (!asset) return null;
+
+    const rawStr = isIncoming
+      ? (op.destination_amount ?? op.amount)
+      : (op.source_amount ?? op.amount);
+    const raw = parseAmount(rawStr);
+    if (raw === null || raw === 0) return null;
+
+    const type: TransactionType = isIncoming ? 'Deposit' : 'Withdrawal';
+    const amount = isIncoming ? raw : -raw;
+
+    return { id: op.id, type, amount, asset, date, time, status };
+  }
+
+  return null;
+}
+
+/**
+ * Normalizes a batch of Horizon operations for the given account.
+ * Operations that cannot be mapped are silently dropped.
+ */
+export function normalizeOperations(
+  operations: HorizonOperation[],
+  accountId: string,
+): Transaction[] {
+  const result: Transaction[] = [];
+  for (const op of operations) {
+    const tx = normalizeOperation(op, accountId);
+    if (tx !== null) result.push(tx);
+  }
+  return result;
+}

--- a/lib/indexer/types.ts
+++ b/lib/indexer/types.ts
@@ -1,0 +1,75 @@
+export type HorizonOperationType =
+  | 'create_account'
+  | 'payment'
+  | 'path_payment_strict_receive'
+  | 'path_payment_strict_send'
+  | 'manage_sell_offer'
+  | 'create_passive_sell_offer'
+  | 'set_options'
+  | 'change_trust'
+  | 'allow_trust'
+  | 'account_merge'
+  | 'manage_data'
+  | 'bump_sequence'
+  | 'manage_buy_offer'
+  | 'create_claimable_balance'
+  | 'claim_claimable_balance'
+  | 'begin_sponsoring_future_reserves'
+  | 'end_sponsoring_future_reserves'
+  | 'revoke_sponsorship'
+  | 'clawback'
+  | 'clawback_claimable_balance'
+  | 'set_trust_line_flags'
+  | 'liquidity_pool_deposit'
+  | 'liquidity_pool_withdraw'
+  | 'invoke_host_function'
+  | 'extend_footprint_ttl'
+  | 'restore_footprint';
+
+export interface HorizonOperation {
+  id: string;
+  type: HorizonOperationType;
+  created_at: string;
+  transaction_successful: boolean;
+  // payment / path_payment fields
+  from?: string;
+  to?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  source_amount?: string;
+  source_asset_type?: string;
+  source_asset_code?: string;
+  destination_amount?: string;
+  destination_asset_type?: string;
+  destination_asset_code?: string;
+  // create_account fields
+  starting_balance?: string;
+  funder?: string;
+  account?: string;
+}
+
+export interface HorizonPage {
+  _embedded: {
+    records: HorizonOperation[];
+  };
+  _links: {
+    next?: { href: string };
+    prev?: { href: string };
+    self: { href: string };
+  };
+}
+
+export interface IndexerOptions {
+  /** Max records per Horizon page request (1–200, default 200). */
+  limit?: number;
+  /** Sort order for operations (default 'desc'). */
+  order?: 'asc' | 'desc';
+  /** Horizon paging cursor to start from. */
+  cursor?: string;
+  /** Maximum number of pages to fetch per call (default 5). */
+  maxPages?: number;
+  /** Per-request timeout in milliseconds (default 8 000). */
+  timeoutMs?: number;
+}

--- a/lib/transactions/index.ts
+++ b/lib/transactions/index.ts
@@ -1,3 +1,3 @@
-export { fetchTransactions, filterTransactions } from './repository';
+export { fetchTransactions, fetchTransactionRecords, filterTransactions } from './repository';
 export { serializeTransactionsToCSV, escapeField } from './csv';
 export type { Transaction, TransactionStatus, TransactionAsset, TransactionFilters } from './types';

--- a/lib/transactions/repository.ts
+++ b/lib/transactions/repository.ts
@@ -1,4 +1,9 @@
 import type { Transaction, TransactionFilters } from './types';
+import type { Transaction as IndexerTransaction } from '@/types/Transaction';
+import { indexAccountTransactions } from '@/lib/indexer';
+import { logger } from '@/lib/logger';
+
+const ROUTE = 'lib/transactions/repository';
 
 const MOCK_TRANSACTIONS: Transaction[] = [
   { id: 'TXN12345', type: 'Deposit',      amount:  2000,    asset: 'XLM',  date: '2025-04-12', time: '09:32AM', status: 'Completed'  },
@@ -11,6 +16,35 @@ const MOCK_TRANSACTIONS: Transaction[] = [
 
 export async function fetchTransactions(): Promise<Transaction[]> {
   return MOCK_TRANSACTIONS;
+}
+
+/**
+ * Primary data source for the /api/transactions route.
+ *
+ * When the `STELLAR_INDEXER_ACCOUNT` environment variable is set, live
+ * on-chain operations are fetched from Horizon and normalized into the
+ * Transaction shape.  Falls back to the mock dataset when no account is
+ * configured or when Horizon is unavailable, ensuring the API remains
+ * functional in all environments.
+ */
+export async function fetchTransactionRecords(
+  accountId?: string,
+): Promise<IndexerTransaction[]> {
+  const account = accountId ?? process.env.STELLAR_INDEXER_ACCOUNT;
+
+  if (account) {
+    try {
+      return await indexAccountTransactions(account);
+    } catch (err) {
+      logger.warn(
+        'Horizon indexer failed; falling back to mock data',
+        ROUTE,
+        { error: String(err) },
+      );
+    }
+  }
+
+  return MOCK_TRANSACTIONS as unknown as IndexerTransaction[];
 }
 
 export function filterTransactions(


### PR DESCRIPTION
closes #187

## Summary

Adds a lightweight on-chain transaction indexer module at `lib/indexer/` that reads a Stellar account's operations from Horizon and normalizes them into the internal `Transaction` shape used by the API.

### New files

- `lib/indexer/types.ts` — TypeScript interfaces for Horizon operation and paginated response shapes
- `lib/indexer/horizon.ts` — `fetchAccountOperations()`: paginates Horizon `/accounts/{id}/operations` up to a configurable `maxPages` limit (default 5 × 200 = 1 000 ops), aborts on timeout via `AbortController`, and surfaces failures as typed `HorizonError` instances
- `lib/indexer/normalizer.ts` — `normalizeOperation()` / `normalizeOperations()`: maps `payment`, `create_account`, and `path_payment_strict_send/receive` operations to the `Transaction` interface; unsupported types (change_trust, manage_offer, set_options, etc.) return `null` and are silently dropped; amount sign follows the convention positive = received (Deposit), negative = sent (Withdrawal)
- `lib/indexer/cache.ts` — `IndexerCache<T>`: dependency-free in-process TTL cache with passive expiry on read; suitable for serverless/edge runtimes where background timers are unreliable
- `lib/indexer/index.ts` — `indexAccountTransactions()`: orchestrates fetch → normalize → cache; `invalidateAccountCache()` for post-write invalidation
- `lib/indexer/__tests__/horizon.test.ts` — 30+ vitest cases covering normalizer edge cases (all mapped op types, failed tx, zero amount, unsupported asset, unsupported op type), cache TTL behaviour, `fetchAccountOperations` pagination/error/timeout paths, and end-to-end cache hit/miss logic via mocked `fetch`

### Modified files

- `lib/transactions/repository.ts` — adds `fetchTransactionRecords(accountId?)`, the function already called by `app/api/transactions/route.ts`; reads `STELLAR_INDEXER_ACCOUNT` env var to activate the indexer, falls back to the existing mock dataset when no account is configured or when Horizon is unavailable so the API stays functional in all environments
- `lib/transactions/index.ts` — re-exports `fetchTransactionRecords` from the barrel

### Behaviour notes

- No existing exports, types, or test files were modified
- The indexer is opt-in: the API continues to serve mock data until `STELLAR_INDEXER_ACCOUNT` is set in the environment
- Horizon errors are caught at the repository layer; only a `warn` log is emitted before falling back, so a Horizon outage does not take down the API
- Cache TTL defaults to 60 s and is configurable per call via `cacheTtlMs`; callers can force a fresh fetch with `bypassCache: true`
- Only assets present in the canonical `ASSET_SYMBOLS` enum (`XLM`, `USDC`, `BTC`, `ETH`) are returned; operations involving other assets are dropped during normalization
