### PR TITLE
split bundle budgetting for the lending route

### DIFF
--- a/app/lending/page.tsx
+++ b/app/lending/page.tsx
@@ -1,13 +1,22 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
 import LendingForm from '@/components/features/lending/components/LendingForm';
-import BorrowingForm from '@/components/features/lending/components/BorrowingForm';
-import InterestCalculator from '@/components/features/lending/components/InterestCalculator';
-import TransactionSummary from '@/components/features/lending/components/TransactionSummary';
-import ConfirmModal from '@/components/features/lending/components/ConfirmModal';
-import TabSelector from '@/components/features/lending/components/TabSelector';
 import { PageHeader } from '@/components/shared/common';
+import { Skeleton } from '@/components/shared/common/Skeleton';
+
+const BorrowingForm = dynamic(() => import('@/components/features/lending/components/BorrowingForm'), {
+  loading: () => <div className="space-y-4 animate-pulse"><Skeleton className="h-64 w-full" /></div>,
+});
+const InterestCalculator = dynamic(() => import('@/components/features/lending/components/InterestCalculator'), {
+  loading: () => <div className="space-y-4 animate-pulse"><Skeleton className="h-64 w-full" /></div>,
+});
+const TransactionSummary = dynamic(() => import('@/components/features/lending/components/TransactionSummary'), {
+  loading: () => <div className="space-y-4 animate-pulse"><Skeleton className="h-40 w-full" /></div>,
+});
+const ConfirmModal = dynamic(() => import('@/components/features/lending/components/ConfirmModal'));
+import TabSelector from '@/components/features/lending/components/TabSelector';
 
 export type { LendingData, CalculationResult } from '@/lib/lending/types';
 import type { LendingData, CalculationResult } from '@/lib/lending/types';

--- a/bundlewatch.config.json
+++ b/bundlewatch.config.json
@@ -1,6 +1,10 @@
 {
   "files": [
     {
+      "path": ".next/static/chunks/app/lending/**/*.js",
+      "maxSize": "150kb"
+    },
+    {
       "path": ".next/static/chunks/pages/*.js",
       "maxSize": "250kb"
     },

--- a/docs/PERFORMANCE_BUDGETS.md
+++ b/docs/PERFORMANCE_BUDGETS.md
@@ -1,0 +1,19 @@
+# Performance Budget: Lending Route
+
+To maintain fast initial load times for the lending page, we have implemented code splitting using `next/dynamic`.
+
+## Budget
+
+The lending route chunk is budgeted at **150kb**. 
+
+- This ensures that only the essential code for the landing state (Lending tab) is loaded initially.
+- The `BorrowingForm`, `InterestCalculator`, and `ConfirmModal` are loaded lazily on demand.
+
+## How to maintain this budget
+
+If you add new functionality to the lending page:
+
+1. **Lazy Load:** If the new component is not needed for the initial render (e.g., modals, form variants for off-screen tabs), lazy-load it using `next/dynamic`.
+2. **Review Imports:** Ensure large libraries or heavy utility functions are not bundled into the main `page.tsx` chunk unnecessarily.
+3. **Check CI:** The `bundlewatch` CI check will automatically fail if the budget is exceeded.
+4. **Update Budget:** If the budget is legitimately exceeded due to unavoidable new feature requirements, update the `maxSize` in `bundlewatch.config.json` and document the reason for the increase in this file.


### PR DESCRIPTION
 I have completed the task of implementing code splitting and bundle budgeting
  for the /lending route.

  Summary of Changes

   1. Code Splitting: Refactored app/lending/page.tsx to use next/dynamic for
      loading BorrowingForm, InterestCalculator, and TransactionSummary lazily.
      The LendingForm remains eager to ensure fast initial page load. Consistent
      skeleton loading fallbacks were added to improve user experience and
      prevent layout shifts.
   2. Bundle Budgeting: Added a specific bundle budget of 150kb for the lending
      route chunk in bundlewatch.config.json to prevent future regressions.
   3. Documentation: Created docs/PERFORMANCE_BUDGETS.md, detailing the
      rationale behind the budget, how the code splitting works, and
      instructions for developers to maintain these performance standards.

  Due to the unavailability of dependencies (e.g., node_modules not being
  populated), I was unable to verify the changes through a full build or test
  run. However, the changes follow standard Next.js and React code-splitting
  patterns and should behave correctly upon integration in a properly configured
  build environment.

closes #374 