### PR TITLE
Extend quote property tests for invalid inputs

### DIFF
--- a/lib/lending/quote.property.test.ts
+++ b/lib/lending/quote.property.test.ts
@@ -420,4 +420,105 @@ describe("lending quote properties", () => {
       { numRuns: 100, seed: 42 }
     );
   });
+
+  /**
+   * Property 11: Invalid numeric inputs are rejected without throwing
+   * Both quote modes should use the structured error branch for non-positive
+   * and non-finite amount, rate, or duration inputs.
+   */
+  it("property: invalid amount inputs return INVALID_INPUT for lend and borrow", () => {
+    const invalidNumber = fc.oneof(
+      fc.constant(0),
+      fc.double({ min: -1_000_000, max: 0, noNaN: true }),
+      fc.constant(Number.NaN),
+      fc.constant(Number.POSITIVE_INFINITY),
+      fc.constant(Number.NEGATIVE_INFINITY)
+    );
+
+    fc.assert(
+      fc.property(
+        invalidNumber,
+        fc.constantFrom("lend", "borrow"),
+        (amount, type) => {
+          const result = calculateQuote(type, {
+            asset: "XLM",
+            amount,
+            interestRate: 8,
+            duration: 30,
+          });
+
+          expect(result.ok).toBe(false);
+          if (result.ok) {
+            throw new Error("expected invalid amount to fail");
+          }
+          expect(result.error.code).toBe("INVALID_INPUT");
+        }
+      ),
+      { numRuns: 100, seed: 42 }
+    );
+  });
+
+  it("property: invalid interest rates return INVALID_INPUT for lend and borrow", () => {
+    const invalidNumber = fc.oneof(
+      fc.constant(0),
+      fc.double({ min: -1_000_000, max: 0, noNaN: true }),
+      fc.constant(Number.NaN),
+      fc.constant(Number.POSITIVE_INFINITY),
+      fc.constant(Number.NEGATIVE_INFINITY)
+    );
+
+    fc.assert(
+      fc.property(
+        invalidNumber,
+        fc.constantFrom("lend", "borrow"),
+        (interestRate, type) => {
+          const result = calculateQuote(type, {
+            asset: "XLM",
+            amount: 1_000,
+            interestRate,
+            duration: 30,
+          });
+
+          expect(result.ok).toBe(false);
+          if (result.ok) {
+            throw new Error("expected invalid interest rate to fail");
+          }
+          expect(result.error.code).toBe("INVALID_INPUT");
+        }
+      ),
+      { numRuns: 100, seed: 43 }
+    );
+  });
+
+  it("property: invalid durations return INVALID_INPUT for lend and borrow", () => {
+    const invalidNumber = fc.oneof(
+      fc.constant(0),
+      fc.double({ min: -1_000_000, max: 0, noNaN: true }),
+      fc.constant(Number.NaN),
+      fc.constant(Number.POSITIVE_INFINITY),
+      fc.constant(Number.NEGATIVE_INFINITY)
+    );
+
+    fc.assert(
+      fc.property(
+        invalidNumber,
+        fc.constantFrom("lend", "borrow"),
+        (duration, type) => {
+          const result = calculateQuote(type, {
+            asset: "XLM",
+            amount: 1_000,
+            interestRate: 8,
+            duration,
+          });
+
+          expect(result.ok).toBe(false);
+          if (result.ok) {
+            throw new Error("expected invalid duration to fail");
+          }
+          expect(result.error.code).toBe("INVALID_INPUT");
+        }
+      ),
+      { numRuns: 100, seed: 44 }
+    );
+  });
 });

--- a/lib/lending/quote.property.test.ts
+++ b/lib/lending/quote.property.test.ts
@@ -521,4 +521,88 @@ describe("lending quote properties", () => {
       { numRuns: 100, seed: 44 }
     );
   });
+
+  it("property: lending earnings increase monotonically with duration", () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.integer({ min: 1, max: 3650 }),
+          fc.integer({ min: 1, max: 3650 }),
+          fc.float({ min: 1, max: 1_000_000, noNaN: true }),
+          fc.float({ min: 0.001, max: 100, noNaN: true })
+        ),
+        ([duration1, duration2, amount, interestRate]) => {
+          const d1 = Math.min(duration1, duration2);
+          const d2 = Math.max(duration1, duration2);
+
+          const result1 = calculateQuote("lend", {
+            asset: "XLM",
+            amount,
+            interestRate,
+            duration: d1,
+          });
+
+          const result2 = calculateQuote("lend", {
+            asset: "XLM",
+            amount,
+            interestRate,
+            duration: d2,
+          });
+
+          if (!result1.ok || !result2.ok) {
+            throw new Error(
+              `Unexpected failure: ${!result1.ok ? result1.error.message : result2.error.message}`
+            );
+          }
+
+          expect(result2.result.totalEarnings).toBeGreaterThanOrEqual(
+            result1.result.totalEarnings - 1e-10
+          );
+        }
+      ),
+      { numRuns: 100, seed: 45 }
+    );
+  });
+
+  it("property: borrowing repayment increases monotonically with duration", () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.integer({ min: 1, max: 3650 }),
+          fc.integer({ min: 1, max: 3650 }),
+          fc.float({ min: 1, max: 1_000_000, noNaN: true }),
+          fc.float({ min: 0.001, max: 100, noNaN: true })
+        ),
+        ([duration1, duration2, amount, interestRate]) => {
+          const d1 = Math.min(duration1, duration2);
+          const d2 = Math.max(duration1, duration2);
+
+          const result1 = calculateQuote("borrow", {
+            asset: "XLM",
+            amount,
+            interestRate,
+            duration: d1,
+          });
+
+          const result2 = calculateQuote("borrow", {
+            asset: "XLM",
+            amount,
+            interestRate,
+            duration: d2,
+          });
+
+          if (!result1.ok || !result2.ok) {
+            throw new Error(
+              `Unexpected failure: ${!result1.ok ? result1.error.message : result2.error.message}`
+            );
+          }
+
+          expect(result2.result.totalRepayment ?? 0).toBeGreaterThanOrEqual(
+            (result1.result.totalRepayment ?? 0) - 1e-10
+          );
+        }
+      ),
+      { numRuns: 100, seed: 46 }
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- extend calculateQuote property coverage with invalid amount, rate, and duration generators
- assert lend and borrow quotes return the structured INVALID_INPUT branch instead of throwing for non-positive and non-finite numeric inputs

Closes #367

## Validation
- git diff --check
- static coverage grep for invalid amount/rate/duration properties