### PR TITLE
Add markets API route contract tests

### DIFF
--- a/MARKETS_API.md
+++ b/MARKETS_API.md
@@ -1,0 +1,76 @@
+# Markets API
+
+`GET /api/markets` returns lending market data for the supported Stellarlend assets.
+
+## Query Parameters
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `asset` | No | Comma-separated asset symbols. Symbols are case-insensitive and must be one of `XLM`, `USDC`, `BTC`, or `ETH`. Omit the parameter to return every supported market. |
+
+Examples:
+
+```text
+GET /api/markets
+GET /api/markets?asset=XLM
+GET /api/markets?asset=xlm,usdc
+```
+
+## Response
+
+Successful responses use the `MarketsResponse` shape from `lib/markets/types.ts`.
+
+```json
+{
+  "markets": [
+    {
+      "asset": "XLM",
+      "supplyApr": 8.5,
+      "borrowApr": 12,
+      "utilization": 0.71,
+      "totalSupply": 2500000,
+      "totalBorrow": 1775000
+    }
+  ],
+  "timestamp": "2026-06-20T00:00:00.000Z",
+  "source": "Soroban RPC stub (server relay)"
+}
+```
+
+`markets` is ordered from the requested asset list. When `asset` is omitted, the route returns the canonical order from `ASSET_SYMBOLS`.
+
+## Caching
+
+Unauthenticated requests use the shared server cache:
+
+```text
+Cache-Control: public, max-age=30, stale-while-revalidate=60
+X-Cache: MISS | HIT | STALE
+```
+
+The cache key sorts requested assets so `?asset=XLM,USDC` and `?asset=USDC,XLM` share one cached value.
+
+Requests with an `Authorization` header, `session` or `token` cookie, or `x-user-id` header bypass the public cache:
+
+```text
+Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate
+X-Cache: BYPASS
+```
+
+## Errors
+
+Unknown or malformed asset lists return `400` with the unsupported symbol and the supported symbol list:
+
+```json
+{
+  "error": "Unknown asset(s): UNKNOWN. Supported: XLM, USDC, BTC, ETH"
+}
+```
+
+Unexpected route or data-source failures return:
+
+```json
+{
+  "error": "Failed to fetch market data"
+}
+```

--- a/app/api/markets/route.test.ts
+++ b/app/api/markets/route.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/markets/route';
+import { globalCache } from '@/lib/cache';
+import { ASSET_SYMBOLS } from '@/types/enums';
+
+function makeGetRequest(asset?: string, headers: HeadersInit = {}) {
+  const url = new URL('http://localhost/api/markets');
+  if (asset !== undefined) {
+    url.searchParams.set('asset', asset);
+  }
+  return new NextRequest(url, { headers });
+}
+
+function expectMarketShape(market: Record<string, unknown>) {
+  expect(ASSET_SYMBOLS).toContain(market.asset);
+  expect(typeof market.supplyApr).toBe('number');
+  expect(typeof market.borrowApr).toBe('number');
+  expect(typeof market.utilization).toBe('number');
+  expect(typeof market.totalSupply).toBe('number');
+  expect(typeof market.totalBorrow).toBe('number');
+}
+
+describe('GET /api/markets', () => {
+  beforeEach(() => {
+    globalCache.clear();
+  });
+
+  afterEach(() => {
+    globalCache.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('returns every supported market with the public response shape', async () => {
+    const response = await GET(makeGetRequest());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=30, stale-while-revalidate=60');
+    expect(response.headers.get('X-Cache')).toBe('MISS');
+
+    const body = await response.json();
+    expect(body.markets).toHaveLength(ASSET_SYMBOLS.length);
+    expect(typeof body.timestamp).toBe('string');
+    expect(body.source).toBe('Soroban RPC stub (server relay)');
+    body.markets.forEach(expectMarketShape);
+  });
+
+  it('filters a single asset case-insensitively', async () => {
+    const response = await GET(makeGetRequest('xlm'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.markets).toHaveLength(1);
+    expect(body.markets[0].asset).toBe('XLM');
+    expectMarketShape(body.markets[0]);
+  });
+
+  it('filters multiple comma-separated assets while sharing an order-invariant cache key', async () => {
+    const first = await GET(makeGetRequest('XLM,USDC'));
+    expect(first.status).toBe(200);
+    expect(first.headers.get('X-Cache')).toBe('MISS');
+
+    const firstBody = await first.json();
+    expect(firstBody.markets.map((market: { asset: string }) => market.asset)).toEqual(['XLM', 'USDC']);
+
+    const second = await GET(makeGetRequest('USDC,XLM'));
+    expect(second.status).toBe(200);
+    expect(second.headers.get('X-Cache')).toBe('HIT');
+  });
+
+  it('rejects unknown assets with the supported symbol list', async () => {
+    const response = await GET(makeGetRequest('XLM,UNKNOWN'));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('UNKNOWN');
+    expect(body.error).toContain(`Supported: ${ASSET_SYMBOLS.join(', ')}`);
+  });
+
+  it('rejects malformed comma-separated asset queries', async () => {
+    const response = await GET(makeGetRequest('XLM,,USDC'));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('Unknown asset(s):');
+    expect(body.error).toContain(`Supported: ${ASSET_SYMBOLS.join(', ')}`);
+  });
+
+  it('bypasses the public cache for authenticated requests', async () => {
+    await GET(makeGetRequest());
+
+    const response = await GET(makeGetRequest('XLM', { Authorization: 'Bearer test-token' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Cache')).toBe('BYPASS');
+    expect(response.headers.get('Cache-Control')).toBe('no-store, no-cache, must-revalidate, proxy-revalidate');
+  });
+
+  it('returns the route-level error response when request parsing fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const badRequest = {
+      get url(): never {
+        throw new Error('Unable to read URL');
+      },
+    } as unknown as NextRequest;
+
+    const response = await GET(badRequest);
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe('Failed to fetch market data');
+    expect(console.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add /api/markets route tests for response shape, asset filtering, malformed queries, cache behavior, and route-level errors
- document the markets API query, response, caching, and error contract

Closes #365

## Validation
- git diff --check
- static coverage grep for route-test cases and MARKETS_API contract