### PR TITLE
PR for Add gzip/brotli compression negotiation for /api/transactions and other large read responses

### DIFF
--- a/app/api/transactions/export/route.ts
+++ b/app/api/transactions/export/route.ts
@@ -6,6 +6,7 @@ import {
   serializeTransactionsToCSV,
 } from '@/lib/transactions';
 import type { TransactionFilters, TransactionStatus } from '@/lib/transactions';
+import { withRequestLogging } from '@/lib/api/handler';
 
 export const runtime = 'nodejs';
 
@@ -21,7 +22,7 @@ function parseFilters(searchParams: URLSearchParams): TransactionFilters {
   };
 }
 
-export async function GET(request: NextRequest) {
+async function handleExportTransactions(request: NextRequest) {
   const user = await getUser();
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -43,3 +44,5 @@ export async function GET(request: NextRequest) {
     },
   });
 }
+
+export const GET = withRequestLogging('/api/transactions/export', handleExportTransactions);

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -147,6 +147,18 @@ CSV export, filtering helpers, and validation used by `/api/transactions/export`
 `generateETag(data)` — deterministic ETag for conditional GET (`If-None-Match`).
 Used by read routes to return `304 Not Modified` and save bandwidth.
 
+### lib/api/handler.ts — Request logging and response compression
+
+`withRequestLogging(route, handler)` records structured request metrics and applies response compression negotiation for large read responses. If the client sends `Accept-Encoding: br` or `Accept-Encoding: gzip`, compressible responses at or above 1 KiB are returned with `Content-Encoding` and `Vary: Accept-Encoding`. Brotli is preferred when both encodings are acceptable.
+
+Compression is intentionally skipped for responses that are already encoded, empty/conditional responses (`HEAD`, `204`, `304`), and content types that are already compressed or should remain stream-native, including `text/csv` exports and `text/event-stream`. Content-length-delimited streams are piped through gzip/brotli transforms so large payloads do not need to be buffered before sending.
+
+Performance-sensitive callers can opt out per request by sending:
+
+```http
+X-Stellarlend-Compression: off
+```
+
 ---
 
 ## Type Definitions

--- a/lib/api/handler.test.ts
+++ b/lib/api/handler.test.ts
@@ -1,6 +1,20 @@
+import { promisify } from 'node:util';
+import { brotliDecompress, gunzip } from 'node:zlib';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
-import { withRequestLogging } from '@/lib/api/handler';
+import {
+  RESPONSE_COMPRESSION_MIN_BYTES,
+  RESPONSE_COMPRESSION_OPT_OUT_HEADER,
+  applyResponseCompression,
+  withRequestLogging,
+} from '@/lib/api/handler';
+
+const gunzipAsync = promisify(gunzip);
+const brotliDecompressAsync = promisify(brotliDecompress);
+
+async function responseBuffer(response: Response) {
+  return Buffer.from(await response.arrayBuffer());
+}
 
 describe('withRequestLogging', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -55,5 +69,100 @@ describe('withRequestLogging', () => {
     expect(logEntry.route).toBe('/api/test-error');
     expect(logEntry.context?.request?.method).toBe('POST');
     expect(logEntry.context?.error?.message).toBe('boom');
+  });
+
+  it('brotli-compresses large JSON responses when the client supports br', async () => {
+    const payload = { transactions: Array.from({ length: 200 }, (_, index) => ({ id: `txn-${index}`, memo: 'mobile-json'.repeat(8) })) };
+    const handler = withRequestLogging('/api/transactions', async () => NextResponse.json(payload));
+    const request = new NextRequest('http://localhost/api/transactions', {
+      method: 'GET',
+      headers: { 'Accept-Encoding': 'gzip, br' },
+    });
+
+    const response = await handler(request);
+
+    expect(response.headers.get('Content-Encoding')).toBe('br');
+    expect(response.headers.get('Vary')).toContain('Accept-Encoding');
+    expect(response.headers.has('Content-Length')).toBe(false);
+
+    const decompressed = await brotliDecompressAsync(await responseBuffer(response));
+    expect(JSON.parse(decompressed.toString('utf8'))).toEqual(payload);
+  });
+});
+
+describe('applyResponseCompression', () => {
+  it('leaves responses below the threshold uncompressed while preserving Vary', async () => {
+    const request = new NextRequest('http://localhost/api/transactions', {
+      method: 'GET',
+      headers: { 'Accept-Encoding': 'gzip' },
+    });
+    const response = NextResponse.json({ ok: true });
+
+    const compressed = await applyResponseCompression(request, response);
+
+    expect(compressed.headers.get('Content-Encoding')).toBeNull();
+    expect(compressed.headers.get('Vary')).toContain('Accept-Encoding');
+    expect(await compressed.json()).toEqual({ ok: true });
+  });
+
+  it('honors the request opt-out header for performance-sensitive callers', async () => {
+    const request = new NextRequest('http://localhost/api/transactions', {
+      method: 'GET',
+      headers: {
+        'Accept-Encoding': 'br, gzip',
+        [RESPONSE_COMPRESSION_OPT_OUT_HEADER]: 'off',
+      },
+    });
+    const response = NextResponse.json({ data: 'x'.repeat(RESPONSE_COMPRESSION_MIN_BYTES + 1) });
+
+    const compressed = await applyResponseCompression(request, response);
+
+    expect(compressed.headers.get('Content-Encoding')).toBeNull();
+    expect(await compressed.json()).toEqual({ data: 'x'.repeat(RESPONSE_COMPRESSION_MIN_BYTES + 1) });
+  });
+
+  it('gzip-compresses content-length delimited streams without buffering the whole response first', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(Buffer.from('streamed-'));
+        controller.enqueue(Buffer.from('transaction-data'.repeat(200)));
+        controller.close();
+      },
+    });
+    const request = new NextRequest('http://localhost/api/transactions', {
+      method: 'GET',
+      headers: { 'Accept-Encoding': 'gzip' },
+    });
+    const response = new NextResponse(body, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': String(RESPONSE_COMPRESSION_MIN_BYTES + 100),
+      },
+    });
+
+    const compressed = await applyResponseCompression(request, response);
+
+    expect(compressed.headers.get('Content-Encoding')).toBe('gzip');
+    expect(compressed.headers.get('Vary')).toContain('Accept-Encoding');
+    expect(compressed.headers.has('Content-Length')).toBe(false);
+
+    const decompressed = await gunzipAsync(await responseBuffer(compressed));
+    expect(decompressed.toString('utf8')).toBe(`streamed-${'transaction-data'.repeat(200)}`);
+  });
+
+  it('does not compress CSV export responses', async () => {
+    const request = new NextRequest('http://localhost/api/transactions/export', {
+      method: 'GET',
+      headers: { 'Accept-Encoding': 'br, gzip' },
+    });
+    const response = new NextResponse(`id,amount\ntxn-1,10\n${'txn-2,20\n'.repeat(200)}`, {
+      headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+    });
+
+    const compressed = await applyResponseCompression(request, response);
+
+    expect(compressed.headers.get('Content-Encoding')).toBeNull();
+    expect(compressed.headers.get('Content-Type')).toBe('text/csv; charset=utf-8');
+    expect(await compressed.text()).toContain('txn-1,10');
   });
 });

--- a/lib/api/handler.ts
+++ b/lib/api/handler.ts
@@ -1,8 +1,31 @@
+import { Readable } from 'node:stream';
+import { constants as zlibConstants, createBrotliCompress, createGzip } from 'node:zlib';
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 import { metrics } from '@/lib/metrics/registry';
 import { chaosInject } from '@/lib/chaos/inject';
 import { verifyCsrfToken } from '@/lib/security/csrf';
+
+export const RESPONSE_COMPRESSION_MIN_BYTES = 1024;
+export const RESPONSE_COMPRESSION_OPT_OUT_HEADER = 'X-Stellarlend-Compression';
+
+type CompressionEncoding = 'br' | 'gzip';
+
+async function captureRequestError(
+  error: unknown,
+  context: {
+    route?: string;
+    method?: string;
+    sessionId?: string;
+  }
+) {
+  try {
+    const { captureServerError } = await import('@/lib/telemetry/sentry');
+    captureServerError(error, context);
+  } catch {
+    // Sentry must never prevent returning the API error response.
+  }
+}
 
 function serializeError(error: unknown) {
   if (error instanceof Error) {
@@ -14,6 +37,161 @@ function serializeError(error: unknown) {
   }
 
   return String(error);
+}
+
+function appendVary(headers: Headers, value: string) {
+  const existing = headers.get('Vary');
+  if (!existing) {
+    headers.set('Vary', value);
+    return;
+  }
+
+  const values = existing.split(',').map((entry) => entry.trim().toLowerCase());
+  if (!values.includes(value.toLowerCase())) {
+    headers.set('Vary', `${existing}, ${value}`);
+  }
+}
+
+function acceptsCompressionOptOut(request: NextRequest | undefined) {
+  return request?.headers.get(RESPONSE_COMPRESSION_OPT_OUT_HEADER)?.toLowerCase() === 'off';
+}
+
+function parseAcceptEncoding(header: string | null): CompressionEncoding | null {
+  if (!header) return null;
+
+  const qByCoding = new Map<string, number>();
+  for (const entry of header.split(',')) {
+    const [rawCoding, ...params] = entry.trim().split(';');
+    const coding = rawCoding.trim().toLowerCase();
+    const qParam = params.find((param) => param.trim().toLowerCase().startsWith('q='));
+    const q = qParam ? Number(qParam.split('=')[1]) : 1;
+    qByCoding.set(coding, Number.isFinite(q) ? q : 0);
+  }
+
+  const brQ = qByCoding.get('br') ?? qByCoding.get('*') ?? 0;
+  const gzipQ = qByCoding.get('gzip') ?? qByCoding.get('*') ?? 0;
+  if (brQ <= 0 && gzipQ <= 0) return null;
+
+  return brQ >= gzipQ ? 'br' : 'gzip';
+}
+
+function isCompressibleContentType(contentType: string | null) {
+  if (!contentType) return true;
+
+  const normalized = contentType.toLowerCase();
+  if (
+    normalized.includes('text/event-stream') ||
+    normalized.includes('text/csv') ||
+    normalized.includes('application/zip') ||
+    normalized.includes('application/gzip') ||
+    normalized.includes('application/x-gzip') ||
+    normalized.startsWith('image/') ||
+    normalized.startsWith('audio/') ||
+    normalized.startsWith('video/')
+  ) {
+    return false;
+  }
+
+  return (
+    normalized.startsWith('text/') ||
+    normalized.includes('json') ||
+    normalized.includes('xml') ||
+    normalized.includes('javascript') ||
+    normalized.includes('wasm')
+  );
+}
+
+function createCompressedStream(body: ReadableStream<Uint8Array>, encoding: CompressionEncoding) {
+  const compressor =
+    encoding === 'br'
+      ? createBrotliCompress({
+          params: {
+            [zlibConstants.BROTLI_PARAM_QUALITY]: 4,
+          },
+        })
+      : createGzip({ level: zlibConstants.Z_BEST_SPEED });
+
+  return Readable.toWeb(Readable.fromWeb(body).pipe(compressor)) as ReadableStream<Uint8Array>;
+}
+
+function responseHasBody(response: Response, method: string | undefined) {
+  return method !== 'HEAD' && response.body !== null && response.status !== 204 && response.status !== 304;
+}
+
+function buildCompressedResponse(response: Response, encoding: CompressionEncoding, body: ReadableStream<Uint8Array>) {
+  const headers = new Headers(response.headers);
+  headers.set('Content-Encoding', encoding);
+  appendVary(headers, 'Accept-Encoding');
+  headers.delete('Content-Length');
+  headers.delete('Content-MD5');
+
+  return new NextResponse(createCompressedStream(body, encoding), {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function applyResponseCompression(
+  request: NextRequest | undefined,
+  response: NextResponse,
+  minBytes = RESPONSE_COMPRESSION_MIN_BYTES
+): Promise<NextResponse> {
+  if (!request || acceptsCompressionOptOut(request)) return response;
+
+  const headers = new Headers(response.headers);
+  if (!responseHasBody(response, request.method) || headers.has('Content-Encoding')) return response;
+
+  const encoding = parseAcceptEncoding(request.headers.get('Accept-Encoding'));
+  if (!encoding) return response;
+
+  if (!isCompressibleContentType(headers.get('Content-Type'))) return response;
+
+  appendVary(headers, 'Accept-Encoding');
+
+  const contentLength = headers.get('Content-Length');
+  if (contentLength !== null) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength < minBytes) {
+      return new NextResponse(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
+    }
+
+    if (response.body) {
+      return buildCompressedResponse(
+        new NextResponse(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        }),
+        encoding,
+        response.body
+      );
+    }
+  }
+
+  const cloned = response.clone();
+  const body = new Uint8Array(await cloned.arrayBuffer());
+  if (body.byteLength < minBytes) {
+    return new NextResponse(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  return buildCompressedResponse(
+    new NextResponse(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }),
+    encoding,
+    new Response(body).body as ReadableStream<Uint8Array>
+  );
 }
 
 export function withCsrfProtection<T extends (...args: unknown[]) => Promise<NextResponse> | NextResponse>(handler: T) {
@@ -71,7 +249,7 @@ export function withRequestLogging<T extends (...args: unknown[]) => Promise<Nex
         request: requestContext,
       });
 
-      return response;
+      return (await applyResponseCompression(request, response)) as ReturnType<T>;
     } catch (error) {
       const durationMs = Date.now() - startedAt;
 
@@ -83,7 +261,7 @@ export function withRequestLogging<T extends (...args: unknown[]) => Promise<Nex
         // swallow metrics errors
       }
 
-      captureServerError(error, {
+      await captureRequestError(error, {
         route,
         method,
         sessionId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9279,3 +9279,5 @@ zod@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
+
+


### PR DESCRIPTION
### Motivation
- Large JSON responses from endpoints like `/api/transactions` and `/api/transactions/export` were sent uncompressed and inflated bandwidth, especially on mobile; adding negotiation reduces client bandwidth and latency. 
- Compression must be safe (skip already-encoded or stream-native content), memory-bounded for streaming responses, and opt-out-able for performance-sensitive callers.

### Description
- Add streaming-aware compression negotiation and helpers in `lib/api/handler.ts`: `applyResponseCompression`, `RESPONSE_COMPRESSION_MIN_BYTES`, and `RESPONSE_COMPRESSION_OPT_OUT_HEADER` with Accept-Encoding parsing (brotli preferred) and q-value handling. 
- Apply compression only when appropriate and set `Content-Encoding` and `Vary: Accept-Encoding`, remove `Content-Length`, skip compression for CSV/SSE/media/compressed types, and pipe content-length-delimited streams through `gzip`/`brotli` transforms to avoid buffering. 
- Wire compression into `withRequestLogging` so existing read routes are automatically considered for compression. 
- Route `/api/transactions/export` through the shared handler (`withRequestLogging`) while preserving its `text/csv` response (explicitly skipped by the compressor). 
- Add server tests in `lib/api/handler.test.ts` covering brotli/gzip negotiation, threshold behavior, opt-out header (`X-Stellarlend-Compression: off`), CSV skip behavior, and streaming compression. 
- Document the behavior and opt-out header in `docs/backend-architecture.md`.

### Testing
- Ran server unit tests for the new behavior: `vitest` on `lib/api/handler.test.ts` passed (all tests for compression negotiation and edge cases succeeded). 
- Ran coverage for the handler tests with `vitest --coverage` for the focused test file; the tests completed successfully (coverage run emitted unrelated existing repo warnings but did not fail the tests). 
- Type-check (`tsc --noEmit`) is blocked by pre-existing unrelated TypeScript issues elsewhere in the repo and was not resolved by this change. 
- ESLint and full `pnpm`-based runs were prevented by environment/tooling issues in this execution (not related to the feature implementation).

------

Closes #289