### PR TITLE
test(lending): add TabSelector accessibility coverage

### DIFF
--- a/COMPONENT-CHECKLIST.md
+++ b/COMPONENT-CHECKLIST.md
@@ -39,3 +39,4 @@
 - [ ] ARIA attributes
 - [ ] Keyboard navigation
 - [ ] Screen reader support
+- [ ] Tabs use role="tablist"/`role="tab"`, `aria-selected`, roving tabIndex, and arrow-key navigation

--- a/components/features/lending/components/TabSelector.test.tsx
+++ b/components/features/lending/components/TabSelector.test.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import type { LendingActionType } from "@/lib/lending/types";
+import TabSelector from "./TabSelector";
+
+function StatefulTabSelector({
+  initialTab = "lend",
+  onTabChange = () => undefined,
+}: {
+  initialTab?: LendingActionType;
+  onTabChange?: (tab: LendingActionType) => void;
+}) {
+  const [activeTab, setActiveTab] = useState<LendingActionType>(initialTab);
+
+  return (
+    <TabSelector
+      activeTab={activeTab}
+      onTabChange={(tab) => {
+        setActiveTab(tab);
+        onTabChange(tab);
+      }}
+    />
+  );
+}
+
+describe("TabSelector", () => {
+  it("renders a labelled tablist with all lending action tabs", () => {
+    render(<TabSelector activeTab="lend" onTabChange={() => undefined} />);
+
+    expect(screen.getByRole("tablist", { name: /lending action/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /lend assets/i })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: /borrow assets/i })).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("tab", { name: /repay loan/i })).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("calls onTabChange with the selected tab when clicked", async () => {
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+
+    render(<TabSelector activeTab="lend" onTabChange={onTabChange} />);
+
+    await user.click(screen.getByRole("tab", { name: /borrow assets/i }));
+    await user.click(screen.getByRole("tab", { name: /repay loan/i }));
+
+    expect(onTabChange).toHaveBeenNthCalledWith(1, "borrow");
+    expect(onTabChange).toHaveBeenNthCalledWith(2, "repay");
+  });
+
+  it("keeps only the active tab in the roving tab stop", () => {
+    render(<TabSelector activeTab="borrow" onTabChange={() => undefined} />);
+
+    expect(screen.getByRole("tab", { name: /lend assets/i })).toHaveAttribute("tabIndex", "-1");
+    expect(screen.getByRole("tab", { name: /borrow assets/i })).toHaveAttribute("tabIndex", "0");
+    expect(screen.getByRole("tab", { name: /repay loan/i })).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("moves selection with arrow keys and wraps at the ends", async () => {
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+
+    render(<StatefulTabSelector onTabChange={onTabChange} />);
+
+    const lendTab = screen.getByRole("tab", { name: /lend assets/i });
+    lendTab.focus();
+
+    await user.keyboard("{ArrowRight}");
+    expect(onTabChange).toHaveBeenLastCalledWith("borrow");
+    expect(screen.getByRole("tab", { name: /borrow assets/i })).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{ArrowRight}");
+    expect(onTabChange).toHaveBeenLastCalledWith("repay");
+    expect(screen.getByRole("tab", { name: /repay loan/i })).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{ArrowRight}");
+    expect(onTabChange).toHaveBeenLastCalledWith("lend");
+    expect(screen.getByRole("tab", { name: /lend assets/i })).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{ArrowLeft}");
+    expect(onTabChange).toHaveBeenLastCalledWith("repay");
+    expect(screen.getByRole("tab", { name: /repay loan/i })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("supports Home and End keyboard shortcuts", async () => {
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+
+    render(<StatefulTabSelector initialTab="borrow" onTabChange={onTabChange} />);
+
+    screen.getByRole("tab", { name: /borrow assets/i }).focus();
+
+    await user.keyboard("{End}");
+    expect(onTabChange).toHaveBeenLastCalledWith("repay");
+
+    await user.keyboard("{Home}");
+    expect(onTabChange).toHaveBeenLastCalledWith("lend");
+  });
+});

--- a/components/features/lending/components/TabSelector.tsx
+++ b/components/features/lending/components/TabSelector.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from "react";
 import type { LendingActionType } from "@/lib/lending/types";
 
 interface TabSelectorProps {
@@ -15,22 +16,73 @@ export default function TabSelector({
   activeTab,
   onTabChange,
 }: TabSelectorProps) {
+  const focusTab = (value: LendingActionType) => {
+    requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLButtonElement>(`[data-tab-value="${value}"]`)
+        ?.focus();
+    });
+  };
+
+  const selectTab = (value: LendingActionType) => {
+    onTabChange(value);
+    focusTab(value);
+  };
+
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    const lastIndex = TABS.length - 1;
+    let nextIndex = index;
+
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      nextIndex = index === lastIndex ? 0 : index + 1;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      nextIndex = index === 0 ? lastIndex : index - 1;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = lastIndex;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    selectTab(TABS[nextIndex].value);
+  };
+
   return (
-    <div className="flex bg-white rounded-lg p-1 shadow-sm border border-gray-200">
-      {TABS.map((tab) => (
-        <button
-          key={tab.value}
-          type="button"
-          onClick={() => onTabChange(tab.value)}
-          className={`flex-1 px-4 py-3 rounded-md text-sm font-medium transition-all duration-200 ${
-            activeTab === tab.value
-              ? "bg-green-500 text-white shadow-sm"
-              : "text-gray-600 hover:text-gray-900"
-          }`}
-        >
-          {tab.label}
-        </button>
-      ))}
+    <div
+      className="flex bg-white rounded-lg p-1 shadow-sm border border-gray-200"
+      role="tablist"
+      aria-label="Lending action"
+    >
+      {TABS.map((tab, index) => {
+        const selected = activeTab === tab.value;
+
+        return (
+          <button
+            key={tab.value}
+            type="button"
+            role="tab"
+            id={`lending-tab-${tab.value}`}
+            aria-selected={selected}
+            aria-controls={`lending-panel-${tab.value}`}
+            tabIndex={selected ? 0 : -1}
+            data-tab-value={tab.value}
+            onClick={() => onTabChange(tab.value)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+            className={`flex-1 px-4 py-3 rounded-md text-sm font-medium transition-all duration-200 ${
+              selected
+                ? "bg-green-500 text-white shadow-sm"
+                : "text-gray-600 hover:text-gray-900"
+            }`}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add ARIA tablist semantics to the lending action selector.
- Add roving tabIndex and Arrow/Home/End keyboard selection behavior.
- Add RTL/user-event coverage for rendering, clicks, selected state, wrapping keyboard navigation, and Home/End shortcuts.
- Document the tab accessibility contract in the component checklist.

## Verification

- Static preparation in GitHub web editor.
- Local test execution was not available in this browser-only environment.
- Expected reviewer check: `npm test -- components/features/lending/components/TabSelector.test.tsx`.

Closes #362