### PR TITLE
dixes

### DIFF
--- a/app/lending/page.tsx
+++ b/app/lending/page.tsx
@@ -1,49 +1,74 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import LendingForm from '@/components/features/lending/components/LendingForm';
-import BorrowingForm from '@/components/features/lending/components/BorrowingForm';
-import InterestCalculator from '@/components/features/lending/components/InterestCalculator';
-import TransactionSummary from '@/components/features/lending/components/TransactionSummary';
-import ConfirmModal from '@/components/features/lending/components/ConfirmModal';
-import TabSelector from '@/components/features/lending/components/TabSelector';
-import { PageHeader } from '@/components/shared/common';
+import { useState, useEffect } from "react";
+import useTxStatus from "@/lib/tx/useTxStatus";
+import { Toast } from "@/components/shared/common";
+import LendingForm from "@/components/features/lending/components/LendingForm";
+import BorrowingForm from "@/components/features/lending/components/BorrowingForm";
+import InterestCalculator from "@/components/features/lending/components/InterestCalculator";
+import TransactionSummary from "@/components/features/lending/components/TransactionSummary";
+import ConfirmModal from "@/components/features/lending/components/ConfirmModal";
+import TabSelector from "@/components/features/lending/components/TabSelector";
+import { PageHeader } from "@/components/shared/common";
 
-export type { LendingData, CalculationResult } from '@/lib/lending/types';
-import type { LendingData, CalculationResult } from '@/lib/lending/types';
+export type { LendingData, CalculationResult } from "@/lib/lending/types";
+import type { LendingData, CalculationResult } from "@/lib/lending/types";
 
 export default function LendingPage() {
-  const [activeTab, setActiveTab] = useState<'lend' | 'borrow'>('lend');
+  const [activeTab, setActiveTab] = useState<"lend" | "borrow">("lend");
   const [lendingData, setLendingData] = useState<LendingData>({
-    asset: 'XLM',
+    asset: "XLM",
     amount: 0,
     interestRate: 8.5,
   });
   const [borrowingData, setBorrowingData] = useState<LendingData>({
-    asset: 'XLM',
+    asset: "XLM",
     amount: 0,
     interestRate: 12.0,
     duration: 30,
-    collateral: 'XLM',
+    collateral: "XLM",
     collateralAmount: 0,
   });
-  const [calculationResult, setCalculationResult] = useState<CalculationResult | null>(null);
+  const [calculationResult, setCalculationResult] =
+    useState<CalculationResult | null>(null);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    variant: "processing" | "success" | "error" | "info";
+    title?: string;
+    description?: string;
+  } | null>(null);
+  const txStatus = useTxStatus(txHash);
 
   // Hydrate default interest rates from the live /api/markets endpoint.
   // Falls back silently to the hardcoded values above if the fetch fails.
   useEffect(() => {
     const controller = new AbortController();
-    fetch('/api/markets?asset=XLM', { signal: controller.signal })
+    fetch("/api/markets?asset=XLM", { signal: controller.signal })
       .then((res) => (res.ok ? res.json() : null))
-      .then((data: { markets?: Array<{ asset: string; supplyApr: number; borrowApr: number }> } | null) => {
-        if (!data?.markets) return;
-        const xlm = data.markets.find((m) => m.asset === 'XLM');
-        if (!xlm) return;
-        setLendingData((prev) => ({ ...prev, interestRate: xlm.supplyApr }));
-        setBorrowingData((prev) => ({ ...prev, interestRate: xlm.borrowApr }));
-      })
-      .catch(() => { /* keep hardcoded fallback */ });
+      .then(
+        (
+          data: {
+            markets?: Array<{
+              asset: string;
+              supplyApr: number;
+              borrowApr: number;
+            }>;
+          } | null,
+        ) => {
+          if (!data?.markets) return;
+          const xlm = data.markets.find((m) => m.asset === "XLM");
+          if (!xlm) return;
+          setLendingData((prev) => ({ ...prev, interestRate: xlm.supplyApr }));
+          setBorrowingData((prev) => ({
+            ...prev,
+            interestRate: xlm.borrowApr,
+          }));
+        },
+      )
+      .catch(() => {
+        /* keep hardcoded fallback */
+      });
     return () => controller.abort();
   }, []);
 
@@ -58,12 +83,87 @@ export default function LendingPage() {
   };
 
   const handleConfirm = async () => {
-    console.log('Submitting:', activeTab === 'lend' ? lendingData : borrowingData);
     setShowConfirmModal(false);
+    const payload = {
+      signedEnvelopeXdr: JSON.stringify({
+        action: activeTab,
+        data: activeTab === "lend" ? lendingData : borrowingData,
+      }),
+    };
+    try {
+      const res = await fetch("/api/tx/submit", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
 
+      if (res.status === 429) {
+        const json = await res.json().catch(() => ({}));
+        setToast({
+          variant: "error",
+          title: "Rate limited",
+          description:
+            json?.error?.message || "Too many requests. Try again later.",
+        });
+        return;
+      }
+
+      const json = await res.json();
+      if (res.ok && json?.status === "submitted" && json?.hash) {
+        setTxHash(json.hash);
+        setToast({
+          variant: "processing",
+          title: "Transaction submitted",
+          description: "Waiting for on-chain settlement...",
+        });
+      } else {
+        setToast({
+          variant: "error",
+          title: "Submission failed",
+          description: json?.error?.message || "Unable to submit transaction",
+        });
+      }
+    } catch (err) {
+      setToast({
+        variant: "error",
+        title: "Submission error",
+        description: String(err),
+      });
+    }
   };
 
-  const currentData = activeTab === 'lend' ? lendingData : borrowingData;
+  useEffect(() => {
+    if (!txStatus) return;
+    if (txStatus.state === "processing") {
+      setToast({
+        variant: "processing",
+        title: "Processing",
+        description: "Transaction is being processed on-chain",
+      });
+    } else if (txStatus.state === "completed") {
+      setToast({
+        variant: "success",
+        title: "Completed",
+        description: "Transaction settled on-chain",
+      });
+      setTimeout(() => setTxHash(null), 2000);
+    } else if (txStatus.state === "failed") {
+      setToast({
+        variant: "error",
+        title: "Failed",
+        description: "Transaction failed on-chain",
+      });
+      setTimeout(() => setTxHash(null), 2000);
+    } else if (txStatus.state === "rate_limited") {
+      setToast({
+        variant: "error",
+        title: "Rate limited",
+        description: `Rate limited by relay. Retry after ${txStatus.retryAfterSeconds || "some"}s`,
+      });
+    }
+  }, [txStatus]);
+
+  const currentData = activeTab === "lend" ? lendingData : borrowingData;
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-slate-50 px-4 py-6 sm:px-6 lg:px-8">
@@ -95,7 +195,7 @@ export default function LendingPage() {
 
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
           <div className="lg:col-span-2">
-            {activeTab === 'lend' ? (
+            {activeTab === "lend" ? (
               <LendingForm
                 onSubmit={handleLendingSubmit}
                 initialData={lendingData}
@@ -132,6 +232,13 @@ export default function LendingPage() {
           calculation={calculationResult}
           type={activeTab}
         />
+        {toast && (
+          <Toast
+            variant={toast.variant}
+            title={toast.title}
+            description={toast.description}
+          />
+        )}
       </div>
     </div>
   );

--- a/components/shared/common/Toast.test.tsx
+++ b/components/shared/common/Toast.test.tsx
@@ -1,0 +1,13 @@
+import { render } from "@testing-library/react";
+import Toast from "./Toast";
+import { describe, it, expect } from "vitest";
+
+describe("Toast", () => {
+  it("renders title and description", () => {
+    const { getByText } = render(
+      <Toast title="Hi" description="there" variant="success" />,
+    );
+    expect(getByText("Hi")).toBeTruthy();
+    expect(getByText("there")).toBeTruthy();
+  });
+});

--- a/components/shared/common/Toast.tsx
+++ b/components/shared/common/Toast.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+
+export type ToastVariant = "processing" | "success" | "error" | "info";
+
+interface ToastProps {
+  id?: string;
+  title?: string;
+  description?: string;
+  variant?: ToastVariant;
+}
+
+export default function Toast({
+  title,
+  description,
+  variant = "info",
+}: ToastProps) {
+  const variantClasses =
+    variant === "success"
+      ? "bg-green-50 text-green-800 border border-green-200"
+      : variant === "error"
+        ? "bg-red-50 text-red-800 border border-red-200"
+        : variant === "processing"
+          ? "bg-yellow-50 text-yellow-800 border border-yellow-200"
+          : "bg-blue-50 text-blue-800 border border-blue-200";
+
+  return (
+    <div
+      className={`fixed right-4 top-6 z-50 max-w-sm p-3 rounded-lg shadow-lg ${variantClasses}`}
+      role="status"
+      aria-live="polite"
+    >
+      {title && <div className="font-medium mb-1">{title}</div>}
+      {description && <div className="text-sm">{description}</div>}
+    </div>
+  );
+}

--- a/components/shared/common/index.ts
+++ b/components/shared/common/index.ts
@@ -7,3 +7,5 @@ export { PageHeader } from './PageHeader';
 export { AlertBanner } from './AlertBanner';
 export type { PageHeaderProps, PageHeaderTone } from './PageHeader';
 export type { AlertBannerSeverity, AlertBannerProps } from './AlertBanner';
+export { default as Toast } from './Toast';
+export type { ToastVariant } from './Toast';

--- a/docs/TX_STATUS_TRACKING.md
+++ b/docs/TX_STATUS_TRACKING.md
@@ -1,0 +1,9 @@
+# Tx status tracking
+
+This document describes the client-side polling lifecycle for transaction settlement used by `useTxStatus`.
+
+- After the app receives a `{ status: 'submitted', hash }` response from `POST /api/tx/submit`, the client calls `useTxStatus(hash)`.
+- `useTxStatus` will poll `GET /api/tx/status/[hash]` with exponential backoff starting at 1s, doubling up to 30s.
+- Terminal API statuses: `SUCCESS` -> considered completed; `FAILED` and `NOT_FOUND` -> considered failed. The hook stops polling when a terminal status is reached.
+- If the status endpoint returns `429`, the hook stops and surfaces a `rate_limited` state containing `Retry-After` when present.
+- The hook cleans up on unmount and when the hash is cleared.

--- a/lib/tx/useTxStatus.test.ts
+++ b/lib/tx/useTxStatus.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useTxStatus from './useTxStatus';
+
+vi.useFakeTimers();
+
+describe('useTxStatus', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it('resolves to completed when API returns SUCCESS', async () => {
+    const mock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ status: 'SUCCESS', hash: 'h' }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    vi.stubGlobal('fetch', mock as any);
+
+    const { result, waitForNextUpdate } = renderHook(() => useTxStatus('h'));
+
+    // initial processing
+    expect(result.current).toEqual({ state: 'processing' });
+
+    // allow promise microtasks
+    await Promise.resolve();
+    // since hook sets completed, await next tick
+    await waitForNextUpdate();
+    expect(result.current?.state).toBe('completed');
+  });
+
+  it('stops and returns rate_limited on 429', async () => {
+    const mock = vi.fn().mockResolvedValue(new Response('rate', { status: 429, headers: { 'Retry-After': '5' } }));
+    vi.stubGlobal('fetch', mock as any);
+
+    const { result, waitForNextUpdate } = renderHook(() => useTxStatus('r'));
+    await Promise.resolve();
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({ state: 'rate_limited', retryAfterSeconds: 5 });
+  });
+});

--- a/lib/tx/useTxStatus.ts
+++ b/lib/tx/useTxStatus.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export type TxStatus =
+  | { state: "processing" }
+  | { state: "completed"; result: any }
+  | { state: "failed"; error?: any }
+  | { state: "rate_limited"; retryAfterSeconds?: number };
+
+export default function useTxStatus(hash: string | null) {
+  const [status, setStatus] = useState<TxStatus | null>(null);
+  const mounted = useRef(true);
+  const abortCtrl = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      abortCtrl.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!hash) return;
+
+    let attempts = 0;
+    let delay = 1000; // 1s
+    let stopped = false;
+
+    const poll = async () => {
+      if (!mounted.current || stopped) return;
+      attempts += 1;
+      abortCtrl.current = new AbortController();
+      try {
+        setStatus({ state: "processing" });
+        const res = await fetch(`/api/tx/status/${hash}`, { signal: abortCtrl.current.signal });
+
+        if (res.status === 429) {
+          const retry = res.headers.get("Retry-After");
+          const retryAfterSeconds = retry ? Number(retry) : undefined;
+          setStatus({ state: "rate_limited", retryAfterSeconds });
+          stopped = true;
+          return;
+        }
+
+        const json = await res.json();
+        const apiStatus = (json && json.status) || null;
+
+        if (apiStatus === "SUCCESS") {
+          setStatus({ state: "completed", result: json });
+          stopped = true;
+          return;
+        }
+
+        if (apiStatus === "FAILED" || apiStatus === "NOT_FOUND") {
+          setStatus({ state: "failed", error: json });
+          stopped = true;
+          return;
+        }
+
+        // otherwise keep polling with backoff
+        attempts += 0;
+        await new Promise((r) => setTimeout(r, delay));
+        delay = Math.min(30000, delay * 2);
+        if (!stopped) poll();
+      } catch (err: any) {
+        if (err?.name === "AbortError") return;
+        // transient network error: backoff and retry
+        await new Promise((r) => setTimeout(r, delay));
+        delay = Math.min(30000, delay * 2);
+        if (!stopped) poll();
+      }
+    };
+
+    poll();
+
+    return () => {
+      stopped = true;
+      abortCtrl.current?.abort();
+    };
+  }, [hash]);
+
+  return status;
+}


### PR DESCRIPTION
Title
feat(tx): poll /api/tx/status and surface settlement toasts after submit

Description
Adds client-side settlement tracking and live toasts so users see on-chain progression for submitted transactions (Processing → Completed/Failed). Polls the relay's status endpoint with backoff, respects rate-limits, and cleans up on unmount/navigation.

Closes #359 