### PR TITLE
Add Prometheus /api/metrics endpoint exposing request, latency, and Soroban relay counters

### DIFF
--- a/app/api/metrics/route.test.ts
+++ b/app/api/metrics/route.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from './route';
+
+vi.mock('@/lib/server-config', () => ({
+  default: { server: { token: 'secret-token' } },
+}));
+
+describe('GET /api/metrics', () => {
+  it('returns 401 without bearer token', async () => {
+    const req = new Request('http://localhost/api/metrics');
+    const res = await GET(req as any);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns metrics when authorized', async () => {
+    const req = new Request('http://localhost/api/metrics', { headers: { Authorization: 'Bearer secret-token' } });
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const ct = res.headers.get('Content-Type') || res.headers.get('content-type');
+    expect(ct).toMatch(/text\/plain/);
+    const body = await res.text();
+    expect(body).toMatch(/# HELP http_requests_total/);
+  });
+});

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import serverConfig from '@/lib/server-config';
+import { metrics } from '@/lib/metrics/registry';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/metrics
+ * Prometheus exposition endpoint. Protected via bearer token configured
+ * in lib/server-config.ts (server.token). Exempt this path from rate
+ * limiting in the rate limiter configuration to allow scrapers.
+ */
+export async function GET(req: Request) {
+  const auth = req.headers.get('authorization') || '';
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  const token = match ? match[1] : '';
+
+  if (!token || token !== serverConfig.server.token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = metrics.collect();
+  return new NextResponse(body, {
+    headers: {
+      'Content-Type': 'text/plain; version=0.0.4',
+      'Cache-Control': 'no-cache',
+    },
+  });
+}

--- a/app/api/tx/submit/route.ts
+++ b/app/api/tx/submit/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import config from '@/lib/config';
 import { httpPost } from '@/lib/http/client';
+import { metrics } from '@/lib/metrics/registry';
 import {
   buildSorobanRpcError,
   buildSorobanSubmitRpcRequest,
@@ -43,9 +44,15 @@ export async function POST(request: NextRequest) {
   const payload = buildSorobanSubmitRpcRequest(body.signedEnvelopeXdr);
 
   try {
+    const start = Date.now();
     const rpcResponse = await httpPost<unknown>(config.stellar.sorobanRpcUrl, payload, {
       timeoutMs: 10000,
     });
+    const dur = (Date.now() - start) / 1000;
+    try {
+      metrics.sorobanSubmissions.inc({ result: 'success' });
+      metrics.sorobanSubmitDuration.observe(dur, { result: 'success' });
+    } catch (e) {}
 
     if (typeof rpcResponse === 'object' && rpcResponse && 'error' in rpcResponse) {
       return NextResponse.json(
@@ -63,7 +70,12 @@ export async function POST(request: NextRequest) {
       { status: 'submitted', hash: submission.hash },
       { status: 200 },
     );
-  } catch (error) {
+    } catch (error) {
+    try {
+      metrics.sorobanSubmissions.inc({ result: 'failure' });
+      metrics.sorobanSubmitDuration.observe(0, { result: 'failure' });
+    } catch (e) {}
+
     return NextResponse.json(
       { error: buildSorobanRpcError(error) },
       { status: 502 },

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,21 @@
+**Prometheus Metrics**
+
+Endpoints:
+- `GET /api/metrics` — Prometheus exposition (text/plain; version=0.0.4). Protected by a bearer token (`SERVER_TOKEN` / `lib/server-config.ts`).
+
+Metric catalog:
+- `http_requests_total{method,route,status}` — counter for incoming HTTP requests.
+- `http_request_duration_seconds{method,route,status}` — histogram of request latencies (seconds).
+- `http_errors_total{route,error}` — counter for internal errors.
+- `soroban_submissions_total{result}` — counter for Soroban tx submissions (`success`/`failure`).
+- `soroban_submit_duration_seconds{result}` — histogram for Soroban submit duration.
+- `outbound_http_requests_total{method,host,status}` — counter for outbound HTTP calls.
+- `outbound_http_request_duration_seconds{method,host,status}` — histogram for outbound request durations.
+
+Cardinality guidance:
+- Keep `route` and `host` labels limited to known values (do not use unbounded user-provided values).
+- Avoid adding high-cardinality labels such as user IDs.
+
+Usage:
+- Configure your Prometheus scrape config to use the bearer token: `Authorization: Bearer <token>`.
+- Exempt `/api/metrics` from rate limiting in the API gateway or middleware.

--- a/lib/api/handler.ts
+++ b/lib/api/handler.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
+import { metrics } from '@/lib/metrics/registry';
 
 function serializeError(error: unknown) {
   if (error instanceof Error) {
@@ -31,7 +32,15 @@ export function withRequestLogging<T extends (...args: unknown[]) => Promise<Nex
     try {
       const response = await handler(...args);
       const durationMs = Date.now() - startedAt;
-      const status = typeof (response as any)?.status === 'number' ? (response as any).status : undefined;
+      const status = typeof (response as any)?.status === 'number' ? (response as any).status : 0;
+
+      // Metrics
+      try {
+        metrics.httpRequests.inc({ method, route, status: String(status) });
+        metrics.httpRequestDuration.observe(durationMs / 1000, { method, route, status: String(status) });
+      } catch (e) {
+        // swallow metrics errors
+      }
 
       logger.info('request completed', route, {
         status,
@@ -42,6 +51,12 @@ export function withRequestLogging<T extends (...args: unknown[]) => Promise<Nex
       return response;
     } catch (error) {
       const durationMs = Date.now() - startedAt;
+
+      try {
+        metrics.httpRequests.inc({ method, route, status: '500' });
+        metrics.httpRequestDuration.observe(durationMs / 1000, { method, route, status: '500' });
+        metrics.httpErrors.inc({ route, error: (error as Error)?.name ?? 'Error' });
+      } catch (e) {}
 
       logger.error('request failed', route, {
         durationMs,

--- a/lib/http/client.ts
+++ b/lib/http/client.ts
@@ -6,6 +6,7 @@ import {
   TimeoutError,
   UpstreamHttpError,
 } from './errors';
+import { metrics } from '@/lib/metrics/registry';
 
 export interface RequestOptions extends Omit<RequestInit, 'signal'> {
   /** Override the global timeout from config.api.timeout (ms). */
@@ -17,6 +18,7 @@ export interface RequestOptions extends Omit<RequestInit, 'signal'> {
 }
 
 async function fetchOnce<T>(url: string, options: RequestOptions): Promise<T> {
+  const start = Date.now();
   const timeoutMs = options.timeoutMs ?? config.api.timeout;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -39,7 +41,15 @@ async function fetchOnce<T>(url: string, options: RequestOptions): Promise<T> {
     }
 
     try {
-      return (await response.json()) as T;
+      const json = (await response.json()) as T;
+      try {
+        const dur = (Date.now() - start) / 1000;
+        const method = (options.method ?? 'GET').toUpperCase();
+        const host = new URL(url).host;
+        metrics.outboundRequests.inc({ method, host, status: String(response.status) });
+        metrics.outboundRequestDuration.observe(dur, { method, host, status: String(response.status) });
+      } catch (e) {}
+      return json;
     } catch (err) {
       throw new HttpError('PARSE_ERROR', `Failed to parse JSON from ${url}`, undefined, err);
     }

--- a/lib/metrics/registry.ts
+++ b/lib/metrics/registry.ts
@@ -1,0 +1,99 @@
+// Lightweight Prometheus-style metrics registry used for tests and exposition.
+type Labels = Record<string, string> | undefined;
+
+function labelKey(labels?: Labels) {
+  if (!labels) return '{}';
+  return Object.keys(labels)
+    .sort()
+    .map((k) => `${k}="${labels[k]}"`)
+    .join(',');
+}
+
+class Counter {
+  private values = new Map<string, number>();
+  constructor(private name: string, private help: string) {}
+  inc(labels?: Labels, v = 1) {
+    const key = labelKey(labels);
+    this.values.set(key, (this.values.get(key) || 0) + v);
+  }
+  collect(): string {
+    let out = `# HELP ${this.name} ${this.help}\n# TYPE ${this.name} counter\n`;
+    for (const [lbl, val] of this.values) {
+      const labelPart = lbl === '{}' ? '' : `{${lbl}}`;
+      out += `${this.name}${labelPart} ${val}\n`;
+    }
+    return out;
+  }
+}
+
+class Histogram {
+  private buckets = new Map<string, number>();
+  private sum = 0;
+  private count = 0;
+  constructor(private name: string, private help: string, private bucketBounds = [0.005,0.01,0.025,0.05,0.1,0.25,0.5,1,2.5,5,10]) {
+    // initialize per-label buckets lazily
+  }
+  observe(value: number, labels?: Labels) {
+    const base = labelKey(labels);
+    for (const b of this.bucketBounds) {
+      const key = `${base}|le=${b}`;
+      this.buckets.set(key, (this.buckets.get(key) || 0) + (value <= b ? 1 : 0));
+    }
+    // +Inf bucket
+    const infKey = `${base}|le=+Inf`;
+    this.buckets.set(infKey, (this.buckets.get(infKey) || 0) + 1);
+
+    this.sum += value;
+    this.count++;
+  }
+  collect(): string {
+    let out = `# HELP ${this.name} ${this.help}\n# TYPE ${this.name} histogram\n`;
+    // group by label base
+    const groups = new Map<string, { buckets: [string, number][]; sum: number; count: number }>();
+    for (const [key, val] of this.buckets) {
+      const [base, lePart] = key.split('|le=');
+      if (!groups.has(base)) groups.set(base, { buckets: [], sum: 0, count: 0 });
+      groups.get(base)!.buckets.push([lePart, val]);
+    }
+    for (const [base, grp] of groups) {
+      const labelPart = base === '{}' ? '' : `{${base}}`;
+      // buckets in ascending order
+      grp.buckets.sort((a,b) => parseFloat(a[0]) - parseFloat(b[0]));
+      for (const [le, val] of grp.buckets) {
+        out += `${this.name}_bucket${labelPart},le="${le}" ${val}\n`;
+      }
+      out += `${this.name}_sum${labelPart} ${this.sum}\n`;
+      out += `${this.name}_count${labelPart} ${this.count}\n`;
+    }
+    return out;
+  }
+}
+
+class Registry {
+  httpRequests = new Counter('http_requests_total', 'Total HTTP requests');
+  httpRequestDuration = new Histogram('http_request_duration_seconds', 'HTTP request duration in seconds');
+  httpErrors = new Counter('http_errors_total', 'HTTP error count');
+
+  sorobanSubmissions = new Counter('soroban_submissions_total', 'Soroban transaction submissions');
+  sorobanSubmitDuration = new Histogram('soroban_submit_duration_seconds', 'Soroban submit duration seconds');
+
+  outboundRequests = new Counter('outbound_http_requests_total', 'Outbound HTTP requests');
+  outboundRequestDuration = new Histogram('outbound_http_request_duration_seconds', 'Outbound HTTP request duration seconds');
+
+  collect(): string {
+    // Return concatenated exposition
+    let out = '';
+    out += this.httpRequests.collect();
+    out += this.httpRequestDuration.collect();
+    out += this.httpErrors.collect();
+    out += this.sorobanSubmissions.collect();
+    out += this.sorobanSubmitDuration.collect();
+    out += this.outboundRequests.collect();
+    out += this.outboundRequestDuration.collect();
+    return out;
+  }
+}
+
+export const metrics = new Registry();
+
+export default metrics;


### PR DESCRIPTION
Added Prometheus metrics endpoint. I set up `registry.ts` with the counters and histograms, and wired `route.ts` to expose them as `text/plain; version=0.0.4` behind a bearer token from `server-config.ts`. I instrumented `handler.ts`, `submit/route.ts`, and `client.ts` to track request counts, latency, error rates, outbound calls, and Soroban submissions. Tests and `observability.md` included
Closed #245 