### PR TITLE
feat(lending): add RepayForm for borrow positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 **Fast & Secure DeFi Lending on Stellar**
 
-Stellarlend is a decentralized finance (DeFi) lending platform built on the Stellar blockchain. It enables users to borrow and lend digital assets with ultra-low fees, instant settlements, and full transparency—powered by Soroban smart contracts. The platform is designed for both crypto-native users and those new to DeFi, offering an intuitive interface for managing lending and borrowing operations on one of the most efficient blockchain networks.
+Stellarlend is a decentralized finance (DeFi) lending platform built on the Stellar blockchain. It enables users to borrow and lend digital assets with ultra-low fees, instant settlements, and full transparency-powered by Soroban smart contracts. The platform is designed for both crypto-native users and those new to DeFi, offering an intuitive interface for managing lending and borrowing operations on one of the most efficient blockchain networks.
 
 This frontend application provides a modern, responsive web interface for interacting with the Stellarlend protocol, featuring real-time transaction tracking, interest rate calculations, and comprehensive dashboard analytics.
 
 ## Developer Guides
 
 - [Lending and borrowing data flow](docs/LENDING_FLOW.md)
+- [Borrow repayment flow](docs/REPAY_FLOW.md)
 
-## 🚀 Features
+## ?? Features
 
 - **Lending & Borrowing**: Earn interest by lending assets or borrow against collateral
 - **Multi-Asset Support**: Support for XLM, USDC, BTC, ETH, and other Stellar-based assets
@@ -21,13 +22,13 @@ This frontend application provides a modern, responsive web interface for intera
 - **Responsive Design**: Optimized for desktop, tablet, and mobile devices
 - **Component Library**: Built with Storybook for component development and documentation
 
-## 📋 Requirements
+## ?? Requirements
 
 - **Node.js**: v18.0.0 or higher
 - **Package Manager**: npm, yarn, pnpm, or bun
 - **Git**: For version control
 
-## 🛠️ Setup Instructions
+## ??? Setup Instructions
 
 ### 1. Clone the Repository
 
@@ -95,6 +96,7 @@ The Tx relay routes `/api/tx/build` and `/api/tx/submit` are protected by an acc
 Migration note: if you previously used `NEXT_PUBLIC_SOROBAN_RPC_URL`, rename it to `SOROBAN_RPC_URL` and restart the dev server or rebuild your deployment. The RPC endpoint now stays server-only so browsers cannot bypass the relay and its rate limits.
 
 Logging is emitted as structured JSON by `lib/logger.ts` and includes:
+
 - `timestamp`
 - `level`
 - `route`
@@ -131,11 +133,13 @@ Open [http://localhost:3000](http://localhost:3000) in your browser to see the a
 Stellarlend uses **Drizzle ORM** with a **PostgreSQL** database backend to persist accounts, sessions, notifications, transactions, and audit logs.
 
 1. Ensure your `.env.local` contains the database connection URL:
+
    ```env
    DATABASE_URL=postgres://postgres:postgres@localhost:5432/stellarlend
    ```
 
 2. Run the migrations to initialize your local database:
+
    ```bash
    # Using npm
    npm run db:migrate
@@ -151,7 +155,7 @@ npm run build
 npm start
 ```
 
-## 🧪 Testing
+## ?? Testing
 
 ### Run Tests
 
@@ -178,55 +182,55 @@ npm run build-storybook
 
 Storybook will be available at [http://localhost:6006](http://localhost:6006)
 
-## 📁 Project Structure
+## ?? Project Structure
 
 ```
 Stellarlend-frontend/
-├── app/                      # Next.js App Router pages
-│   ├── account/             # User account pages
-│   ├── dashboard/           # Dashboard pages
-│   ├── lending/             # Lending & borrowing pages
-│   └── layout.tsx           # Root layout
-├── components/              # React components
-│   ├── atoms/              # Atomic design: smallest components
-│   ├── molecules/          # Composite components
-│   ├── organisms/          # Complex components
-│   ├── features/           # Feature-specific components
-│   │   ├── account/        # Account feature components
-│   │   ├── dashboard/      # Dashboard feature components
-│   │   └── lending/        # Lending feature components
-│   ├── marketing/          # Marketing page components
-│   └── shared/             # Shared components
-│       ├── ui/             # UI components (buttons, icons, etc.)
-│       ├── layout/         # Layout components (navbar, sidebar, etc.)
-│       └── common/         # Common utility components
-├── constants/              # Application constants
-│   └── design-tokens.ts   # Design system tokens
-├── context/               # React context providers
-│   └── SidebarContext.tsx
-├── lib/                   # Utility libraries
-│   ├── auth.ts            # Authentication utilities
-│   ├── utils/             # Utility functions
-│   │   ├── cn.ts          # Class name utilities (Tailwind merge)
-│   │   └── index.ts       # Utils barrel export
-│   └── index.ts           # Lib barrel export
-├── types/                 # TypeScript type definitions
-│   ├── Transaction.ts     # Transaction-related types
-│   ├── common.ts          # Common utility types
-│   └── index.ts           # Types barrel export
-├── public/                # Static assets
-│   ├── icons/             # Icon assets
-│   └── images/            # Image assets
-├── scripts/               # Build and utility scripts
-│   ├── svgToComponent.js  # SVG to React component converter
-│   └── generate-component.js
-├── test/                 # Test utilities and helpers
-│   ├── test-utils.tsx
-│   └── component-helpers.ts
-└── stories/              # Storybook stories
+??? app/                      # Next.js App Router pages
+?   ??? account/             # User account pages
+?   ??? dashboard/           # Dashboard pages
+?   ??? lending/             # Lending & borrowing pages
+?   ??? layout.tsx           # Root layout
+??? components/              # React components
+?   ??? atoms/              # Atomic design: smallest components
+?   ??? molecules/          # Composite components
+?   ??? organisms/          # Complex components
+?   ??? features/           # Feature-specific components
+?   ?   ??? account/        # Account feature components
+?   ?   ??? dashboard/      # Dashboard feature components
+?   ?   ??? lending/        # Lending feature components
+?   ??? marketing/          # Marketing page components
+?   ??? shared/             # Shared components
+?       ??? ui/             # UI components (buttons, icons, etc.)
+?       ??? layout/         # Layout components (navbar, sidebar, etc.)
+?       ??? common/         # Common utility components
+??? constants/              # Application constants
+?   ??? design-tokens.ts   # Design system tokens
+??? context/               # React context providers
+?   ??? SidebarContext.tsx
+??? lib/                   # Utility libraries
+?   ??? auth.ts            # Authentication utilities
+?   ??? utils/             # Utility functions
+?   ?   ??? cn.ts          # Class name utilities (Tailwind merge)
+?   ?   ??? index.ts       # Utils barrel export
+?   ??? index.ts           # Lib barrel export
+??? types/                 # TypeScript type definitions
+?   ??? Transaction.ts     # Transaction-related types
+?   ??? common.ts          # Common utility types
+?   ??? index.ts           # Types barrel export
+??? public/                # Static assets
+?   ??? icons/             # Icon assets
+?   ??? images/            # Image assets
+??? scripts/               # Build and utility scripts
+?   ??? svgToComponent.js  # SVG to React component converter
+?   ??? generate-component.js
+??? test/                 # Test utilities and helpers
+?   ??? test-utils.tsx
+?   ??? component-helpers.ts
+??? stories/              # Storybook stories
 ```
 
-## 🎨 Component Development
+## ?? Component Development
 
 ### Generate New Components
 
@@ -248,33 +252,34 @@ npm run svg
 
 This will automatically convert SVGs to React components in `components/shared/ui/icons/`.
 
-## 🗄️ Backend & API
+## ??? Backend & API
 
 The server-side API surface is documented in two places:
 
-| Resource | Description |
-|---|---|
-| [`docs/backend-architecture.md`](docs/backend-architecture.md) | Architecture overview — lib/ modules, caching model, security, and how to add a new route |
-| [`openapi.yaml`](openapi.yaml) | OpenAPI 3.1 spec for all `app/api/*` routes, params, and response shapes |
+| Resource                                                       | Description                                                                               |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [`docs/backend-architecture.md`](docs/backend-architecture.md) | Architecture overview - lib/ modules, caching model, security, and how to add a new route |
+| [`openapi.yaml`](openapi.yaml)                                 | OpenAPI 3.1 spec for all `app/api/*` routes, params, and response shapes                  |
 
 ### Available API Routes
 
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| `GET` | `/api/health` | Public | Platform & Stellar network health |
-| `POST/GET/DELETE` | `/api/auth/session` | — | Session lifecycle |
-| `GET` | `/api/prices` | Public | Asset spot prices (cached 5 s) |
-| `GET` | `/api/markets` | Public | Per-asset supply/borrow APR & utilization (cached 30 s) |
-| `GET` | `/api/positions` | Optional | User lending/borrowing positions |
-| `GET/POST` | `/api/transactions` | Public | Transaction history and creation |
-| `GET` | `/api/transactions/export` | Public | Transactions CSV export |
-| `POST` | `/api/quote` | Public | Lending/borrowing quote calculation |
-| `GET` | `/api/notifications` | Required | List in-app notifications |
-| `PATCH` | `/api/notifications/:id` | Required | Mark notification as read |
+| Method            | Path                       | Auth     | Description                                             |
+| ----------------- | -------------------------- | -------- | ------------------------------------------------------- |
+| `GET`             | `/api/health`              | Public   | Platform & Stellar network health                       |
+| `POST/GET/DELETE` | `/api/auth/session`        | -        | Session lifecycle                                       |
+| `GET`             | `/api/prices`              | Public   | Asset spot prices (cached 5 s)                          |
+| `GET`             | `/api/markets`             | Public   | Per-asset supply/borrow APR & utilization (cached 30 s) |
+| `GET`             | `/api/positions`           | Optional | User lending/borrowing positions                        |
+| `GET/POST`        | `/api/transactions`        | Public   | Transaction history and creation                        |
+| `GET`             | `/api/transactions/export` | Public   | Transactions CSV export                                 |
+| `POST`            | `/api/quote`               | Public   | Lending/borrowing quote calculation                     |
+| `GET`             | `/api/notifications`       | Required | List in-app notifications                               |
+| `PATCH`           | `/api/notifications/:id`   | Required | Mark notification as read                               |
 
-## 🔗 Helpful Links
+## ?? Helpful Links
 
 ### Documentation
+
 - [Next.js Documentation](https://nextjs.org/docs) - Learn about Next.js features and API
 - [React Documentation](https://react.dev) - React library documentation
 - [TypeScript Documentation](https://www.typescriptlang.org/docs/) - TypeScript language reference
@@ -284,19 +289,22 @@ The server-side API surface is documented in two places:
 - [Idempotency contract and key lifetime](docs/idempotency.md) - API replay protection and cache retention guidance
 
 ### Development Tools
+
 - [Storybook](https://storybook.js.org/docs) - Component development environment
 - [Vitest](https://vitest.dev) - Fast unit test framework
 - [Playwright](https://playwright.dev) - End-to-end testing framework
 
 ### Design & Styling
+
 - [Framer Motion](https://www.framer.com/motion/) - Animation library
 - [Lucide Icons](https://lucide.dev) - Icon library
 
-## 🤝 Contributing
+## ?? Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for detailed guidelines.
 
 **Quick Start:**
+
 1. **Fork the repository** and create a feature branch
 2. **Follow the code style** - We use ESLint and Prettier (configured with Husky pre-commit hooks)
 3. **Write tests** for new features and bug fixes
@@ -312,13 +320,14 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 ### Commit Guidelines
 
 We use [Conventional Commits](https://www.conventionalcommits.org/). Examples:
+
 - `feat: add new lending form component`
 - `fix: resolve transaction status display issue`
 - `docs: update README with setup instructions`
 
 For more details, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## ⚙️ Background Workers & Job Queues
+## ?? Background Workers & Job Queues
 
 Stellarlend uses **BullMQ** (backed by Redis) to process long-running, asynchronous tasks outside the Next.js API request lifecycle. This guarantees that user-facing API routes remain responsive and non-blocking.
 
@@ -361,7 +370,7 @@ Jobs that exhaust retries are copied into dedicated dead-letter queues for inves
 
 Each dead-letter payload includes the original job id, input payload, error reason, and failure timestamp.
 
-## 🚢 Deployment
+## ?? Deployment
 
 ### Vercel (Recommended)
 
@@ -388,38 +397,39 @@ For more deployment options, see the [Next.js deployment documentation](https://
 
 Cron registration is protected by Postgres advisory-lock leader election so only one application replica schedules retention, snapshot, and indexer health-check jobs. See [docs/scheduler-leader-election.md](docs/scheduler-leader-election.md) and [docs/infrastructure/README.md](docs/infrastructure/README.md) for failover and recovery procedures.
 
-## 📝 Scripts Reference
+## ?? Scripts Reference
 
-| Command | Description |
-|---------|-------------|
-| `npm run dev` | Start development server |
-| `npm run build` | Build for production |
-| `npm start` | Start production server |
-| `npm run lint` | Run ESLint |
-| `npm test` | Run tests with Vitest |
-| `npm run storybook` | Start Storybook |
-| `npm run build-storybook` | Build Storybook for static hosting |
-| `npm run svg` | Convert SVG files to React components |
-| `npm run generate-component` | Generate new component scaffold |
+| Command                      | Description                           |
+| ---------------------------- | ------------------------------------- |
+| `npm run dev`                | Start development server              |
+| `npm run build`              | Build for production                  |
+| `npm start`                  | Start production server               |
+| `npm run lint`               | Run ESLint                            |
+| `npm test`                   | Run tests with Vitest                 |
+| `npm run storybook`          | Start Storybook                       |
+| `npm run build-storybook`    | Build Storybook for static hosting    |
+| `npm run svg`                | Convert SVG files to React components |
+| `npm run generate-component` | Generate new component scaffold       |
 
-## 🔒 Security
+## ?? Security
 
 - Never commit `.env.local` or any files containing secrets
 - Use environment variables for all sensitive configuration
 - Regularly update dependencies to patch security vulnerabilities
 - Review and audit smart contract interactions before production use
 
-## 📄 License
+## ?? License
 
 [Add your license information here]
 
-## 🙋 Support
+## ?? Support
 
 For questions, issues, or feature requests:
+
 - Open an issue on GitHub
 - Contact the development team
 - Check the documentation links above
 
 ---
 
-**Built with ❤️ for the Stellar ecosystem**
+**Built with ?? for the Stellar ecosystem**

--- a/app/lending/page.tsx
+++ b/app/lending/page.tsx
@@ -1,58 +1,121 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import dynamic from 'next/dynamic';
-import LendingForm from '@/components/features/lending/components/LendingForm';
-import { PageHeader } from '@/components/shared/common';
-import { Skeleton } from '@/components/shared/common/Skeleton';
+import { useState, useEffect } from "react";
+import dynamic from "next/dynamic";
+import LendingForm from "@/components/features/lending/components/LendingForm";
+import { PageHeader } from "@/components/shared/common";
+import { Skeleton } from "@/components/shared/common/Skeleton";
+import type { LendingActionType } from "@/lib/lending/types";
 
-const BorrowingForm = dynamic(() => import('@/components/features/lending/components/BorrowingForm'), {
-  loading: () => <div className="space-y-4 animate-pulse"><Skeleton className="h-64 w-full" /></div>,
-});
-const InterestCalculator = dynamic(() => import('@/components/features/lending/components/InterestCalculator'), {
-  loading: () => <div className="space-y-4 animate-pulse"><Skeleton className="h-64 w-full" /></div>,
-});
-const TransactionSummary = dynamic(() => import('@/components/features/lending/components/TransactionSummary'), {
-  loading: () => <div className="space-y-4 animate-pulse"><Skeleton className="h-40 w-full" /></div>,
-});
-const ConfirmModal = dynamic(() => import('@/components/features/lending/components/ConfirmModal'));
-import TabSelector from '@/components/features/lending/components/TabSelector';
+const BorrowingForm = dynamic(
+  () => import("@/components/features/lending/components/BorrowingForm"),
+  {
+    loading: () => (
+      <div className="space-y-4 animate-pulse">
+        <Skeleton className="h-64 w-full" />
+      </div>
+    ),
+  },
+);
+const RepayForm = dynamic(
+  () => import("@/components/features/lending/components/RepayForm"),
+  {
+    loading: () => (
+      <div className="space-y-4 animate-pulse">
+        <Skeleton className="h-64 w-full" />
+      </div>
+    ),
+  },
+);
+const InterestCalculator = dynamic(
+  () => import("@/components/features/lending/components/InterestCalculator"),
+  {
+    loading: () => (
+      <div className="space-y-4 animate-pulse">
+        <Skeleton className="h-64 w-full" />
+      </div>
+    ),
+  },
+);
+const TransactionSummary = dynamic(
+  () => import("@/components/features/lending/components/TransactionSummary"),
+  {
+    loading: () => (
+      <div className="space-y-4 animate-pulse">
+        <Skeleton className="h-40 w-full" />
+      </div>
+    ),
+  },
+);
+const ConfirmModal = dynamic(
+  () => import("@/components/features/lending/components/ConfirmModal"),
+);
+import TabSelector from "@/components/features/lending/components/TabSelector";
 
-export type { LendingData, CalculationResult } from '@/lib/lending/types';
-import type { LendingData, CalculationResult } from '@/lib/lending/types';
+export type { LendingData, CalculationResult } from "@/lib/lending/types";
+import type { LendingData, CalculationResult } from "@/lib/lending/types";
 
 export default function LendingPage() {
-  const [activeTab, setActiveTab] = useState<'lend' | 'borrow'>('lend');
+  const [activeTab, setActiveTab] = useState<LendingActionType>("lend");
   const [lendingData, setLendingData] = useState<LendingData>({
-    asset: 'XLM',
+    asset: "XLM",
     amount: 0,
     interestRate: 8.5,
   });
   const [borrowingData, setBorrowingData] = useState<LendingData>({
-    asset: 'XLM',
+    asset: "XLM",
     amount: 0,
     interestRate: 12.0,
     duration: 30,
-    collateral: 'XLM',
+    collateral: "XLM",
     collateralAmount: 0,
   });
-  const [calculationResult, setCalculationResult] = useState<CalculationResult | null>(null);
+  const [repayData, setRepayData] = useState<LendingData>({
+    asset: "XLM",
+    amount: 0,
+    interestRate: 12.0,
+    duration: 30,
+    collateral: "XLM",
+    collateralAmount: 5000,
+    positionId: "xlm-borrow-001",
+    outstandingDebt: 1500,
+    remainingDebt: 1500,
+    healthFactorBefore: 1.5,
+    healthFactorAfter: 1.5,
+  });
+  const [calculationResult, setCalculationResult] =
+    useState<CalculationResult | null>(null);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   // Hydrate default interest rates from the live /api/markets endpoint.
   // Falls back silently to the hardcoded values above if the fetch fails.
   useEffect(() => {
     const controller = new AbortController();
-    fetch('/api/markets?asset=XLM', { signal: controller.signal })
+    fetch("/api/markets?asset=XLM", { signal: controller.signal })
       .then((res) => (res.ok ? res.json() : null))
-      .then((data: { markets?: Array<{ asset: string; supplyApr: number; borrowApr: number }> } | null) => {
-        if (!data?.markets) return;
-        const xlm = data.markets.find((m) => m.asset === 'XLM');
-        if (!xlm) return;
-        setLendingData((prev) => ({ ...prev, interestRate: xlm.supplyApr }));
-        setBorrowingData((prev) => ({ ...prev, interestRate: xlm.borrowApr }));
-      })
-      .catch(() => { /* keep hardcoded fallback */ });
+      .then(
+        (
+          data: {
+            markets?: Array<{
+              asset: string;
+              supplyApr: number;
+              borrowApr: number;
+            }>;
+          } | null,
+        ) => {
+          if (!data?.markets) return;
+          const xlm = data.markets.find((m) => m.asset === "XLM");
+          if (!xlm) return;
+          setLendingData((prev) => ({ ...prev, interestRate: xlm.supplyApr }));
+          setBorrowingData((prev) => ({
+            ...prev,
+            interestRate: xlm.borrowApr,
+          }));
+        },
+      )
+      .catch(() => {
+        /* keep hardcoded fallback */
+      });
     return () => controller.abort();
   }, []);
 
@@ -66,13 +129,26 @@ export default function LendingPage() {
     setShowConfirmModal(true);
   };
 
-  const handleConfirm = async () => {
-    console.log('Submitting:', activeTab === 'lend' ? lendingData : borrowingData);
-    setShowConfirmModal(false);
-
+  const handleRepaySubmit = (
+    data: LendingData,
+    quote: CalculationResult | null,
+  ) => {
+    setRepayData(data);
+    setCalculationResult(quote);
+    setShowConfirmModal(true);
   };
 
-  const currentData = activeTab === 'lend' ? lendingData : borrowingData;
+  const handleConfirm = async () => {
+    console.log("Submitting:", currentData);
+    setShowConfirmModal(false);
+  };
+
+  const currentData =
+    activeTab === "lend"
+      ? lendingData
+      : activeTab === "borrow"
+        ? borrowingData
+        : repayData;
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-slate-50 px-4 py-6 sm:px-6 lg:px-8">
@@ -92,7 +168,7 @@ export default function LendingPage() {
             <PageHeader
               tone="light"
               title="Lending & Borrowing"
-              description="Earn interest by lending your assets or borrow against your collateral."
+              description="Earn interest, borrow against collateral, or repay open debt positions."
               className="mb-0"
             />
           </div>
@@ -104,31 +180,47 @@ export default function LendingPage() {
 
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
           <div className="lg:col-span-2">
-            {activeTab === 'lend' ? (
+            {activeTab === "lend" ? (
               <LendingForm
                 onSubmit={handleLendingSubmit}
                 initialData={lendingData}
               />
-            ) : (
+            ) : activeTab === "borrow" ? (
               <BorrowingForm
                 onSubmit={handleBorrowingSubmit}
                 initialData={borrowingData}
               />
+            ) : (
+              <RepayForm onSubmit={handleRepaySubmit} />
             )}
           </div>
 
           <div className="space-y-6">
-            <InterestCalculator
-              data={currentData}
-              type={activeTab}
-              onCalculate={setCalculationResult}
-            />
-            {calculationResult && (
-              <TransactionSummary
-                data={currentData}
-                calculation={calculationResult}
-                type={activeTab}
-              />
+            {activeTab === "repay" ? (
+              <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                <h2 className="mb-2 text-lg font-semibold text-gray-900">
+                  Repayment Status
+                </h2>
+                <p className="text-sm text-gray-600">
+                  Submit a repayment preview to open the confirmation step and
+                  review quote details before signing.
+                </p>
+              </div>
+            ) : (
+              <>
+                <InterestCalculator
+                  data={currentData}
+                  type={activeTab}
+                  onCalculate={setCalculationResult}
+                />
+                {calculationResult && (
+                  <TransactionSummary
+                    data={currentData}
+                    calculation={calculationResult}
+                    type={activeTab}
+                  />
+                )}
+              </>
             )}
           </div>
         </div>

--- a/components/features/lending/components/ConfirmModal.tsx
+++ b/components/features/lending/components/ConfirmModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { LendingData, CalculationResult } from "@/app/lending/page";
+import type { LendingActionType } from "@/lib/lending/types";
 import { cn } from "@/lib/utils/cn";
 
 interface ConfirmModalProps {
@@ -10,7 +11,7 @@ interface ConfirmModalProps {
   onConfirm: () => void;
   data: LendingData;
   calculation: CalculationResult | null;
-  type: "lend" | "borrow";
+  type: LendingActionType;
 }
 
 export default function ConfirmModal({
@@ -23,33 +24,44 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   const [isConfirming, setIsConfirming] = useState(false);
   const [hasAgreed, setHasAgreed] = useState(false);
-  const [submitStatus, setSubmitStatus] = useState<'idle' | 'success' | 'error'>('idle');
-  const [submitMessage, setSubmitMessage] = useState('');
+  const [submitStatus, setSubmitStatus] = useState<
+    "idle" | "success" | "error"
+  >("idle");
+  const [submitMessage, setSubmitMessage] = useState("");
 
   useEffect(() => {
     if (isOpen) {
-      setSubmitStatus('idle');
-      setSubmitMessage('');
+      setSubmitStatus("idle");
+      setSubmitMessage("");
       setHasAgreed(false);
     }
   }, [isOpen]);
 
   if (!isOpen) return null;
 
+  const actionLabel =
+    type === "lend" ? "Lending" : type === "borrow" ? "Borrowing" : "Repayment";
+  const amountLabel =
+    type === "lend"
+      ? "Amount to Lend"
+      : type === "borrow"
+        ? "Amount to Borrow"
+        : "Amount to Repay";
+
   const handleConfirm = async () => {
     if (!hasAgreed) return;
 
     setIsConfirming(true);
-    setSubmitStatus('idle');
-    setSubmitMessage('');
+    setSubmitStatus("idle");
+    setSubmitMessage("");
     try {
       await onConfirm();
-      setSubmitStatus('success');
-      setSubmitMessage('Transaction confirmed successfully!');
+      setSubmitStatus("success");
+      setSubmitMessage("Transaction confirmed successfully!");
       setTimeout(onClose, 2000);
     } catch (err) {
-      setSubmitStatus('error');
-      setSubmitMessage('Transaction failed. Please try again.');
+      setSubmitStatus("error");
+      setSubmitMessage("Transaction failed. Please try again.");
     } finally {
       setIsConfirming(false);
     }
@@ -76,7 +88,7 @@ export default function ConfirmModal({
           {/* Header */}
           <div className="flex items-center justify-between mb-6">
             <h3 className="text-lg font-semibold text-gray-900">
-              Confirm {type === "lend" ? "Lending" : "Borrowing"} Transaction
+              Confirm {actionLabel} Transaction
             </h3>
             <button
               onClick={onClose}
@@ -103,9 +115,9 @@ export default function ConfirmModal({
             <div
               className={cn(
                 "p-3 rounded-lg mb-4 text-sm font-medium",
-                submitStatus === 'success' 
-                  ? "bg-green-50 text-green-800 border border-green-200" 
-                  : "bg-red-50 text-red-800 border border-red-200"
+                submitStatus === "success"
+                  ? "bg-green-50 text-green-800 border border-green-200"
+                  : "bg-red-50 text-red-800 border border-red-200",
               )}
               role="alert"
               aria-live="polite"
@@ -136,7 +148,7 @@ export default function ConfirmModal({
                     type === "lend" ? "text-green-600" : "text-blue-600"
                   }`}
                 >
-                  {type === "lend" ? "Amount to Lend" : "Amount to Borrow"}
+                  {amountLabel}
                 </div>
               </div>
             </div>
@@ -150,14 +162,43 @@ export default function ConfirmModal({
                 </span>
               </div>
 
-              {type === "borrow" && data.duration && (
+              {(type === "borrow" || type === "repay") && data.duration && (
                 <div className="flex justify-between">
                   <span className="text-gray-600">Loan Duration</span>
                   <span className="font-medium">{data.duration} days</span>
                 </div>
               )}
 
-              {calculation && (
+              {type === "repay" && (
+                <>
+                  {data.positionId && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">Position</span>
+                      <span className="font-medium">{data.positionId}</span>
+                    </div>
+                  )}
+                  {typeof data.remainingDebt === "number" && (
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-medium">Remaining Debt</span>
+                      <span className="font-semibold text-gray-900">
+                        {formatCurrency(data.remainingDebt, data.asset)}
+                      </span>
+                    </div>
+                  )}
+                  {typeof data.healthFactorAfter === "number" && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">New Health Factor</span>
+                      <span className="font-medium text-green-600">
+                        {Number.isFinite(data.healthFactorAfter)
+                          ? data.healthFactorAfter.toFixed(2)
+                          : "Debt cleared"}
+                      </span>
+                    </div>
+                  )}
+                </>
+              )}
+
+              {calculation && type !== "repay" && (
                 <>
                   {type === "lend" ? (
                     <>
@@ -214,19 +255,23 @@ export default function ConfirmModal({
             </div>
 
             {/* Collateral Info for Borrowing */}
-            {type === "borrow" && data.collateral && data.collateralAmount && (
-              <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-                <h4 className="font-medium text-yellow-800 mb-2">
-                  Collateral Required
-                </h4>
-                <div className="flex justify-between text-sm">
-                  <span className="text-yellow-700">Asset & Amount</span>
-                  <span className="font-medium">
-                    {formatCurrency(data.collateralAmount, data.collateral)}
-                  </span>
+            {(type === "borrow" || type === "repay") &&
+              data.collateral &&
+              data.collateralAmount && (
+                <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+                  <h4 className="font-medium text-yellow-800 mb-2">
+                    {type === "repay"
+                      ? "Collateral Securing Position"
+                      : "Collateral Required"}
+                  </h4>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-yellow-700">Asset & Amount</span>
+                    <span className="font-medium">
+                      {formatCurrency(data.collateralAmount, data.collateral)}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
           </div>
 
           {/* Terms Agreement */}
@@ -271,7 +316,9 @@ export default function ConfirmModal({
                 hasAgreed && !isConfirming
                   ? type === "lend"
                     ? "bg-green-500 hover:bg-green-600"
-                    : "bg-blue-500 hover:bg-blue-600"
+                    : type === "repay"
+                      ? "bg-green-500 hover:bg-green-600"
+                      : "bg-blue-500 hover:bg-blue-600"
                   : "bg-gray-300 cursor-not-allowed"
               }`}
             >
@@ -299,7 +346,7 @@ export default function ConfirmModal({
                   Processing...
                 </div>
               ) : (
-                `Confirm ${type === "lend" ? "Lending" : "Borrowing"}`
+                `Confirm ${actionLabel}`
               )}
             </button>
           </div>

--- a/components/features/lending/components/RepayForm.test.tsx
+++ b/components/features/lending/components/RepayForm.test.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@/test/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import RepayForm, { BorrowPosition } from "./RepayForm";
+
+const positions: BorrowPosition[] = [
+  {
+    id: "loan-1",
+    asset: "XLM",
+    outstandingDebt: 1500,
+    interestRate: 12,
+    collateralAsset: "XLM",
+    collateralAmount: 5000,
+    healthFactor: 1.5,
+    duration: 30,
+  },
+  {
+    id: "loan-2",
+    asset: "USDC",
+    outstandingDebt: 900,
+    interestRate: 9,
+    collateralAsset: "ETH",
+    collateralAmount: 3000,
+    healthFactor: 2.1,
+    duration: 60,
+  },
+];
+
+const quoteResult = {
+  totalEarnings: 5,
+  dailyEarnings: 0.16,
+  totalRepayment: 505,
+  monthlyPayment: 505,
+};
+
+describe("RepayForm Component", () => {
+  const onSubmit = vi.fn();
+
+  beforeEach(() => {
+    onSubmit.mockReset();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ result: quoteResult }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the repayment workflow", () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    expect(screen.getByText(/Repay Borrowed Assets/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Borrow position/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Repayment amount/i)).toBeInTheDocument();
+  });
+
+  it("validates repayment amount is greater than zero", async () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByText(/Review Repayment/i));
+
+    expect(
+      await screen.findByText(/Enter a repayment amount greater than zero/i),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a clear error when there are no open positions", async () => {
+    render(<RepayForm positions={[]} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Repayment amount/i), {
+      target: { value: "100" },
+    });
+    fireEvent.click(screen.getByText(/Review Repayment/i));
+
+    expect(
+      await screen.findByText(/Please select an open borrow position/i),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("validates repayment does not exceed outstanding debt", async () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Repayment amount/i), {
+      target: { value: "1500.01" },
+    });
+    fireEvent.click(screen.getByText(/Review Repayment/i));
+
+    expect(
+      await screen.findByText(/Repayment cannot exceed 1,500.00 XLM/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows partial repayment preview with updated debt and health factor", () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Repayment amount/i), {
+      target: { value: "500" },
+    });
+
+    expect(screen.getByText("1,000.00 XLM")).toBeInTheDocument();
+    expect(screen.getByText(/2.25 \(Healthy\)/i)).toBeInTheDocument();
+  });
+
+  it("shows full repayment preview as debt cleared", () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByText("MAX"));
+
+    expect(screen.getByText("0.00 XLM")).toBeInTheDocument();
+    expect(screen.getAllByText(/Debt cleared/i).length).toBeGreaterThan(0);
+  });
+
+  it("submits quote preview and repayment data", async () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Repayment amount/i), {
+      target: { value: "500" },
+    });
+    fireEvent.click(screen.getByText(/Review Repayment/i));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/quote",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: 500,
+          asset: "XLM",
+          positionId: "loan-1",
+          remainingDebt: 1000,
+          healthFactorAfter: 2.25,
+        }),
+        quoteResult,
+      );
+    });
+    expect(screen.getByText(/Repayment preview ready/i)).toBeInTheDocument();
+  });
+
+  it("shows loading and error states when quote preview fails", async () => {
+    let rejectPreview: () => void = () => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectPreview = () => reject(new Error("network"));
+          }),
+      ),
+    );
+
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Repayment amount/i), {
+      target: { value: "250" },
+    });
+    fireEvent.click(screen.getByText(/Review Repayment/i));
+
+    expect(
+      await screen.findByText(/Preparing repayment preview/i),
+    ).toBeInTheDocument();
+
+    rejectPreview();
+
+    expect(
+      await screen.findByText(/Unable to prepare repayment preview/i),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/components/features/lending/components/RepayForm.tsx
+++ b/components/features/lending/components/RepayForm.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { CalculationResult, LendingData } from "@/lib/lending/types";
+import { Input } from "@/components/shared/ui/Input";
+import Button from "@/components/shared/ui/Button";
+import PositionSummary from "@/components/features/dashboard/components/PositionSummary";
+import { cn } from "@/lib/utils/cn";
+
+export interface BorrowPosition {
+  id: string;
+  asset: string;
+  outstandingDebt: number;
+  interestRate: number;
+  collateralAsset: string;
+  collateralAmount: number;
+  healthFactor: number;
+  duration?: number;
+}
+
+interface RepayFormProps {
+  onSubmit: (data: LendingData, quote: CalculationResult | null) => void;
+  positions?: BorrowPosition[];
+  initialPositionId?: string;
+}
+
+const DEFAULT_POSITIONS: BorrowPosition[] = [
+  {
+    id: "xlm-borrow-001",
+    asset: "XLM",
+    outstandingDebt: 1500,
+    interestRate: 12,
+    collateralAsset: "XLM",
+    collateralAmount: 5000,
+    healthFactor: 1.5,
+    duration: 30,
+  },
+  {
+    id: "usdc-borrow-002",
+    asset: "USDC",
+    outstandingDebt: 2200,
+    interestRate: 10.5,
+    collateralAsset: "ETH",
+    collateralAmount: 6200,
+    healthFactor: 1.18,
+    duration: 60,
+  },
+];
+
+const formatAmount = (amount: number, asset: string) =>
+  `${amount.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })} ${asset}`;
+
+const getHealthLabel = (healthFactor: number) => {
+  if (!Number.isFinite(healthFactor)) return "Debt cleared";
+  if (healthFactor >= 2) return "Healthy";
+  if (healthFactor >= 1) return "At Risk";
+  return "Critical";
+};
+
+const computeHealthAfterRepayment = (
+  currentHealthFactor: number,
+  outstandingDebt: number,
+  repaymentAmount: number,
+) => {
+  const remainingDebt = Math.max(outstandingDebt - repaymentAmount, 0);
+
+  if (remainingDebt === 0) return Infinity;
+
+  return (currentHealthFactor * outstandingDebt) / remainingDebt;
+};
+
+export default function RepayForm({
+  onSubmit,
+  positions = DEFAULT_POSITIONS,
+  initialPositionId,
+}: RepayFormProps) {
+  const [selectedPositionId, setSelectedPositionId] = useState(
+    initialPositionId ?? positions[0]?.id ?? "",
+  );
+  const [amount, setAmount] = useState(0);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitStatus, setSubmitStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
+  const [submitMessage, setSubmitMessage] = useState("");
+
+  const selectedPosition = positions.find(
+    (position) => position.id === selectedPositionId,
+  );
+
+  const preview = useMemo(() => {
+    if (!selectedPosition) {
+      return {
+        remainingDebt: 0,
+        healthFactorAfter: 0,
+        label: "Unavailable",
+      };
+    }
+
+    const remainingDebt = Math.max(
+      selectedPosition.outstandingDebt - amount,
+      0,
+    );
+    const healthFactorAfter = computeHealthAfterRepayment(
+      selectedPosition.healthFactor,
+      selectedPosition.outstandingDebt,
+      amount,
+    );
+
+    return {
+      remainingDebt,
+      healthFactorAfter,
+      label: getHealthLabel(healthFactorAfter),
+    };
+  }, [amount, selectedPosition]);
+
+  const positionSummaryData = selectedPosition
+    ? {
+        suppliedFunds: `$${selectedPosition.collateralAmount.toLocaleString()} ${selectedPosition.collateralAsset}`,
+        borrowedAmount: `$${preview.remainingDebt.toLocaleString()} ${selectedPosition.asset}`,
+        healthFactor: Number.isFinite(preview.healthFactorAfter)
+          ? preview.healthFactorAfter
+          : 99,
+      }
+    : null;
+
+  const validate = () => {
+    const nextErrors: Record<string, string> = {};
+
+    if (!selectedPosition) {
+      nextErrors.position = "Please select an open borrow position";
+    }
+
+    if (!amount || amount <= 0) {
+      nextErrors.amount = "Enter a repayment amount greater than zero";
+    } else if (selectedPosition && amount > selectedPosition.outstandingDebt) {
+      nextErrors.amount = `Repayment cannot exceed ${formatAmount(
+        selectedPosition.outstandingDebt,
+        selectedPosition.asset,
+      )}`;
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handlePositionChange = (positionId: string) => {
+    const nextPosition = positions.find(
+      (position) => position.id === positionId,
+    );
+    setSelectedPositionId(positionId);
+    setAmount(0);
+    setErrors({});
+    setSubmitStatus("idle");
+    setSubmitMessage(
+      nextPosition ? `Selected ${nextPosition.asset} borrow position.` : "",
+    );
+  };
+
+  const handleMaxRepayment = () => {
+    if (!selectedPosition) return;
+    setAmount(selectedPosition.outstandingDebt);
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next.amount;
+      return next;
+    });
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setSubmitStatus("idle");
+    setSubmitMessage("");
+
+    if (!validate() || !selectedPosition) {
+      setSubmitStatus("error");
+      setSubmitMessage("Please fix the errors in the form before continuing.");
+      return;
+    }
+
+    setSubmitStatus("loading");
+    setSubmitMessage("Preparing repayment preview...");
+
+    try {
+      const response = await fetch("/api/quote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "borrow",
+          data: {
+            asset: selectedPosition.asset,
+            amount,
+            interestRate: selectedPosition.interestRate,
+            duration: selectedPosition.duration ?? 30,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Quote preview failed");
+      }
+
+      const payload = (await response.json()) as {
+        result?: CalculationResult;
+      };
+
+      const data: LendingData = {
+        asset: selectedPosition.asset,
+        amount,
+        interestRate: selectedPosition.interestRate,
+        duration: selectedPosition.duration,
+        collateral: selectedPosition.collateralAsset,
+        collateralAmount: selectedPosition.collateralAmount,
+        positionId: selectedPosition.id,
+        outstandingDebt: selectedPosition.outstandingDebt,
+        remainingDebt: preview.remainingDebt,
+        healthFactorBefore: selectedPosition.healthFactor,
+        healthFactorAfter: preview.healthFactorAfter,
+      };
+
+      setSubmitStatus("success");
+      setSubmitMessage("Repayment preview ready.");
+      onSubmit(data, payload.result ?? null);
+    } catch {
+      setSubmitStatus("error");
+      setSubmitMessage(
+        "Unable to prepare repayment preview. Please try again.",
+      );
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          Repay Borrowed Assets
+        </h2>
+        <p className="text-gray-600 text-sm">
+          Choose an open borrow position and preview how repayment changes debt
+          and account health.
+        </p>
+      </div>
+
+      {submitMessage && (
+        <div
+          className={cn(
+            "p-4 rounded-xl mb-6 text-sm font-medium",
+            submitStatus === "success"
+              ? "bg-green-50 text-green-800 border border-green-200"
+              : submitStatus === "loading"
+                ? "bg-blue-50 text-blue-800 border border-blue-200"
+                : "bg-red-50 text-red-800 border border-red-200",
+          )}
+          role="alert"
+          aria-live="polite"
+        >
+          {submitMessage}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-8">
+        <div>
+          <label
+            htmlFor="repay-position"
+            className="block text-sm font-medium text-gray-700 mb-3"
+          >
+            Borrow position
+          </label>
+          <select
+            id="repay-position"
+            value={selectedPositionId}
+            onChange={(event) => handlePositionChange(event.target.value)}
+            className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 outline-none transition-all focus:border-[#2600FF] focus:ring-1 focus:ring-[#2600FF]"
+            aria-invalid={Boolean(errors.position)}
+            aria-describedby={
+              errors.position ? "repay-position-error" : undefined
+            }
+          >
+            {positions.map((position) => (
+              <option key={position.id} value={position.id}>
+                {position.asset} debt -{" "}
+                {formatAmount(position.outstandingDebt, position.asset)}
+              </option>
+            ))}
+          </select>
+          {errors.position && (
+            <p
+              id="repay-position-error"
+              className="text-xs text-red-500 font-medium mt-2"
+              role="alert"
+            >
+              {errors.position}
+            </p>
+          )}
+        </div>
+
+        <div className="relative">
+          <Input
+            id="repay-amount"
+            label="Repayment amount"
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder="0.00"
+            value={amount || ""}
+            error={errors.amount}
+            helperText={
+              selectedPosition
+                ? `Outstanding: ${formatAmount(
+                    selectedPosition.outstandingDebt,
+                    selectedPosition.asset,
+                  )}`
+                : undefined
+            }
+            onChange={(event) => {
+              setAmount(Number.parseFloat(event.target.value) || 0);
+              if (errors.amount) {
+                setErrors((prev) => {
+                  const next = { ...prev };
+                  delete next.amount;
+                  return next;
+                });
+              }
+            }}
+          />
+          <button
+            type="button"
+            onClick={handleMaxRepayment}
+            className="absolute right-3 top-8 rounded bg-green-50 px-2 py-1 text-xs font-bold text-green-600 transition-colors hover:text-green-700"
+          >
+            MAX
+          </button>
+        </div>
+
+        {selectedPosition && (
+          <div className="space-y-5">
+            <div className="rounded-xl border border-blue-100 bg-blue-50 p-5">
+              <h3 className="text-xs font-bold text-blue-900 mb-3 uppercase tracking-wider">
+                Repayment Preview
+              </h3>
+              <div className="space-y-2.5 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-blue-700">Remaining debt</span>
+                  <span className="font-semibold text-gray-900">
+                    {formatAmount(
+                      preview.remainingDebt,
+                      selectedPosition.asset,
+                    )}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-blue-700">Health factor</span>
+                  <span className="font-semibold text-gray-900">
+                    {Number.isFinite(preview.healthFactorAfter)
+                      ? preview.healthFactorAfter.toFixed(2)
+                      : "Debt cleared"}{" "}
+                    ({preview.label})
+                  </span>
+                </div>
+                <div className="flex justify-between border-t border-blue-200 pt-2.5">
+                  <span className="text-blue-700">Collateral</span>
+                  <span className="font-semibold text-gray-900">
+                    {formatAmount(
+                      selectedPosition.collateralAmount,
+                      selectedPosition.collateralAsset,
+                    )}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <PositionSummary data={positionSummaryData} />
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          variant="primary"
+          size="lg"
+          fullWidth
+          isLoading={submitStatus === "loading"}
+        >
+          Review Repayment
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/components/features/lending/components/TabSelector.tsx
+++ b/components/features/lending/components/TabSelector.tsx
@@ -1,31 +1,36 @@
+import type { LendingActionType } from "@/lib/lending/types";
+
 interface TabSelectorProps {
-    activeTab: 'lend' | 'borrow';
-    onTabChange: (tab: 'lend' | 'borrow') => void;
-  }
-  
-  export default function TabSelector({ activeTab, onTabChange }: TabSelectorProps) {
-    return (
-      <div className="flex bg-white rounded-lg p-1 shadow-sm border border-gray-200">
+  activeTab: LendingActionType;
+  onTabChange: (tab: LendingActionType) => void;
+}
+
+const TABS: Array<{ value: LendingActionType; label: string }> = [
+  { value: "lend", label: "Lend Assets" },
+  { value: "borrow", label: "Borrow Assets" },
+  { value: "repay", label: "Repay Loan" },
+];
+
+export default function TabSelector({
+  activeTab,
+  onTabChange,
+}: TabSelectorProps) {
+  return (
+    <div className="flex bg-white rounded-lg p-1 shadow-sm border border-gray-200">
+      {TABS.map((tab) => (
         <button
-          onClick={() => onTabChange('lend')}
-          className={`flex-1 px-6 py-3 rounded-md text-sm font-medium transition-all duration-200 ${
-            activeTab === 'lend'
-              ? 'bg-green-500 text-white shadow-sm'
-              : 'text-gray-600 hover:text-gray-900'
+          key={tab.value}
+          type="button"
+          onClick={() => onTabChange(tab.value)}
+          className={`flex-1 px-4 py-3 rounded-md text-sm font-medium transition-all duration-200 ${
+            activeTab === tab.value
+              ? "bg-green-500 text-white shadow-sm"
+              : "text-gray-600 hover:text-gray-900"
           }`}
         >
-          Lend Assets
+          {tab.label}
         </button>
-        <button
-          onClick={() => onTabChange('borrow')}
-          className={`flex-1 px-6 py-3 rounded-md text-sm font-medium transition-all duration-200 ${
-            activeTab === 'borrow'
-              ? 'bg-green-500 text-white shadow-sm'
-              : 'text-gray-600 hover:text-gray-900'
-          }`}
-        >
-          Borrow Assets
-        </button>
-      </div>
-    );
-  }
+      ))}
+    </div>
+  );
+}

--- a/components/features/lending/components/index.ts
+++ b/components/features/lending/components/index.ts
@@ -1,6 +1,7 @@
-export { default as LendingForm } from './LendingForm';
-export { default as BorrowingForm } from './BorrowingForm';
-export { default as InterestCalculator } from './InterestCalculator';
-export { default as TransactionSummary } from './TransactionSummary';
-export { default as ConfirmModal } from './ConfirmModal';
-export { default as TabSelector } from './TabSelector'; 
+export { default as LendingForm } from "./LendingForm";
+export { default as BorrowingForm } from "./BorrowingForm";
+export { default as InterestCalculator } from "./InterestCalculator";
+export { default as TransactionSummary } from "./TransactionSummary";
+export { default as ConfirmModal } from "./ConfirmModal";
+export { default as RepayForm } from "./RepayForm";
+export { default as TabSelector } from "./TabSelector";

--- a/docs/REPAY_FLOW.md
+++ b/docs/REPAY_FLOW.md
@@ -1,0 +1,81 @@
+# Repay Flow
+
+This guide documents the borrower repayment path added to the lending page.
+
+## Primary Surfaces
+
+The repayment flow is centered on these files:
+
+- `app/lending/page.tsx`
+- `components/features/lending/components/TabSelector.tsx`
+- `components/features/lending/components/RepayForm.tsx`
+- `components/features/lending/components/ConfirmModal.tsx`
+- `components/features/dashboard/components/PositionSummary.tsx`
+
+`TabSelector` exposes the `repay` tab alongside `lend` and `borrow`. `RepayForm` owns repayment-specific field state, validation, preview calculation, and `/api/quote` preview loading. `app/lending/page.tsx` stores the validated repayment draft and opens `ConfirmModal` for final review.
+
+## User Flow
+
+1. The user opens `/lending` and selects the Repay Loan tab.
+2. The user selects an open borrow position.
+3. The user enters a repayment amount.
+4. The form validates that `0 < amount <= outstandingDebt`.
+5. The form previews remaining debt and the post-repayment health factor.
+6. The form requests `/api/quote` using the existing borrow quote path for repayment cost preview context.
+7. The page opens `ConfirmModal` with the repayment amount, remaining debt, collateral, and updated health factor.
+8. The user confirms before the transaction build/submit layer is invoked.
+
+## Validation Rules
+
+Repayment validation happens in `RepayForm` before any quote request:
+
+- A borrow position must be selected.
+- The repayment amount must be greater than zero.
+- The repayment amount must not exceed the selected position's outstanding debt.
+- Field-level errors and a summary alert are rendered with accessible labels and live regions.
+
+## Health Factor Preview
+
+The repayment preview reuses the same threshold model as `PositionSummary`:
+
+| Health Factor        | Status   |
+| -------------------- | -------- |
+| `>= 2.0`             | Healthy  |
+| `>= 1.0` and `< 2.0` | At Risk  |
+| `< 1.0`              | Critical |
+
+For partial repayments, `RepayForm` keeps collateral fixed and recalculates the post-repayment health factor by reducing the debt denominator. Full repayment is displayed as debt cleared.
+
+## Worked Example
+
+A borrower has an XLM loan with:
+
+- Outstanding debt: `1,500 XLM`
+- Collateral: `5,000 XLM`
+- Current health factor: `1.50`
+
+If the borrower repays `500 XLM`, the live preview shows:
+
+- Remaining debt: `1,000 XLM`
+- New health factor: `2.25`
+- Status: `Healthy`
+
+If the borrower repays the full `1,500 XLM`, the preview shows `0 XLM` remaining debt and `Debt cleared` for the health factor state.
+
+## Tests
+
+`components/features/lending/components/RepayForm.test.tsx` covers:
+
+- Required repayment amount validation.
+- No open positions.
+- Overpayment validation.
+- Partial repayment preview.
+- Full repayment preview.
+- Quote submission and callback payload.
+- Loading and error states when quote preview fails.
+
+Run the focused suite with:
+
+```bash
+npm test -- components/features/lending/components/RepayForm.test.tsx
+```

--- a/lib/lending/types.ts
+++ b/lib/lending/types.ts
@@ -1,3 +1,5 @@
+export type LendingActionType = "lend" | "borrow" | "repay";
+
 export interface LendingData {
   asset: string;
   amount: number;
@@ -5,6 +7,11 @@ export interface LendingData {
   duration?: number;
   collateral?: string;
   collateralAmount?: number;
+  positionId?: string;
+  outstandingDebt?: number;
+  remainingDebt?: number;
+  healthFactorBefore?: number;
+  healthFactorAfter?: number;
 }
 
 export interface CalculationResult {


### PR DESCRIPTION
Closes #350.

## Summary
- adds a Repay tab and routes it through the lending page
- adds `RepayForm` with open-position selection, repayment validation, live remaining-debt and health-factor preview, and `/api/quote` borrow preview submission
- extends `ConfirmModal` for repayment confirmation details
- adds focused RepayForm tests and `docs/REPAY_FLOW.md`, linked from README

## Verification
- `npx --yes prettier@3.6.2 --check app/lending/page.tsx components/features/lending/components/ConfirmModal.tsx components/features/lending/components/RepayForm.tsx components/features/lending/components/RepayForm.test.tsx components/features/lending/components/TabSelector.tsx components/features/lending/components/index.ts lib/lending/types.ts docs/REPAY_FLOW.md README.md` passed
- `npm ci` could not run locally because npm rejected the repository `package-lock.json` despite lockfileVersion 3
- `npm install --package-lock=false --ignore-scripts --no-audit --no-fund` timed out before creating node_modules
- `npx --yes vitest@3.2.4 run components/features/lending/components/RepayForm.test.tsx --environment jsdom` could not start because local dependencies were unavailable and `vitest.config.ts` could not resolve `vitest/config`