### PR TITLE
Harden webhook signature comparison

### DIFF
--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -26,6 +26,13 @@ HMAC-SHA256(WEBHOOK_SECRET, raw-request-body)
 
 > **Important:** The signature is computed over the **raw** request body string — not a re-serialised version. Whitespace, key order, and encoding must be preserved exactly.
 
+### Constant-Time Verification
+
+The server compares webhook signatures with Node.js `crypto.timingSafeEqual`.
+Malformed, missing, wrong-length, and wrong-value signatures all return the same
+`401` response and do not include the received signature or shared secret in the
+response body.
+
 ### Environment Variable
 
 | Variable | Required | Description |

--- a/app/api/webhooks/transactions/route.test.ts
+++ b/app/api/webhooks/transactions/route.test.ts
@@ -133,6 +133,29 @@ describe("POST /api/webhooks/transactions – signature verification", () => {
     const res = await POST(req);
     expect(res.status).toBe(401);
   });
+
+  it("returns 401 when signature digest has the wrong length", async () => {
+    const body = JSON.stringify(makePayload());
+    const req = makeWebhookRequest(body, { [SIGNATURE_HEADER]: "sha256=abcd" });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const json = await res.json();
+    expect(json.error).toMatch(/signature/i);
+    expect(json.error).not.toContain("abcd");
+  });
+
+  it("returns 401 when signature digest contains non-hex characters", async () => {
+    const body = JSON.stringify(makePayload());
+    const req = makeWebhookRequest(body, {
+      [SIGNATURE_HEADER]: `sha256=${"z".repeat(64)}`,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const json = await res.json();
+    expect(json.error).toBe("Invalid or missing webhook signature");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/app/api/webhooks/transactions/route.ts
+++ b/app/api/webhooks/transactions/route.ts
@@ -48,8 +48,8 @@ export async function POST(req: NextRequest) {
   }
 
   // ── 3. Verify signature ─────────────────────────────────────────────────
-  const signature = req.headers.get(SIGNATURE_HEADER);
-  if (!signature || !verifyWebhookSignature(rawBody, signature, secret)) {
+  const signature = req.headers.get(SIGNATURE_HEADER) ?? "";
+  if (!verifyWebhookSignature(rawBody, signature, secret)) {
     return NextResponse.json(
       { error: "Invalid or missing webhook signature" },
       { status: 401 },

--- a/lib/webhooks/verify.test.ts
+++ b/lib/webhooks/verify.test.ts
@@ -53,6 +53,15 @@ describe("verifyWebhookSignature", () => {
   it("returns false when hex digest has wrong length", () => {
     expect(verifyWebhookSignature(payload, "sha256=abcd", secret)).toBe(false);
   });
+
+  it("returns false when hex digest has the right length but invalid characters", () => {
+    expect(verifyWebhookSignature(payload, `sha256=${"z".repeat(64)}`, secret)).toBe(false);
+  });
+
+  it("accepts uppercase hex digest characters", () => {
+    const sig = signPayload(payload, secret).toUpperCase().replace("SHA256=", "sha256=");
+    expect(verifyWebhookSignature(payload, sig, secret)).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/webhooks/verify.ts
+++ b/lib/webhooks/verify.ts
@@ -25,29 +25,25 @@ export function verifyWebhookSignature(
   signature: string,
   secret: string,
 ): boolean {
-  if (!signature || !secret || !payload) {
+  if (!secret || !payload) {
     return false;
   }
 
   const prefix = "sha256=";
-  if (!signature.startsWith(prefix)) {
-    return false;
-  }
-
-  const receivedHex = signature.slice(prefix.length);
   const expectedHex = createHmac("sha256", secret)
     .update(payload)
     .digest("hex");
+  const expected = Buffer.from(expectedHex, "hex");
 
-  // timingSafeEqual requires equal-length buffers
-  if (receivedHex.length !== expectedHex.length) {
-    return false;
-  }
+  const receivedHex = signature.startsWith(prefix)
+    ? signature.slice(prefix.length)
+    : "";
+  const hasValidDigestShape = /^[0-9a-fA-F]{64}$/.test(receivedHex);
+  const received = hasValidDigestShape
+    ? Buffer.from(receivedHex, "hex")
+    : Buffer.alloc(expected.length);
 
-  return timingSafeEqual(
-    Buffer.from(receivedHex, "hex"),
-    Buffer.from(expectedHex, "hex"),
-  );
+  return timingSafeEqual(received, expected) && hasValidDigestShape;
 }
 
 /**


### PR DESCRIPTION
## Summary
- compare webhook HMAC digests through fixed-length buffers before returning invalid-signature results
- route missing, malformed, wrong-length, and wrong-value signatures through the same 401 response
- add verification and route tests for malformed digest cases and document the constant-time contract

Closes #368

## Validation
- git diff --check
- static source review for timingSafeEqual path, fixed-length fallback buffer, and non-leaking 401 response coverage