### PR TITLE
test(lending): add ConfirmModal dialog accessibility coverage

### DIFF
--- a/ICON_BUTTON_ACCESSIBILITY.md
+++ b/ICON_BUTTON_ACCESSIBILITY.md
@@ -51,6 +51,13 @@ This document outlines the accessibility improvements made to icon-only buttons 
   - `aria-label="Close modal"`
   - Enhanced focus styling with visible focus ring
 
+##### ConfirmModal Focus Contract
+- The modal container uses `role="dialog"`, `aria-modal="true"`, and a labelled title.
+- Focus moves to the close button when the modal opens.
+- Tab and Shift+Tab remain inside the dialog while it is open.
+- Escape, the close button, the cancel button, and the backdrop all close the modal.
+- Focus returns to the trigger that opened the modal after close.
+
 #### Pagination Component (`/components/shared/common/Pagination.tsx`)
 - **Before**: Had basic `aria-label` but inconsistent focus styling
 - **After**: Enhanced with:

--- a/components/features/lending/components/ConfirmModal.test.tsx
+++ b/components/features/lending/components/ConfirmModal.test.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import ConfirmModal from "./ConfirmModal";
+import type { LendingData } from "@/app/lending/page";
+
+const lendingData: LendingData = {
+  asset: "XLM",
+  amount: 250,
+  interestRate: 4.5,
+};
+
+function ConfirmModalHarness({
+  onConfirm = vi.fn(),
+  onClose = vi.fn(),
+}: {
+  onConfirm?: () => void | Promise<void>;
+  onClose?: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setIsOpen(true)}>
+        Open confirmation
+      </button>
+      <ConfirmModal
+        isOpen={isOpen}
+        onClose={() => {
+          onClose();
+          setIsOpen(false);
+        }}
+        onConfirm={onConfirm}
+        data={lendingData}
+        calculation={{ dailyEarnings: 0.03, totalEarnings: 4.2 }}
+        type="lend"
+      />
+    </div>
+  );
+}
+
+describe("ConfirmModal accessibility", () => {
+  it("renders as a labelled modal dialog with close, cancel, and confirm controls", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmModalHarness />);
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+
+    const dialog = screen.getByRole("dialog", { name: /confirm lending transaction/i });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(within(dialog).getByRole("button", { name: /close modal/i })).toHaveFocus();
+    expect(within(dialog).getByRole("button", { name: /^cancel$/i })).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: /confirm lending/i })).toBeDisabled();
+  });
+
+  it("traps keyboard focus inside the dialog", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmModalHarness />);
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm lending transaction/i });
+    const closeButton = within(dialog).getByRole("button", { name: /close modal/i });
+    const cancelButton = within(dialog).getByRole("button", { name: /^cancel$/i });
+
+    expect(closeButton).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(cancelButton).toHaveFocus();
+
+    await user.tab();
+    expect(closeButton).toHaveFocus();
+  });
+
+  it("closes on Escape and restores focus to the trigger", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<ConfirmModalHarness onClose={onClose} />);
+
+    const trigger = screen.getByRole("button", { name: /open confirmation/i });
+    await user.click(trigger);
+    expect(screen.getByRole("dialog", { name: /confirm lending transaction/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(trigger).toHaveFocus();
+  });
+
+  it("fires confirm only after the terms checkbox is selected", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(<ConfirmModalHarness onConfirm={onConfirm} />);
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm lending transaction/i });
+    const confirmButton = within(dialog).getByRole("button", { name: /confirm lending/i });
+
+    expect(confirmButton).toBeDisabled();
+
+    await user.click(within(dialog).getByRole("checkbox"));
+    expect(confirmButton).toBeEnabled();
+
+    await user.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes from the close button, cancel button, and backdrop", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<ConfirmModalHarness onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+    await user.click(screen.getByRole("button", { name: /close modal/i }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+    await user.click(document.querySelector(".fixed.inset-0.transition-opacity") as HTMLElement);
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    expect(onClose).toHaveBeenCalledTimes(3);
+  });
+});

--- a/components/features/lending/components/ConfirmModal.tsx
+++ b/components/features/lending/components/ConfirmModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LendingData, CalculationResult } from "@/app/lending/page";
 import type { LendingActionType } from "@/lib/lending/types";
 import { cn } from "@/lib/utils/cn";
@@ -28,6 +28,9 @@ export default function ConfirmModal({
     "idle" | "success" | "error"
   >("idle");
   const [submitMessage, setSubmitMessage] = useState("");
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -36,6 +39,59 @@ export default function ConfirmModal({
       setHasAgreed(false);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previouslyFocusedElementRef.current = document.activeElement as HTMLElement;
+    closeButtonRef.current?.focus();
+
+    const focusableSelector = [
+      "button:not([disabled])",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      "a[href]",
+      "[tabindex]:not([tabindex='-1'])",
+    ].join(", ");
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableElements = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ?? [],
+      ).filter((element) => !element.hasAttribute("disabled"));
+
+      if (!focusableElements.length) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocusedElementRef.current?.focus();
+    };
+  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 
@@ -84,13 +140,23 @@ export default function ConfirmModal({
         />
 
         {/* Modal */}
-        <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+        <div
+          ref={dialogRef}
+          className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-transaction-title"
+        >
           {/* Header */}
           <div className="flex items-center justify-between mb-6">
-            <h3 className="text-lg font-semibold text-gray-900">
+            <h3
+              id="confirm-transaction-title"
+              className="text-lg font-semibold text-gray-900"
+            >
               Confirm {actionLabel} Transaction
             </h3>
             <button
+              ref={closeButtonRef}
               onClick={onClose}
               className="text-gray-400 hover:text-gray-600 transition-colors p-1 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50"
               aria-label="Close modal"


### PR DESCRIPTION
## Summary

- Add dialog semantics, aria-modal, labelled title, Escape-to-close, focus trapping, and focus restoration to ConfirmModal.
- Add RTL/user-event coverage for dialog labelling, close/cancel/backdrop flows, keyboard trapping, Escape, and confirm enablement.
- Document the ConfirmModal focus contract in ICON_BUTTON_ACCESSIBILITY.md.

## Verification

- Static preparation in GitHub web editor.
- Local test execution was not available in this browser-only environment.
- Expected reviewer check: `npm test -- components/features/lending/components/ConfirmModal.test.tsx`.

Closes #363