### PR TITLE
Job scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ npm start
 
 For more deployment options, see the [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying).
 
+### Scheduled jobs
+
+Cron registration is protected by Postgres advisory-lock leader election so only one application replica schedules retention, snapshot, and indexer health-check jobs. See [docs/scheduler-leader-election.md](docs/scheduler-leader-election.md) and [docs/infrastructure/README.md](docs/infrastructure/README.md) for failover and recovery procedures.
+
 ## 📝 Scripts Reference
 
 | Command | Description |

--- a/app/api/metrics/route.test.ts
+++ b/app/api/metrics/route.test.ts
@@ -20,5 +20,7 @@ describe('GET /api/metrics', () => {
     expect(ct).toMatch(/text\/plain/);
     const body = await res.text();
     expect(body).toMatch(/# HELP http_requests_total/);
+    expect(body).toMatch(/# HELP scheduler_is_leader/);
+    expect(body).toMatch(/scheduler_is_leader 0/);
   });
 });

--- a/bullmq.d.ts
+++ b/bullmq.d.ts
@@ -1,0 +1,24 @@
+declare module "bullmq" {
+  export class Queue {
+    constructor(name: string, options?: Record<string, unknown>);
+    getRepeatableJobs(): Promise<Array<{ name: string }>>;
+    add(
+      name: string,
+      data: Record<string, unknown>,
+      options: Record<string, unknown>,
+    ): Promise<unknown>;
+    close?(): Promise<void>;
+  }
+
+  export class Worker {
+    constructor(
+      name: string,
+      processor: (job: Job) => Promise<void>,
+      options?: Record<string, unknown>,
+    );
+  }
+
+  export class Job {
+    data: unknown;
+  }
+}

--- a/docs/infrastructure/README.md
+++ b/docs/infrastructure/README.md
@@ -1,0 +1,29 @@
+# Infrastructure operations
+
+## Cron scheduler leader election
+
+StellarLend schedules background jobs from `src/jobs/cron.ts` through `lib/jobs/scheduler.ts`. Every application replica may start a scheduler instance, but only the replica that acquires the Postgres advisory lock is allowed to register BullMQ repeatable jobs.
+
+### How election works
+
+- On startup, each replica calls `pg_try_advisory_lock($1::integer, $2::integer)` using the shared scheduler lock key.
+- The first replica that receives `acquired = true` keeps that database connection open. Postgres advisory locks are session-scoped, so the lock remains held while that connection is alive.
+- Non-leaders release their temporary database connection immediately and retry on the election interval.
+- The leader registers the cron entries for:
+  - retention cleanup (`0 2 * * *`)
+  - position snapshots (`0 0 * * *`)
+  - indexer health checks (`*/5 * * * *`)
+- The local Prometheus gauge `scheduler_is_leader` is set to `1` on the elected replica and `0` on standbys.
+
+### Crash and mid-cycle recovery
+
+If the leader crashes, its process exits and Postgres closes the session that held the advisory lock. Postgres then releases the lock automatically. The next standby election attempt can acquire the lock and re-register the repeatable jobs.
+
+BullMQ repeatable job registration is idempotent: each cron entry checks existing repeatable jobs by name before calling `queue.add`. This means a replacement leader can safely run registration after a crash without duplicating schedules. If a crash happens after a job was enqueued but before the worker finishes it, recovery follows the normal BullMQ worker semantics for that queue; the leader election only protects cron registration so multiple replicas do not create duplicate repeatable schedules.
+
+### Operational checks
+
+1. Scrape `/api/metrics` with the configured bearer token and verify exactly one healthy replica reports `scheduler_is_leader 1`.
+2. If no replica is leader, check database connectivity and the scheduler logs for advisory-lock query errors.
+3. If more than one replica reports leader status, verify all replicas point at the same Postgres database and are using the same scheduler lock key.
+4. After replacing a crashed leader, confirm a standby logs `Acquired cron scheduler leadership` within one election interval.

--- a/docs/scheduler-leader-election.md
+++ b/docs/scheduler-leader-election.md
@@ -1,0 +1,28 @@
+# Scheduler leader election
+
+`lib/jobs/scheduler.ts` provides a small cron-registration coordinator for multi-replica deployments. It uses a Postgres advisory lock instead of in-memory process state so all replicas agree on a single scheduler leader.
+
+## Registered cron jobs
+
+The cron registry lives in `src/jobs/cron.ts` and currently registers these BullMQ repeatable jobs:
+
+| Entry                  | Queue                      | Job name               | Schedule (UTC) | Purpose                                         |
+| ---------------------- | -------------------------- | ---------------------- | -------------- | ----------------------------------------------- |
+| `retention`            | `retention-job`            | `daily-retention`      | `0 2 * * *`    | Delete stale audit, session, and snapshot data. |
+| `snapshot`             | `snapshot-job`             | `daily-snapshot`       | `0 0 * * *`    | Capture daily wallet position snapshots.        |
+| `indexer-health-check` | `indexer-health-check-job` | `indexer-health-check` | `*/5 * * * *`  | Check indexer progress and upstream health.     |
+
+## Recovery behavior
+
+The advisory lock is scoped to the database session held by the leader. If the leader process exits, loses its database connection, or is killed mid-cycle, Postgres releases the lock. Standby replicas retry election periodically; the first standby to acquire the lock becomes leader and runs the idempotent cron registration flow.
+
+Repeatable job registration checks BullMQ for an existing job name before adding it, so re-registration after failover is safe and avoids duplicate schedules. Running or already-enqueued jobs are handled by the queue workers; the scheduler only decides which process is allowed to create or repair repeatable cron definitions.
+
+## Metrics
+
+`/api/metrics` exposes `scheduler_is_leader` as a Prometheus gauge:
+
+- `1` means this replica owns the scheduler advisory lock.
+- `0` means this replica is a standby or has released leadership.
+
+Alert if no live replica reports `scheduler_is_leader 1` for longer than the election interval plus database connection timeout.

--- a/lib/jobs/scheduler.test.ts
+++ b/lib/jobs/scheduler.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+vi.mock("@/lib/db/pool", () => ({ default: { connect: vi.fn() } }));
+
+import {
+  CronScheduler,
+  createCronScheduler,
+  type CronEntry,
+} from "./scheduler";
+import { metrics } from "@/lib/metrics/registry";
+
+type QueryResult = { rows: Array<Record<string, unknown>> };
+
+class FakeAdvisoryLockManager {
+  holder: FakeClient | null = null;
+
+  tryAcquire(client: FakeClient): boolean {
+    if (!this.holder) {
+      this.holder = client;
+      return true;
+    }
+    return this.holder === client;
+  }
+
+  release(client: FakeClient): void {
+    if (this.holder === client) {
+      this.holder = null;
+    }
+  }
+}
+
+class FakeClient {
+  released = false;
+  queries: string[] = [];
+
+  constructor(private readonly manager: FakeAdvisoryLockManager) {}
+
+  async query(sql: string): Promise<QueryResult> {
+    this.queries.push(sql);
+    if (sql.includes("pg_try_advisory_lock")) {
+      return { rows: [{ acquired: this.manager.tryAcquire(this) }] };
+    }
+    if (
+      sql.includes("pg_advisory_unlock") &&
+      !sql.includes("pg_try_advisory_lock")
+    ) {
+      this.manager.release(this);
+      return { rows: [{ pg_advisory_unlock: true }] };
+    }
+    return { rows: [] };
+  }
+
+  release(): void {
+    this.released = true;
+  }
+}
+
+function createFakePool(manager: FakeAdvisoryLockManager) {
+  const clients: FakeClient[] = [];
+  return {
+    clients,
+    pool: {
+      connect: vi.fn(async () => {
+        const client = new FakeClient(manager);
+        clients.push(client);
+        return client;
+      }),
+    },
+  };
+}
+
+function createEntries() {
+  return [
+    {
+      id: "retention",
+      name: "daily-retention",
+      cron: "0 2 * * *",
+      description: "retention",
+      schedule: vi.fn().mockResolvedValue(undefined),
+    },
+    {
+      id: "snapshot",
+      name: "daily-snapshot",
+      cron: "0 0 * * *",
+      description: "snapshot",
+      schedule: vi.fn().mockResolvedValue(undefined),
+    },
+    {
+      id: "indexer-health-check",
+      name: "indexer-health-check",
+      cron: "*/5 * * * *",
+      description: "indexer health",
+      schedule: vi.fn().mockResolvedValue(undefined),
+    },
+  ] satisfies CronEntry[];
+}
+
+describe("CronScheduler advisory-lock leader election", () => {
+  beforeEach(() => {
+    metrics.setSchedulerIsLeader(0);
+  });
+
+  it("allows only one simulated process to register cron entries", async () => {
+    const manager = new FakeAdvisoryLockManager();
+    const fake = createFakePool(manager);
+    const firstEntries = createEntries();
+    const secondEntries = createEntries();
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const first = new CronScheduler({
+      pool: fake.pool,
+      entries: firstEntries,
+      logger,
+      electionIntervalMs: 60_000,
+    });
+    const second = new CronScheduler({
+      pool: fake.pool,
+      entries: secondEntries,
+      logger,
+      electionIntervalMs: 60_000,
+    });
+
+    await first.start();
+    await second.start();
+
+    expect(first.isLeader).toBe(true);
+    expect(second.isLeader).toBe(false);
+    firstEntries.forEach((entry) =>
+      expect(entry.schedule).toHaveBeenCalledTimes(1),
+    );
+    secondEntries.forEach((entry) =>
+      expect(entry.schedule).not.toHaveBeenCalled(),
+    );
+    expect(fake.clients[1].released).toBe(true);
+
+    await first.stop();
+    await second.stop();
+  });
+
+  it("is idempotent while running and releases leadership if cron registration fails", async () => {
+    const manager = new FakeAdvisoryLockManager();
+    const fake = createFakePool(manager);
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const failingEntries = [
+      {
+        id: "retention",
+        name: "daily-retention",
+        cron: "0 2 * * *",
+        description: "retention",
+        schedule: vi.fn().mockRejectedValue(new Error("queue unavailable")),
+      },
+    ] satisfies CronEntry[];
+
+    const scheduler = createCronScheduler(failingEntries, {
+      pool: fake.pool,
+      logger,
+      electionIntervalMs: 60_000,
+    });
+
+    await expect(scheduler.start()).rejects.toThrow("queue unavailable");
+    expect(scheduler.isLeader).toBe(false);
+    expect(fake.clients[0].released).toBe(true);
+    expect(metrics.collect()).toContain("scheduler_is_leader 0");
+
+    const healthyEntries = createEntries();
+    const healthyScheduler = new CronScheduler({
+      pool: fake.pool,
+      entries: healthyEntries,
+      logger,
+      electionIntervalMs: 60_000,
+    });
+    await healthyScheduler.start();
+    await expect(healthyScheduler.start()).resolves.toBeUndefined();
+    await expect(healthyScheduler.tryBecomeLeader()).resolves.toBe(true);
+    healthyEntries.forEach((entry) =>
+      expect(entry.schedule).toHaveBeenCalledTimes(1),
+    );
+    await healthyScheduler.stop();
+  });
+
+  it("lets a standby process recover scheduling after the leader releases the advisory lock", async () => {
+    const manager = new FakeAdvisoryLockManager();
+    const fake = createFakePool(manager);
+    const leaderEntries = createEntries();
+    const standbyEntries = createEntries();
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const leader = new CronScheduler({
+      pool: fake.pool,
+      entries: leaderEntries,
+      logger,
+      electionIntervalMs: 60_000,
+    });
+    const standby = new CronScheduler({
+      pool: fake.pool,
+      entries: standbyEntries,
+      logger,
+      electionIntervalMs: 60_000,
+    });
+
+    await leader.start();
+    await standby.start();
+
+    await leader.stop();
+    await expect(standby.tryBecomeLeader()).resolves.toBe(true);
+
+    expect(standby.isLeader).toBe(true);
+    standbyEntries.forEach((entry) =>
+      expect(entry.schedule).toHaveBeenCalledTimes(1),
+    );
+    expect(metrics.collect()).toContain("scheduler_is_leader 1");
+
+    await standby.stop();
+    expect(metrics.collect()).toContain("scheduler_is_leader 0");
+  });
+});

--- a/lib/jobs/scheduler.ts
+++ b/lib/jobs/scheduler.ts
@@ -1,0 +1,162 @@
+import type { Pool, PoolClient } from "pg";
+import pool from "@/lib/db/pool";
+import { metrics } from "@/lib/metrics/registry";
+
+export interface CronEntry {
+  id: string;
+  name: string;
+  cron: string;
+  description: string;
+  schedule: () => Promise<void>;
+}
+
+export interface SchedulerOptions {
+  pool?: Pick<Pool, "connect">;
+  entries: CronEntry[];
+  lockKey?: readonly [number, number];
+  electionIntervalMs?: number;
+  logger?: Pick<Console, "info" | "warn" | "error">;
+}
+
+const DEFAULT_LOCK_KEY = [0x53544c4c, 0x43524f4e] as const; // STLL / CRON
+const DEFAULT_ELECTION_INTERVAL_MS = 30_000;
+
+type SchedulerClient = Pick<PoolClient, "query" | "release">;
+
+function getBooleanRow(
+  result: { rows?: Array<Record<string, unknown>> },
+  field: string,
+): boolean {
+  return result.rows?.[0]?.[field] === true;
+}
+
+export class CronScheduler {
+  private readonly pool: Pick<Pool, "connect">;
+  private readonly entries: CronEntry[];
+  private readonly lockKey: readonly [number, number];
+  private readonly electionIntervalMs: number;
+  private readonly logger: Pick<Console, "info" | "warn" | "error">;
+  private leaderClient: SchedulerClient | null = null;
+  private electionTimer: NodeJS.Timeout | null = null;
+  private stopped = true;
+  private scheduledForCurrentTerm = false;
+
+  constructor(options: SchedulerOptions) {
+    this.pool = options.pool ?? pool;
+    this.entries = options.entries;
+    this.lockKey = options.lockKey ?? DEFAULT_LOCK_KEY;
+    this.electionIntervalMs =
+      options.electionIntervalMs ?? DEFAULT_ELECTION_INTERVAL_MS;
+    this.logger = options.logger ?? console;
+  }
+
+  get isLeader(): boolean {
+    return this.leaderClient !== null;
+  }
+
+  async start(): Promise<void> {
+    if (!this.stopped) return;
+
+    this.stopped = false;
+    try {
+      await this.tryBecomeLeader();
+    } catch (error) {
+      this.stopped = true;
+      throw error;
+    }
+    this.electionTimer = setInterval(() => {
+      void this.tryBecomeLeader();
+    }, this.electionIntervalMs);
+    this.electionTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.electionTimer) {
+      clearInterval(this.electionTimer);
+      this.electionTimer = null;
+    }
+    await this.releaseLeadership();
+  }
+
+  async tryBecomeLeader(): Promise<boolean> {
+    if (this.stopped) return false;
+    if (this.leaderClient) return true;
+
+    const client = await this.pool.connect();
+    const acquired = await this.acquireLock(client);
+
+    if (!acquired) {
+      client.release();
+      metrics.setSchedulerIsLeader(0);
+      return false;
+    }
+
+    this.leaderClient = client;
+    this.scheduledForCurrentTerm = false;
+    metrics.setSchedulerIsLeader(1);
+    this.logger.info("[Scheduler] Acquired cron scheduler leadership");
+
+    try {
+      await this.scheduleEntriesOnce();
+      return true;
+    } catch (error) {
+      this.logger.error(
+        "[Scheduler] Failed to schedule cron entries after acquiring leadership",
+        error,
+      );
+      await this.releaseLeadership();
+      throw error;
+    }
+  }
+
+  private async acquireLock(client: SchedulerClient): Promise<boolean> {
+    const result = await client.query(
+      "SELECT pg_try_advisory_lock($1::integer, $2::integer) AS acquired",
+      [this.lockKey[0], this.lockKey[1]],
+    );
+    return getBooleanRow(result, "acquired");
+  }
+
+  private async releaseLeadership(): Promise<void> {
+    const client = this.leaderClient;
+    if (!client) {
+      metrics.setSchedulerIsLeader(0);
+      return;
+    }
+
+    this.leaderClient = null;
+    this.scheduledForCurrentTerm = false;
+
+    try {
+      await client.query(
+        "SELECT pg_advisory_unlock($1::integer, $2::integer)",
+        [this.lockKey[0], this.lockKey[1]],
+      );
+    } finally {
+      client.release();
+      metrics.setSchedulerIsLeader(0);
+      this.logger.info("[Scheduler] Released cron scheduler leadership");
+    }
+  }
+
+  private async scheduleEntriesOnce(): Promise<void> {
+    if (this.scheduledForCurrentTerm) return;
+
+    for (const entry of this.entries) {
+      await entry.schedule();
+      this.logger.info(
+        `[Scheduler] Registered cron entry ${entry.id} (${entry.cron})`,
+      );
+    }
+
+    this.scheduledForCurrentTerm = true;
+  }
+}
+
+export function createCronScheduler(
+  entries: CronEntry[],
+  options: Omit<SchedulerOptions, "entries"> = {},
+): CronScheduler {
+  return new CronScheduler({ ...options, entries });
+}

--- a/lib/metrics/registry.ts
+++ b/lib/metrics/registry.ts
@@ -26,6 +26,17 @@ class Counter {
   }
 }
 
+class Gauge {
+  private value = 0;
+  constructor(private name: string, private help: string) {}
+  set(value: number) {
+    this.value = value;
+  }
+  collect(): string {
+    return `# HELP ${this.name} ${this.help}\n# TYPE ${this.name} gauge\n${this.name} ${this.value}\n`;
+  }
+}
+
 class Histogram {
   private buckets = new Map<string, number>();
   private sum = 0;
@@ -80,6 +91,11 @@ class Registry {
   outboundRequests = new Counter('outbound_http_requests_total', 'Outbound HTTP requests');
   outboundRequestDuration = new Histogram('outbound_http_request_duration_seconds', 'Outbound HTTP request duration seconds');
   horizonSelections = new Counter('horizon_selection_total', 'Horizon endpoint selections');
+  schedulerIsLeader = new Gauge('scheduler_is_leader', 'Whether this replica currently owns the cron scheduler advisory lock');
+
+  setSchedulerIsLeader(value: 0 | 1): void {
+    this.schedulerIsLeader.set(value);
+  }
 
   collect(): string {
     // Return concatenated exposition
@@ -92,6 +108,7 @@ class Registry {
     out += this.outboundRequests.collect();
     out += this.outboundRequestDuration.collect();
     out += this.horizonSelections.collect();
+    out += this.schedulerIsLeader.collect();
     return out;
   }
 }

--- a/src/jobs/cron.test.ts
+++ b/src/jobs/cron.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const queueInstances: Array<{
+  name: string;
+  options: Record<string, unknown> | undefined;
+  getRepeatableJobs: ReturnType<typeof vi.fn>;
+  add: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock("bullmq", () => ({
+  Queue: vi
+    .fn()
+    .mockImplementation((name: string, options?: Record<string, unknown>) => {
+      const instance = {
+        name,
+        options,
+        getRepeatableJobs: vi.fn().mockResolvedValue([]),
+        add: vi.fn().mockResolvedValue({}),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      queueInstances.push(instance);
+      return instance;
+    }),
+}));
+
+describe("cron registry", () => {
+  beforeEach(() => {
+    queueInstances.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("registers retention, snapshot, and indexer health-check repeatable jobs", async () => {
+    const { cronEntries } = await import("./cron");
+
+    expect(cronEntries.map((entry) => entry.id)).toEqual([
+      "retention",
+      "snapshot",
+      "indexer-health-check",
+    ]);
+
+    for (const entry of cronEntries) {
+      await entry.schedule();
+    }
+
+    expect(queueInstances.map((queue) => queue.name)).toEqual([
+      "retention-job",
+      "snapshot-job",
+      "indexer-health-check-job",
+    ]);
+    expect(queueInstances[0].add).toHaveBeenCalledWith(
+      "daily-retention",
+      {},
+      expect.objectContaining({ repeat: { pattern: "0 2 * * *" } }),
+    );
+    expect(queueInstances[1].add).toHaveBeenCalledWith(
+      "daily-snapshot",
+      expect.objectContaining({ timestamp: expect.any(Number) }),
+      expect.objectContaining({ repeat: { pattern: "0 0 * * *" } }),
+    );
+    expect(queueInstances[2].add).toHaveBeenCalledWith(
+      "indexer-health-check",
+      {},
+      expect.objectContaining({ repeat: { pattern: "*/5 * * * *" } }),
+    );
+    queueInstances.forEach((queue) =>
+      expect(queue.close).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  it("does not add a repeatable job that already exists", async () => {
+    const { cronEntries } = await import("./cron");
+
+    queueInstances.push({
+      name: "preconfigured-retention-job",
+      options: undefined,
+      getRepeatableJobs: vi
+        .fn()
+        .mockResolvedValue([{ name: "daily-retention" }]),
+      add: vi.fn().mockResolvedValue({}),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await cronEntries[0].schedule();
+
+    expect(queueInstances[0].add).not.toHaveBeenCalled();
+  });
+});

--- a/src/jobs/cron.ts
+++ b/src/jobs/cron.ts
@@ -1,0 +1,87 @@
+import type { CronEntry } from "@/lib/jobs/scheduler";
+
+interface RepeatableJob {
+  name: string;
+}
+
+interface QueueLike {
+  getRepeatableJobs(): Promise<RepeatableJob[]>;
+  add(
+    name: string,
+    data: Record<string, unknown>,
+    options: Record<string, unknown>,
+  ): Promise<unknown>;
+  close?(): Promise<void>;
+}
+
+type QueueConstructor = new (
+  name: string,
+  options?: Record<string, unknown>,
+) => QueueLike;
+
+async function loadQueueConstructor(): Promise<QueueConstructor> {
+  const bullmq = await import("bullmq");
+  return bullmq.Queue as QueueConstructor;
+}
+
+async function registerRepeatableJob(
+  queueName: string,
+  jobName: string,
+  cron: string,
+  data: Record<string, unknown> = {},
+): Promise<void> {
+  const Queue = await loadQueueConstructor();
+  const queue = new Queue(queueName, {
+    connection: process.env.REDIS_URL ? { url: process.env.REDIS_URL } : {},
+  });
+
+  try {
+    const existing = await queue.getRepeatableJobs();
+    if (existing.some((job) => job.name === jobName)) return;
+
+    await queue.add(jobName, data, {
+      repeat: { pattern: cron },
+      removeOnComplete: true,
+      removeOnFail: true,
+    });
+  } finally {
+    await queue.close?.();
+  }
+}
+
+export const cronEntries: CronEntry[] = [
+  {
+    id: "retention",
+    name: "daily-retention",
+    cron: "0 2 * * *",
+    description:
+      "Prune audit events, sessions, and stale position snapshots beyond retention windows.",
+    schedule: () =>
+      registerRepeatableJob("retention-job", "daily-retention", "0 2 * * *"),
+  },
+  {
+    id: "snapshot",
+    name: "daily-snapshot",
+    cron: "0 0 * * *",
+    description: "Capture daily position snapshots for tracked wallets.",
+    schedule: () =>
+      registerRepeatableJob("snapshot-job", "daily-snapshot", "0 0 * * *", {
+        timestamp: Date.now(),
+      }),
+  },
+  {
+    id: "indexer-health-check",
+    name: "indexer-health-check",
+    cron: "*/5 * * * *",
+    description:
+      "Verify indexer progress and upstream Horizon health every five minutes.",
+    schedule: () =>
+      registerRepeatableJob(
+        "indexer-health-check-job",
+        "indexer-health-check",
+        "*/5 * * * *",
+      ),
+  },
+];
+
+export default cronEntries;

--- a/src/jobs/retention.worker.ts
+++ b/src/jobs/retention.worker.ts
@@ -1,5 +1,5 @@
 // src/jobs/retention.worker.ts
-import { Worker, Queue, QueueScheduler, Job } from 'bullmq';
+import { Worker, Queue, Job } from 'bullmq';
 import pool from '../../lib/db/pool';
 import {
   AUDIT_RETENTION_DAYS,
@@ -71,8 +71,6 @@ const queue = new Queue(queueName, {
     // BullMQ will use default Redis connection env vars (REDIS_URL etc.)
   },
 });
-const scheduler = new QueueScheduler(queueName);
-
 export const retentionWorker = new Worker(
   queueName,
   async (job: Job) => {
@@ -94,7 +92,7 @@ export async function scheduleRetentionJob(): Promise<void> {
       'daily-retention',
       {},
       {
-        repeat: { cron: '0 2 * * *' }, // every day at 02:00 UTC
+        repeat: { pattern: '0 2 * * *' }, // every day at 02:00 UTC
         removeOnComplete: true,
         removeOnFail: true,
       }
@@ -103,4 +101,5 @@ export async function scheduleRetentionJob(): Promise<void> {
   }
 }
 
-scheduleRetentionJob().catch((e) => console.error('Failed to schedule retention job', e));
+// Scheduling is coordinated by lib/jobs/scheduler.ts and src/jobs/cron.ts so
+// multi-replica deployments only register repeatable jobs from the elected leader.


### PR DESCRIPTION
### Motivation
- Prevent duplicate scheduling of repeatable BullMQ cron jobs in multi-replica deployments by electing a single scheduler leader using a Postgres advisory lock.
- Make cron registration idempotent and observable so operators can detect which replica owns scheduling and recover safely after failures.

### Description
- Add `lib/jobs/scheduler.ts` which performs leader election using `pg_try_advisory_lock` on a held Postgres session, exposes `isLeader`, sets/releases leadership, and runs cron registration once per leadership term.
- Add a cron registry in `src/jobs/cron.ts` that idempotently registers repeatable BullMQ jobs for `retention`, `snapshot`, and `indexer-health-check` and closes queue handles after registration.
- Expose a `scheduler_is_leader` Prometheus gauge via the existing metrics registry by adding a lightweight `Gauge` and `setSchedulerIsLeader` in `lib/metrics/registry.ts` and update the metrics test to assert the new gauge.
- Stop the retention worker from registering its own repeatable job on module load so registration is coordinated by the elected scheduler, and add type declarations for `bullmq` used in tests.
- Add tests: `lib/jobs/scheduler.test.ts` simulates two processes and verifies election, failover, idempotency and lock release behavior; `src/jobs/cron.test.ts` verifies cron registry behavior; update docs (`docs/scheduler-leader-election.md`, `docs/infrastructure/README.md`) and link scheduled-jobs guidance from `README.md`.

### Testing
- Ran unit tests with Vitest: `npx vitest run --config vitest.server.config.ts lib/jobs/scheduler.test.ts src/jobs/cron.test.ts app/api/metrics/route.test.ts` and all tests passed (7 tests across added files passed).
- Ran coverage for the new scheduler/cron code: `npx vitest run --coverage --config vitest.server.config.ts --coverage.include='lib/jobs/scheduler.ts' --coverage.include='src/jobs/cron.ts'` which reported ~99%+ statement coverage for the included files and satisfied the coverage requirement for the changed modules.
- Performed a broader test run of the three test files with coverage which completed successfully and included the `scheduler_is_leader` metric in the exported metrics body.
- `npm run type-check` and `npm run lint` were attempted but reported failures due to pre-existing unrelated syntax/lint errors in other parts of the repository (these errors predate the scheduler change and do not affect the new scheduler tests).

------


Closes #288