### PR TITLE
Feature/cache invalidate route

### DIFF
--- a/app/api/internal/cache/invalidate/route.test.ts
+++ b/app/api/internal/cache/invalidate/route.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const routePath = '@/app/api/internal/cache/invalidate/route';
+
+describe('POST /api/internal/cache/invalidate', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    // clear global cache if available
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { globalCache } = require('@/lib/cache');
+      globalCache.clear();
+    } catch {}
+  });
+
+  it('rejects unauthorized requests', async () => {
+    const { POST } = await import(routePath);
+
+    const req = new NextRequest('http://localhost/api/internal/cache/invalidate', { method: 'POST' });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('validates request body', async () => {
+    process.env.SERVER_TOKEN = 'test-token-123';
+    const { POST } = await import(routePath);
+
+    const req = new NextRequest('http://localhost/api/internal/cache/invalidate', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${process.env.SERVER_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/Invalid request body/);
+  });
+
+  it('invalidates specified namespaces and emits logs/metrics', async () => {
+    process.env.SERVER_TOKEN = 'server-token-xyz';
+
+    // Prepare cache
+    const { globalCache } = await import('@/lib/cache');
+    globalCache.set('prices:all', { foo: 'bar' }, { ttl: 1000, swr: 0 });
+    globalCache.set('prices:XLM', { foo: 'baz' }, { ttl: 1000, swr: 0 });
+    globalCache.set('markets:assets:XLM', { m: 1 }, { ttl: 1000, swr: 0 });
+
+    expect(globalCache.size()).toBeGreaterThanOrEqual(3);
+
+    // Spy on logger and console
+    const { logger } = await import('@/lib/logger');
+    const loggerSpy = vi.spyOn(logger, 'info');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { POST } = await import(routePath);
+
+    const req = new NextRequest('http://localhost/api/internal/cache/invalidate', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${process.env.SERVER_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ namespaces: ['prices'] }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.deletedCount).toBe('number');
+    expect(body.deletedCount).toBeGreaterThanOrEqual(2);
+
+    // Ensure prices keys removed, markets remains
+    expect(globalCache.get('prices:all')).toBeNull();
+    expect(globalCache.get('prices:XLM')).toBeNull();
+    expect(globalCache.get('markets:assets:XLM')).not.toBeNull();
+
+    expect(loggerSpy).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalled();
+
+    loggerSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/api/internal/cache/invalidate/route.ts
+++ b/app/api/internal/cache/invalidate/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import serverConfig from '@/lib/server-config';
+import { globalCache } from '@/lib/cache';
+import { logger } from '@/lib/logger';
+
+export const runtime = 'nodejs';
+
+async function authorize(request: NextRequest): Promise<boolean> {
+  const auth = request.headers.get('Authorization') || '';
+  if (!auth) return false;
+
+  // Accept Bearer <token>
+  const parts = auth.split(' ');
+  if (parts.length === 2 && parts[0].toLowerCase() === 'bearer') {
+    return parts[1] === serverConfig.server.token;
+  }
+
+  return false;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const ok = await authorize(request);
+    if (!ok) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => null);
+    if (!body || !Array.isArray(body.namespaces)) {
+      return NextResponse.json({ error: 'Invalid request body. Expected { namespaces: string[] }' }, { status: 400 });
+    }
+
+    const namespaces = body.namespaces.filter((n: unknown) => typeof n === 'string') as string[];
+
+    const deletedCount = globalCache.invalidateNamespaces(namespaces);
+
+    // Emit a simple metric and audit log entry
+    console.log(`metric:cache_invalidate count=${deletedCount} namespaces=${namespaces.join(',')}`);
+
+    logger.info('Cache invalidation requested', '/api/internal/cache/invalidate', { namespaces, deletedCount });
+
+    return NextResponse.json({ deletedCount }, { status: 200 });
+  } catch (err) {
+    console.error('Cache invalidate route error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export const dynamic = 'force-dynamic';

--- a/lib/cache/README.md
+++ b/lib/cache/README.md
@@ -59,6 +59,20 @@ Manually invalidates/removes a single key from the cache.
 ### `globalCache.clear()`
 Purges all cache entries and resets the revalidation keys.
 
+### `globalCache.invalidateNamespaces(namespaces)`
+Invalidates all cache keys that belong to the provided namespaces. A namespace is
+matched when a cache key is exactly equal to the namespace or when it starts
+with `${namespace}:` (for example `markets:assets:XLM` will match the
+`markets` namespace). The method returns the number of deleted keys.
+
+Supported namespaces (common examples):
+- `prices` — price oracle cache keys (e.g. `prices:all`, `prices:XLM`)
+- `markets` — market data cache keys (e.g. `markets:assets:XLM`)
+- `idempotency` — idempotency records (e.g. `idempotency:<hash>`)
+
+This API is used by the internal deployment invalidation endpoint
+`POST /api/internal/cache/invalidate` which accepts `{ namespaces: string[] }`.
+
 ---
 
 ## 🔒 Security & Cache Key Safety

--- a/lib/cache/index.ts
+++ b/lib/cache/index.ts
@@ -35,6 +35,35 @@ export class InMemoryCache {
   }
 
   /**
+   * Invalidates all keys that belong to the provided namespaces.
+   * A namespace matches a key when the key is exactly the namespace
+   * or when it starts with `${namespace}:` (covers nested keys like `markets:assets:XLM`).
+   * Returns the number of deleted keys.
+   */
+  public invalidateNamespaces(namespaces: string[]): number {
+    if (!namespaces || namespaces.length === 0) return 0;
+
+    const toDelete: string[] = [];
+
+    for (const key of this.cache.keys()) {
+      for (const ns of namespaces) {
+        if (!ns || typeof ns !== 'string') continue;
+        if (key === ns || key.startsWith(`${ns}:`)) {
+          toDelete.push(key);
+          break;
+        }
+      }
+    }
+
+    for (const k of toDelete) {
+      this.cache.delete(k);
+      this.revalidatingKeys.delete(k);
+    }
+
+    return toDelete.length;
+  }
+
+  /**
    * Retrieves the full cache entry including metadata if not fully expired.
    */
   public getEntry<T>(key: string): CacheEntry<T> | null {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -227,6 +227,54 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/internal/cache/invalidate:
+    post:
+      operationId: invalidateCache
+      tags: [auth]
+      summary: Invalidate cache namespaces (internal only)
+      description: |
+        Internal-only endpoint used by deployment tooling to invalidate
+        specific cache namespaces (e.g. `prices`, `markets`, `idempotency`).
+        This route is protected by an internal server token and should only
+        be invoked from trusted CI/CD workflows.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [namespaces]
+              properties:
+                namespaces:
+                  type: array
+                  items:
+                    type: string
+                  example: ["prices", "markets"]
+      responses:
+        "200":
+          description: Number of cache keys deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deletedCount:
+                    type: integer
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   # ---------------------------------------------------------------------------
   # Positions
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Title**  
- **Summary**: Add an internal cache-invalidation endpoint to allow targeted namespace-based cache-busting from deployments.

**Problem**  
- **Context**: The shared in-memory cache (cache) can retain stale entries (prices, markets, idempotency) until TTL expiry, causing stale public reads after rollouts. Deployment tooling needs a safe, targeted way to invalidate those entries.

**What I changed**  
- **Cache API**: Added `invalidateNamespaces(namespaces: string[])` to index.ts to delete keys matching a namespace (exact or prefix `namespace:`).  
- **Internal route**: Added token-gated POST route at route.ts which accepts `{ namespaces: string[] }`, calls the cache invalidator, emits a simple metric log, and writes an audit-log entry via `logger`.  
- **Tests**: Added unit tests at route.test.ts covering auth gate, request validation, and invalidation effects.  
- **Docs / API spec**: Updated cache docs at README.md and OpenAPI at openapi.yaml to document the endpoint and supported namespaces.  
- **Branch**: Changes are on branch `feature/cache-invalidate-route` (pushed).

**Files touched**  
- index.ts: new `invalidateNamespaces` method.  
- route.ts: new internal POST route.  
- route.test.ts: tests for auth, validation, behavior.  
- README.md: docs updated with invalidation API and example namespaces.  
- openapi.yaml: added `POST /api/internal/cache/invalidate` spec.

**Security**  
- **Auth**: The route is protected by the server token from `serverConfig.server.token` (`SERVER_TOKEN` env var). It accepts only `Authorization: Bearer <token>`.  
- **Scope**: Endpoint is internal-only; it expects trusted invocation from CI/CD (deploy workflow).  
- **Logging**: Audit entry written via existing `logger` API; a metric line is emitted to stdout for ingestion by external agents.

**Testing**  
- **Unit tests**: Added tests covering: unauthorized requests, request-body validation, successful namespace invalidation (ensures only targeted keys removed).  
- **How to run locally**:
```bash
npm install
npx vitest run app/api/internal/cache/invalidate/route.test.ts --coverage.enabled false
```
- **Note**: Tests are included; I attempted to run them here but the environment prompted to install `vitest`. They should run cleanly after installing dev dependencies.

**Usage / Example**  
- Example curl to invalidate `prices` and `markets`:
```bash
curl -X POST https://your.api/_next/data/.../api/internal/cache/invalidate \
  -H "Authorization: Bearer $SERVER_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"namespaces":["prices","markets"]}'
```
- Response: `{ "deletedCount": <number> }`

**Open items / deployment**  
- **CI wiring**: Add a step in `deploy-production.yml` (or equivalent) to call this endpoint after deploy using the `SERVER_TOKEN` secret. If you'd like, I can add a suggested snippet for the workflow.  
- **Monitoring**: stdout metric lines are emitted like `metric:cache_invalidate count=<n> namespaces=...` — ensure your logging/metrics pipeline captures these.

**Checklist (requirements)**  
- **Secure**: ✅ Token-gated via `SERVER_TOKEN`.  
- **Tested**: ✅ Unit tests added.  
- **Documented**: ✅ README + OpenAPI updated.  
- **Efficient & Reviewable**: ✅ Small, focused changes; single new route + cache helper.  
- **Branch / Commit**: ✅ `feature/cache-invalidate-route`, commit message `feat: add internal cache-invalidation route`.

Issue:
closes #281 