### PR TITLE
feat: pre-simulate Soroban transactions in build/submit routes

### DIFF
--- a/app/api/tx/build/route.test.ts
+++ b/app/api/tx/build/route.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
+import simulateRestoreRequiredFixture from '@/lib/soroban/__fixtures__/simulate-restore-required.json';
+import simulateSuccessFixture from '@/lib/soroban/__fixtures__/simulate-success.json';
 
 vi.mock('@/lib/config', () => ({
   default: {
@@ -53,12 +55,20 @@ describe('POST /api/tx/build', () => {
   });
 
   it('returns unsignedXdr when RPC build succeeds', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({ result: { transaction: 'unsigned-xdr' } }),
-        { status: 200, headers: { 'content-type': 'application/json' } },
-      ),
-    );
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ result: { transaction: 'unsigned-xdr' } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(simulateSuccessFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
 
     vi.stubGlobal('fetch', mockFetch);
 
@@ -76,7 +86,25 @@ describe('POST /api/tx/build', () => {
 
     expect(response.status).toBe(200);
     const json = await response.json();
-    expect(json).toEqual({ unsignedXdr: 'unsigned-xdr' });
+    expect(json).toEqual({
+      unsignedXdr: 'unsigned-xdr',
+      simulation: {
+        transactionDataXdr: 'AAAAAgAAAAE=',
+        minResourceFee: '3210',
+        footprint: {
+          readOnly: ['AAAAAQ=='],
+          readWrite: ['AAAAAg=='],
+        },
+        auth: ['AAAAAw==', 'AAAABA=='],
+      },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(mockFetch.mock.calls[0][1]?.body)).method).toBe(
+      'build_soroban_transaction',
+    );
+    expect(JSON.parse(String(mockFetch.mock.calls[1][1]?.body)).method).toBe(
+      'simulateTransaction',
+    );
   });
 
   it('maps upstream RPC errors to a 502 response', async () => {
@@ -106,14 +134,79 @@ describe('POST /api/tx/build', () => {
     expect(json.error.code).toBe(400);
   });
 
+  it('returns a safe restore-required error when simulation requires restore', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ result: { transaction: 'unsigned-xdr' } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(simulateRestoreRequiredFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const response = await POST(
+      new Request('http://localhost/api/tx/build', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          type: 'lend',
+          sourceAccount: `G${'A'.repeat(55)}`,
+          data: { asset: 'XLM', amount: 1000, interestRate: 5, duration: 30 },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    const json = await response.json();
+    expect(json.error.code).toBe('RESTORE_REQUIRED');
+    expect(json.error.message).toBe(
+      'This transaction requires a restore before it can be submitted.',
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it('returns 429 when the authenticated wallet exceeds account rate limit', async () => {
     getSessionMock.mockResolvedValue({ user: { walletAddress: 'GABC123' } });
-    const mockFetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({ result: { transaction: 'unsigned-xdr' } }),
-        { status: 200, headers: { 'content-type': 'application/json' } },
-      ),
-    );
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ result: { transaction: 'unsigned-xdr' } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ result: { transaction: 'unsigned-xdr' } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(simulateSuccessFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ result: { transaction: 'unsigned-xdr' } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(simulateSuccessFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
 
     vi.stubGlobal('fetch', mockFetch);
 

--- a/app/api/tx/build/route.ts
+++ b/app/api/tx/build/route.ts
@@ -4,6 +4,11 @@ import { httpPost } from '@/lib/http/client';
 import { getSession } from '@/lib/auth';
 import { accountBucketRateLimit } from '@/lib/rate-limit/account-bucket';
 import {
+  buildSorobanSimulationApiError,
+  getSorobanSimulationStatus,
+  simulateSorobanTransaction,
+} from '@/lib/soroban/simulate';
+import {
   buildSorobanRpcError,
   buildSorobanTransactionRpcRequest,
   extractUnsignedXdr,
@@ -106,7 +111,19 @@ export async function POST(request: NextRequest) {
       return rpcFailure();
     }
 
-    return NextResponse.json({ unsignedXdr }, { status: 200 });
+    try {
+      const simulation = await simulateSorobanTransaction(
+        config.stellar.sorobanRpcUrl,
+        unsignedXdr,
+      );
+
+      return NextResponse.json({ unsignedXdr, simulation }, { status: 200 });
+    } catch (error) {
+      return NextResponse.json(
+        { error: buildSorobanSimulationApiError(error) },
+        { status: getSorobanSimulationStatus(error) },
+      );
+    }
   } catch (error) {
     return NextResponse.json(
       { error: buildSorobanRpcError(error) },

--- a/app/api/tx/submit/route.test.ts
+++ b/app/api/tx/submit/route.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
+import simulateRestoreRequiredFixture from '@/lib/soroban/__fixtures__/simulate-restore-required.json';
+import simulateSuccessFixture from '@/lib/soroban/__fixtures__/simulate-success.json';
 
 vi.mock('@/lib/config', () => ({
   default: {
@@ -75,6 +77,43 @@ describe('POST /api/tx/submit', () => {
     expect(json).toEqual({ status: 'submitted', hash: 'tx-hash-123' });
   });
 
+  it('pre-simulates signed XDR when simulate=true is set', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(simulateSuccessFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ result: { hash: 'tx-hash-123' } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      );
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const response = await POST(
+      new Request('http://localhost/api/tx/submit?simulate=true', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ signedEnvelopeXdr: 'signed-envelope-xdr' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'submitted', hash: 'tx-hash-123' });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(mockFetch.mock.calls[0][1]?.body)).method).toBe(
+      'simulateTransaction',
+    );
+    expect(JSON.parse(String(mockFetch.mock.calls[1][1]?.body)).method).toBe(
+      'send_transaction',
+    );
+  });
+
   it('maps upstream RPC errors to a 502 response', async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       new Response(
@@ -96,6 +135,33 @@ describe('POST /api/tx/submit', () => {
     expect(response.status).toBe(502);
     const json = await response.json();
     expect(json.error.code).toBe(500);
+  });
+
+  it('short-circuits submission when simulation requires restore', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(simulateRestoreRequiredFixture), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const response = await POST(
+      new Request('http://localhost/api/tx/submit?simulate=true', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ signedEnvelopeXdr: 'signed-envelope-xdr' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    const json = await response.json();
+    expect(json.error.code).toBe('RESTORE_REQUIRED');
+    expect(json.error.message).toBe(
+      'This transaction requires a restore before it can be submitted.',
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('returns 429 when the authenticated wallet exceeds account rate limit', async () => {

--- a/app/api/tx/submit/route.ts
+++ b/app/api/tx/submit/route.ts
@@ -1,7 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import config from '@/lib/config';
+import { getSession } from '@/lib/auth';
 import { httpPost } from '@/lib/http/client';
 import { metrics } from '@/lib/metrics/registry';
+import { accountBucketRateLimit } from '@/lib/rate-limit/account-bucket';
+import {
+  buildSorobanSimulationApiError,
+  getSorobanSimulationStatus,
+  simulateSorobanTransaction,
+  SorobanSimulationError,
+} from '@/lib/soroban/simulate';
 import {
   buildSorobanRpcError,
   buildSorobanSubmitRpcRequest,
@@ -70,8 +78,13 @@ export async function POST(request: NextRequest) {
   }
 
   const payload = buildSorobanSubmitRpcRequest(body.signedEnvelopeXdr);
+  const shouldSimulate = new URL(request.url).searchParams.get('simulate') === 'true';
 
   try {
+    if (shouldSimulate) {
+      await simulateSorobanTransaction(config.stellar.sorobanRpcUrl, body.signedEnvelopeXdr);
+    }
+
     const start = Date.now();
     const rpcResponse = await httpPost<unknown>(config.stellar.sorobanRpcUrl, payload, {
       timeoutMs: 10000,
@@ -98,11 +111,18 @@ export async function POST(request: NextRequest) {
       { status: 'submitted', hash: submission.hash },
       { status: 200 },
     );
-    } catch (error) {
+  } catch (error) {
     try {
       metrics.sorobanSubmissions.inc({ result: 'failure' });
       metrics.sorobanSubmitDuration.observe(0, { result: 'failure' });
     } catch (e) {}
+
+    if (error instanceof SorobanSimulationError) {
+      return NextResponse.json(
+        { error: buildSorobanSimulationApiError(error) },
+        { status: getSorobanSimulationStatus(error) },
+      );
+    }
 
     return NextResponse.json(
       { error: buildSorobanRpcError(error) },

--- a/docs/soroban.md
+++ b/docs/soroban.md
@@ -1,0 +1,41 @@
+# Soroban Transaction Preflight
+
+The transaction relay now pre-simulates Soroban transactions before they are
+handed to the network RPC.
+
+## Build Flow
+
+`POST /api/tx/build` now performs two server-side steps:
+
+1. Build an unsigned transaction with `build_soroban_transaction`.
+2. Pre-simulate the returned XDR with `simulateTransaction`.
+
+On success the API returns:
+
+- `unsignedXdr`: the unsigned transaction envelope to sign
+- `simulation.transactionDataXdr`: Soroban transaction data returned by simulation
+- `simulation.minResourceFee`: the resource fee estimate returned by the RPC
+- `simulation.footprint`: the computed read-only and read-write ledger key sets
+- `simulation.auth`: any auth entries surfaced by simulation
+
+## Submit Flow
+
+`POST /api/tx/submit?simulate=true` performs an additional preflight simulation
+before sending the signed envelope to `send_transaction`.
+
+This is optional so existing clients remain compatible, but enabling the flag
+prevents obviously failing submissions from consuming fees or entering the RPC
+queue.
+
+## Error Mapping
+
+Simulation failures are mapped to safe API errors instead of leaking raw RPC or
+transport details:
+
+- `RESTORE_REQUIRED` with HTTP `409` when archived ledger entries must be restored
+- `AUTH_REQUIRED` with HTTP `422` when additional authorization is needed
+- `SIMULATION_FAILED` with HTTP `422` for other deterministic preflight failures
+- `SIMULATION_UNAVAILABLE` with HTTP `502` when the simulation RPC cannot be reached
+
+Routes continue to use the existing `{ error: { code, message, data? } }`
+envelope so clients can handle preflight failures consistently.

--- a/lib/soroban/__fixtures__/simulate-auth-required.json
+++ b/lib/soroban/__fixtures__/simulate-auth-required.json
@@ -1,0 +1,11 @@
+{
+  "jsonrpc": "2.0",
+  "id": "simulate_transaction",
+  "error": {
+    "code": -32000,
+    "message": "HostError: Error(Auth, InvalidAction)",
+    "data": {
+      "kind": "auth"
+    }
+  }
+}

--- a/lib/soroban/__fixtures__/simulate-restore-required.json
+++ b/lib/soroban/__fixtures__/simulate-restore-required.json
@@ -1,0 +1,11 @@
+{
+  "jsonrpc": "2.0",
+  "id": "simulate_transaction",
+  "result": {
+    "restorePreamble": {
+      "minResourceFee": "9876",
+      "transactionData": "AAAAAgAAAAI=",
+      "transaction": "AAAAAwAAAAE="
+    }
+  }
+}

--- a/lib/soroban/__fixtures__/simulate-success.json
+++ b/lib/soroban/__fixtures__/simulate-success.json
@@ -1,0 +1,18 @@
+{
+  "jsonrpc": "2.0",
+  "id": "simulate_transaction",
+  "result": {
+    "transactionData": "AAAAAgAAAAE=",
+    "minResourceFee": "3210",
+    "footprint": {
+      "readOnly": ["AAAAAQ=="],
+      "readWrite": ["AAAAAg=="]
+    },
+    "results": [
+      {
+        "auth": ["AAAAAw==", "AAAABA=="],
+        "xdr": "AAAAAg=="
+      }
+    ]
+  }
+}

--- a/lib/soroban/simulate.test.ts
+++ b/lib/soroban/simulate.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import simulateAuthRequiredFixture from './__fixtures__/simulate-auth-required.json';
+import simulateRestoreRequiredFixture from './__fixtures__/simulate-restore-required.json';
+import simulateSuccessFixture from './__fixtures__/simulate-success.json';
+import {
+  buildSorobanSimulationApiError,
+  getSorobanSimulationStatus,
+  simulateSorobanTransaction,
+  SorobanSimulationError,
+} from './simulate';
+
+describe('simulateSorobanTransaction', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns normalized fee, auth, and footprint metadata on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(simulateSuccessFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+
+    await expect(
+      simulateSorobanTransaction('https://soroban-testnet.stellar.org', 'unsigned-xdr'),
+    ).resolves.toEqual({
+      transactionDataXdr: 'AAAAAgAAAAE=',
+      minResourceFee: '3210',
+      footprint: {
+        readOnly: ['AAAAAQ=='],
+        readWrite: ['AAAAAg=='],
+      },
+      auth: ['AAAAAw==', 'AAAABA=='],
+    });
+  });
+
+  it('throws a restore-required error when restore preamble is present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(simulateRestoreRequiredFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+
+    try {
+      await simulateSorobanTransaction('https://soroban-testnet.stellar.org', 'unsigned-xdr');
+      throw new Error('Expected restore-required simulation error.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SorobanSimulationError);
+      expect((error as SorobanSimulationError).code).toBe('RESTORE_REQUIRED');
+      expect(getSorobanSimulationStatus(error)).toBe(409);
+      expect(buildSorobanSimulationApiError(error)).toEqual({
+        code: 'RESTORE_REQUIRED',
+        message: 'This transaction requires a restore before it can be submitted.',
+        data: {
+          restoreRequired: true,
+          restorePreamble: simulateRestoreRequiredFixture.result.restorePreamble,
+        },
+      });
+    }
+  });
+
+  it('maps auth-related RPC failures to a safe API error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(simulateAuthRequiredFixture), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+
+    try {
+      await simulateSorobanTransaction('https://soroban-testnet.stellar.org', 'unsigned-xdr');
+      throw new Error('Expected auth-related simulation error.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SorobanSimulationError);
+      expect((error as SorobanSimulationError).code).toBe('AUTH_REQUIRED');
+      expect(buildSorobanSimulationApiError(error)).toEqual({
+        code: 'AUTH_REQUIRED',
+        message: 'This transaction requires additional authorization before it can be submitted.',
+        data: { authRequired: true },
+      });
+    }
+  });
+
+  it('sanitizes transport-level simulation failures', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1')),
+    );
+
+    try {
+      await simulateSorobanTransaction('https://private-rpc.test', 'unsigned-xdr');
+      throw new Error('Expected transport-level simulation error.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SorobanSimulationError);
+      expect((error as SorobanSimulationError).code).toBe('SIMULATION_UNAVAILABLE');
+      expect((error as SorobanSimulationError).message).toBe(
+        'Unable to simulate the transaction right now. Please try again later.',
+      );
+      expect(JSON.stringify(buildSorobanSimulationApiError(error))).not.toContain(
+        'private-rpc.test',
+      );
+    }
+  });
+});

--- a/lib/soroban/simulate.ts
+++ b/lib/soroban/simulate.ts
@@ -1,0 +1,331 @@
+import { xdr } from '@stellar/stellar-sdk';
+import { httpPost } from '@/lib/http/client';
+import {
+  HttpError,
+  NetworkError,
+  RetryExhaustedError,
+  TimeoutError,
+  UpstreamHttpError,
+} from '@/lib/http/errors';
+import { buildSorobanRpcError, SorobanRpcError } from './tx';
+
+type SimulationErrorCode =
+  | 'RESTORE_REQUIRED'
+  | 'AUTH_REQUIRED'
+  | 'SIMULATION_FAILED'
+  | 'SIMULATION_UNAVAILABLE';
+
+type SorobanSimulationRpcEnvelope = {
+  result?: unknown;
+  error?: unknown;
+};
+
+type SorobanSimulationResources = {
+  footprint?: unknown;
+  transactionData?: unknown;
+  transaction_data?: unknown;
+  minResourceFee?: unknown;
+  min_resource_fee?: unknown;
+  results?: unknown;
+  restorePreamble?: unknown;
+  restore_preamble?: unknown;
+};
+
+export interface SorobanSimulationFootprint {
+  readOnly: string[];
+  readWrite: string[];
+}
+
+export interface SorobanSimulationResult {
+  transactionDataXdr: string;
+  minResourceFee: string;
+  footprint: SorobanSimulationFootprint;
+  auth: string[];
+}
+
+export class SorobanSimulationError extends Error {
+  constructor(
+    public readonly code: SimulationErrorCode,
+    message: string,
+    public readonly status: number,
+    public readonly data?: unknown,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'SorobanSimulationError';
+  }
+}
+
+const RESTORE_ERROR_MESSAGE =
+  'This transaction requires a restore before it can be submitted.';
+const AUTH_ERROR_MESSAGE =
+  'This transaction requires additional authorization before it can be submitted.';
+const SIMULATION_FAILURE_MESSAGE =
+  'Transaction simulation failed. Review the transaction details and try again.';
+const SIMULATION_UNAVAILABLE_MESSAGE =
+  'Unable to simulate the transaction right now. Please try again later.';
+
+const RESTORE_PATTERN = /(restore|archived|expired.*footprint|restorepreamble)/i;
+const AUTH_PATTERN = /(auth|authorization|signature|missing.*authoriz)/i;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+function readString(
+  value: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate;
+    }
+
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return String(candidate);
+    }
+  }
+
+  return undefined;
+}
+
+function buildSimulationRequest(transactionXdr: string): Record<string, unknown> {
+  return {
+    jsonrpc: '2.0',
+    id: 'simulate_transaction',
+    method: 'simulateTransaction',
+    params: [{ transaction: transactionXdr }],
+  };
+}
+
+function extractAuthEntries(result: Record<string, unknown>): string[] {
+  const authEntries = new Set<string>();
+  const results = Array.isArray(result.results) ? result.results : [];
+
+  for (const item of results) {
+    if (!isObject(item) || !Array.isArray(item.auth)) {
+      continue;
+    }
+
+    for (const authEntry of item.auth) {
+      if (isString(authEntry)) {
+        authEntries.add(authEntry);
+      }
+    }
+  }
+
+  return [...authEntries];
+}
+
+function parseFootprintFromTransactionData(transactionDataXdr: string): SorobanSimulationFootprint {
+  try {
+    const transactionData = xdr.SorobanTransactionData.fromXDR(transactionDataXdr, 'base64');
+    const footprint = transactionData.resources().footprint();
+
+    return {
+      readOnly: footprint.readOnly().map((ledgerKey) => ledgerKey.toXDR('base64')),
+      readWrite: footprint.readWrite().map((ledgerKey) => ledgerKey.toXDR('base64')),
+    };
+  } catch {
+    return {
+      readOnly: [],
+      readWrite: [],
+    };
+  }
+}
+
+function normalizeFootprint(
+  rawFootprint: unknown,
+  transactionDataXdr: string,
+): SorobanSimulationFootprint {
+  if (isObject(rawFootprint)) {
+    const readOnlySource =
+      Array.isArray(rawFootprint.readOnly)
+        ? rawFootprint.readOnly
+        : Array.isArray(rawFootprint.read_only)
+        ? rawFootprint.read_only
+        : [];
+    const readWriteSource =
+      Array.isArray(rawFootprint.readWrite)
+        ? rawFootprint.readWrite
+        : Array.isArray(rawFootprint.read_write)
+        ? rawFootprint.read_write
+        : [];
+    const readOnly = Array.isArray(readOnlySource)
+      ? readOnlySource.filter(isString)
+      : [];
+    const readWrite = Array.isArray(readWriteSource)
+      ? readWriteSource.filter(isString)
+      : [];
+
+    return { readOnly, readWrite };
+  }
+
+  return parseFootprintFromTransactionData(transactionDataXdr);
+}
+
+function buildRestoreError(data?: unknown): SorobanSimulationError {
+  return new SorobanSimulationError(
+    'RESTORE_REQUIRED',
+    RESTORE_ERROR_MESSAGE,
+    409,
+    {
+      restoreRequired: true,
+      restorePreamble: data,
+    },
+  );
+}
+
+function mapRpcSimulationError(error: unknown): SorobanSimulationError {
+  const rpcError = buildSorobanRpcError(error);
+  const detailsText = [rpcError.message, JSON.stringify(rpcError.data ?? null)].join(' ');
+  const restorePreamble =
+    isObject(rpcError.data) && 'restorePreamble' in rpcError.data
+      ? rpcError.data.restorePreamble
+      : isObject(rpcError.data) && 'restore_preamble' in rpcError.data
+      ? rpcError.data.restore_preamble
+      : undefined;
+
+  if (restorePreamble !== undefined || RESTORE_PATTERN.test(detailsText)) {
+    return buildRestoreError(restorePreamble ?? rpcError.data);
+  }
+
+  if (AUTH_PATTERN.test(detailsText)) {
+    return new SorobanSimulationError(
+      'AUTH_REQUIRED',
+      AUTH_ERROR_MESSAGE,
+      422,
+      { authRequired: true },
+    );
+  }
+
+  return new SorobanSimulationError(
+    'SIMULATION_FAILED',
+    SIMULATION_FAILURE_MESSAGE,
+    422,
+  );
+}
+
+function mapTransportSimulationError(error: unknown): SorobanSimulationError {
+  if (
+    error instanceof TimeoutError ||
+    error instanceof NetworkError ||
+    error instanceof UpstreamHttpError ||
+    error instanceof RetryExhaustedError ||
+    error instanceof HttpError
+  ) {
+    return new SorobanSimulationError(
+      'SIMULATION_UNAVAILABLE',
+      SIMULATION_UNAVAILABLE_MESSAGE,
+      502,
+      undefined,
+      error,
+    );
+  }
+
+  return new SorobanSimulationError(
+    'SIMULATION_FAILED',
+    SIMULATION_FAILURE_MESSAGE,
+    422,
+    undefined,
+    error,
+  );
+}
+
+function parseSimulationResult(response: unknown): SorobanSimulationResult {
+  if (!isObject(response)) {
+    throw new SorobanSimulationError(
+      'SIMULATION_FAILED',
+      SIMULATION_FAILURE_MESSAGE,
+      422,
+    );
+  }
+
+  if ('error' in response && response.error !== undefined) {
+    throw mapRpcSimulationError(response.error);
+  }
+
+  const result = response as SorobanSimulationResources;
+  const restorePreamble = result.restorePreamble ?? result.restore_preamble;
+  if (restorePreamble !== undefined) {
+    throw buildRestoreError(restorePreamble);
+  }
+
+  const transactionDataXdr =
+    readString(result as Record<string, unknown>, 'transactionData', 'transaction_data');
+  const minResourceFee =
+    readString(result as Record<string, unknown>, 'minResourceFee', 'min_resource_fee');
+
+  if (!transactionDataXdr || !minResourceFee) {
+    throw new SorobanSimulationError(
+      'SIMULATION_FAILED',
+      SIMULATION_FAILURE_MESSAGE,
+      422,
+    );
+  }
+
+  return {
+    transactionDataXdr,
+    minResourceFee,
+    footprint: normalizeFootprint(result.footprint, transactionDataXdr),
+    auth: extractAuthEntries(result as Record<string, unknown>),
+  };
+}
+
+export async function simulateSorobanTransaction(
+  rpcUrl: string,
+  transactionXdr: string,
+): Promise<SorobanSimulationResult> {
+  try {
+    const rpcResponse = await httpPost<SorobanSimulationRpcEnvelope>(
+      rpcUrl,
+      buildSimulationRequest(transactionXdr),
+      { timeoutMs: 10000 },
+    );
+
+    if (isObject(rpcResponse) && 'error' in rpcResponse && rpcResponse.error !== undefined) {
+      throw mapRpcSimulationError(rpcResponse.error);
+    }
+
+    return parseSimulationResult(
+      isObject(rpcResponse) && 'result' in rpcResponse ? rpcResponse.result : rpcResponse,
+    );
+  } catch (error) {
+    if (error instanceof SorobanSimulationError) {
+      throw error;
+    }
+
+    throw mapTransportSimulationError(error);
+  }
+}
+
+export function buildSorobanSimulationApiError(error: unknown): SorobanRpcError {
+  if (error instanceof SorobanSimulationError) {
+    const apiError: SorobanRpcError = {
+      code: error.code,
+      message: error.message,
+    };
+
+    if (error.data !== undefined) {
+      apiError.data = error.data;
+    }
+
+    return apiError;
+  }
+
+  return {
+    code: 'SIMULATION_FAILED',
+    message: SIMULATION_FAILURE_MESSAGE,
+  };
+}
+
+export function getSorobanSimulationStatus(error: unknown): number {
+  if (error instanceof SorobanSimulationError) {
+    return error.status;
+  }
+
+  return 502;
+}


### PR DESCRIPTION
## Summary
- add `lib/soroban/simulate.ts` to preflight Soroban envelopes through `simulateTransaction` and map restore/auth/upstream failures to safe API errors
- call simulation from `/api/tx/build` so successful builds return resource fee, footprint, and auth metadata alongside `unsignedXdr`
- optionally enforce simulation in `/api/tx/submit?simulate=true`, backed by fixture-driven tests and `docs/soroban.md`

## Testing
- Not run: Vitest / coverage / lint because `node_modules` is not present in this workspace and the task explicitly disallowed installing packages
- Performed: `git diff --check`