### PR TITLE
docs: add environment variable reference and sync check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,47 @@ API_RATE_LIMIT_WINDOW_MS=60000
 TX_ACCOUNT_RATE_LIMIT_MAX=30
 TX_ACCOUNT_RATE_LIMIT_WINDOW_MS=60000
 TX_ACCOUNT_RATE_LIMIT_BURST=60
+
+# Public auth/session display settings
+NEXT_PUBLIC_SESSION_COOKIE=session
+NEXT_PUBLIC_APP_DOMAIN=localhost:3000
+NEXT_PUBLIC_SOROBAN_CONTRACT_ID=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# Webhook HMAC signing secret
+WEBHOOK_SECRET=replace-with-webhook-hmac-secret
+
+# Session/JWT signing configuration
+AUTH_SECRET=replace-with-auth-secret
+AUTH_SESSION_EXPIRY=24
+JWT_SECRET=replace-with-jwt-secret
+
+# Stellar server-side signing configuration
+STELLAR_SIGNING_SECRET=replace-with-stellar-signing-secret
+
+# Database and cache configuration
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/stellarlend
+REDIS_URL=redis://localhost:6379
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# Security and session cookies
+CSRF_COOKIE_NAME=csrf-token
+
+# Background jobs and retention
+RETENTION_DRY_RUN=true
+AUDIT_RETENTION_DAYS=30
+SESSION_RETENTION_DAYS=30
+SNAPSHOT_RETENTION_DAYS=30
+
+# Circuit breaker and chaos testing
+CIRCUIT_FAILURE_RATE=0.5
+CIRCUIT_MIN_CALLS=20
+CIRCUIT_COOLDOWN_MS=60000
+ENABLE_CHAOS_INJECTION=false
+
+# Optional telemetry and indexing
+SENTRY_RELEASE=local-dev
+STELLAR_INDEXER_ACCOUNT=
+MEMO_SALT=stellarlend-default-salt
+STRICT_MEMO_MODE=false
+SERVER_LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This frontend application provides a modern, responsive web interface for intera
 
 - [Lending and borrowing data flow](docs/LENDING_FLOW.md)
 - [Borrow repayment flow](docs/REPAY_FLOW.md)
+- [Environment variables reference](docs/ENVIRONMENT.md)
 
 ## ?? Features
 
@@ -56,6 +57,8 @@ bun install
 ```
 
 ### 3. Environment Variables
+
+See [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md) for the complete public/server-only variable reference and `.env.example` sync checks.
 
 Create a `.env.local` file in the root directory:
 

--- a/__tests__/config/env-example-sync.test.ts
+++ b/__tests__/config/env-example-sync.test.ts
@@ -1,0 +1,119 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const rootDir = path.resolve(__dirname, "../..");
+const scanTargets = [
+  "app",
+  "components",
+  "config",
+  "context",
+  "lib",
+  "src",
+  "utils",
+  "middleware.ts",
+  "instrumentation.ts",
+  "next.config.ts",
+];
+
+const ignoredEnv = new Set([
+  "CI",
+  "NODE_ENV",
+  "NEXT_RUNTIME",
+]);
+
+const ignoredDirectories = new Set([
+  "__tests__",
+  "node_modules",
+  ".next",
+  ".git",
+  "coverage",
+  "dist",
+  "build",
+]);
+
+function walkFiles(target: string): string[] {
+  const absolute = path.join(rootDir, target);
+  if (!existsSync(absolute)) {
+    return [];
+  }
+
+  const stats = statSync(absolute);
+  if (stats.isFile()) {
+    return /\.[cm]?[tj]sx?$/.test(absolute) ? [absolute] : [];
+  }
+
+  return readdirSync(absolute).flatMap((entry) => {
+    if (ignoredDirectories.has(entry)) {
+      return [];
+    }
+
+    return walkFiles(path.join(target, entry));
+  });
+}
+
+function collectEnvReads(source: string): string[] {
+  const variables = new Set<string>();
+  const patterns = [
+    /process\.env\.([A-Z][A-Z0-9_]*)/g,
+    /process\.env\[['"]([A-Z][A-Z0-9_]*)['"]\]/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      const variable = match[1];
+      if (!ignoredEnv.has(variable)) {
+        variables.add(variable);
+      }
+    }
+  }
+
+  return [...variables];
+}
+
+function collectExampleKeys(): Set<string> {
+  const example = readFileSync(path.join(rootDir, ".env.example"), "utf8");
+  return new Set(
+    example
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"))
+      .map((line) => line.split("=")[0]?.trim())
+      .filter(Boolean),
+  );
+}
+
+describe(".env.example sync", () => {
+  it("documents app-specific process.env reads", () => {
+    const used = new Set<string>();
+
+    for (const file of scanTargets.flatMap(walkFiles)) {
+      for (const variable of collectEnvReads(readFileSync(file, "utf8"))) {
+        used.add(variable);
+      }
+    }
+
+    const documented = collectExampleKeys();
+    const missing = [...used].filter((variable) => !documented.has(variable)).sort();
+
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps server-only secrets out of NEXT_PUBLIC names", () => {
+    const documented = collectExampleKeys();
+    const serverOnlySecrets = [
+      "AUTH_SECRET",
+      "AUTH_SIGNING_SECRET",
+      "JWT_SECRET",
+      "PRICE_ORACLE_API_KEY",
+      "SERVER_TOKEN",
+      "STELLAR_SIGNING_SECRET",
+      "WEBHOOK_SECRET",
+    ];
+
+    for (const secret of serverOnlySecrets) {
+      expect(documented.has(secret)).toBe(true);
+      expect(documented.has("NEXT_PUBLIC_" + secret)).toBe(false);
+    }
+  });
+});

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,61 @@
+# Environment Variables
+
+This reference keeps `.env.example`, client bundle safety checks, and server-only configuration in sync. Public variables are available to browser code and must use the `NEXT_PUBLIC_` prefix. Server-only variables must never use that prefix.
+
+## Public Variables
+
+| Variable | Required | Default/example | Purpose |
+| --- | --- | --- | --- |
+| `NEXT_PUBLIC_APP_NAME` | Yes | `Stellarlend` | Product name shown by frontend config. |
+| `NEXT_PUBLIC_APP_VERSION` | Yes | `1.0.0` | Frontend release/version label. |
+| `NEXT_PUBLIC_APP_ENV` | Yes | `development` | Runtime environment: `development`, `staging`, or `production`. |
+| `NEXT_PUBLIC_API_BASE_URL` | Yes | `http://localhost:3001` | Public API base URL used by frontend requests. |
+| `NEXT_PUBLIC_STELLAR_NETWORK` | Yes | `testnet` | Stellar network label shown and validated by the frontend. |
+| `NEXT_PUBLIC_STELLAR_HORIZON_URL` | Yes | `https://horizon-testnet.stellar.org` | Public Horizon endpoint for read-only network display and defaults. |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Development only | `https://soroban-testnet.stellar.org` | Legacy/public RPC value still validated by config; production traffic should use server relay configuration. |
+| `NEXT_PUBLIC_SOROBAN_CONTRACT_ID` | Deployment-specific | placeholder contract id | Contract id displayed by public config. |
+| `NEXT_PUBLIC_SESSION_COOKIE` | No | `session` | Cookie name used by client-visible auth helpers. |
+| `NEXT_PUBLIC_APP_DOMAIN` | No | `localhost:3000` | Domain used in wallet authentication messages. |
+| `NEXT_PUBLIC_GA_TRACKING_ID` | No | placeholder | Optional Google Analytics id. |
+| `NEXT_PUBLIC_MIXPANEL_TOKEN` | No | placeholder | Optional Mixpanel token. |
+
+## Server-only Variables
+
+| Variable | Required | Default/example | Purpose |
+| --- | --- | --- | --- |
+| `SOROBAN_RPC_URL` | Yes for relay routes | testnet RPC URL | Server-only Soroban RPC endpoint for transaction relay routes. |
+| `STELLAR_HORIZON_URLS` | No | comma-separated testnet URLs | Ordered Horizon fallback list for server-side calls. |
+| `PRICE_ORACLE_API_KEY` | Production | placeholder secret | Server-side price oracle credential. |
+| `AUTH_SIGNING_SECRET` | Production | placeholder secret | Server auth signing secret used by server config. |
+| `AUTH_SECRET` | Production | placeholder secret | Session auth secret used by auth helpers. |
+| `AUTH_SESSION_EXPIRY` | No | `24` | Session lifetime in hours. |
+| `JWT_SECRET` | Production | placeholder secret | JWT signing fallback for API auth code. |
+| `SERVER_TOKEN` | Production | placeholder secret | Bearer token for internal server endpoints. |
+| `WEBHOOK_SECRET` | Yes for webhooks | placeholder secret | HMAC secret for transaction webhooks. Do not prefix with `NEXT_PUBLIC_`. |
+| `STELLAR_SIGNING_SECRET` | Wallet auth deployments | placeholder secret | Server-side Stellar signing secret. |
+| `DATABASE_URL` | Yes for persistence | local Postgres URL | Postgres connection for Drizzle-backed data. |
+| `REDIS_URL` | Background jobs | local Redis URL | BullMQ/job cache connection string. |
+| `REDIS_HOST` / `REDIS_PORT` | Background workers | `localhost` / `6379` | Host/port fallback for worker Redis connections. |
+| `CSRF_COOKIE_NAME` | No | `csrf-token` | CSRF cookie name. |
+| `API_RATE_LIMIT_MAX` / `API_RATE_LIMIT_WINDOW_MS` | No | `100` / `60000` | Global API rate limit window. |
+| `TX_ACCOUNT_RATE_LIMIT_MAX` / `TX_ACCOUNT_RATE_LIMIT_WINDOW_MS` / `TX_ACCOUNT_RATE_LIMIT_BURST` | No | `30` / `60000` / `60` | Wallet-scoped transaction relay throttling. |
+| `RETENTION_DRY_RUN` | No | `true` | Runs retention jobs without destructive writes when true. |
+| `AUDIT_RETENTION_DAYS` / `SESSION_RETENTION_DAYS` / `SNAPSHOT_RETENTION_DAYS` | No | `30` | Retention windows for server cleanup jobs. |
+| `CIRCUIT_FAILURE_RATE` / `CIRCUIT_MIN_CALLS` / `CIRCUIT_COOLDOWN_MS` | No | `0.5` / `20` / `60000` | Circuit breaker tuning. |
+| `ENABLE_CHAOS_INJECTION` | No | `false` | Enables non-production chaos injection helpers. |
+| `SENTRY_RELEASE` | No | `local-dev` | Optional Sentry release tag. |
+| `STELLAR_INDEXER_ACCOUNT` | No | empty | Optional account filter for transaction indexing. |
+| `MEMO_SALT` | No | `stellarlend-default-salt` | Salt for deterministic memo helpers. |
+| `STRICT_MEMO_MODE` | No | `false` | Enables strict memo validation path. |
+| `SERVER_LOG_LEVEL` | No | `info` | Structured server logging level. |
+
+## Sync Check
+
+`__tests__/config/env-example-sync.test.ts` scans application source for `process.env.*` reads and fails when an app-specific variable is missing from `.env.example`. It intentionally ignores platform-provided variables such as `NODE_ENV`, `CI`, and `NEXT_RUNTIME`.
+
+## Related Guides
+
+- `README.md` for setup instructions.
+- `WEBHOOKS.md` for webhook signing and `WEBHOOK_SECRET`.
+- `README_AUTH.md` and `docs/AUTH.md` for session and wallet authentication settings.
+- `docs/SECRET_SCANNER.md` for client bundle secret checks.


### PR DESCRIPTION
## Summary

- Add docs/ENVIRONMENT.md with public and server-only environment variable tables.
- Expand .env.example with missing app-specific server, auth, webhook, Redis, retention, circuit breaker, and telemetry settings.
- Add a Vitest sync check that scans application source for process.env reads and verifies .env.example documents them.
- Link the new reference from README setup docs.

## Verification

- Static preparation in GitHub web editor.
- Local test execution was not available in this browser-only environment.
- Expected reviewer check: `npm test -- __tests__/config/env-example-sync.test.ts`.

Closes #372