### PR TITLE
feat(lending): add projected borrow health preview

### DIFF
--- a/BORROW_HEALTH_PREVIEW.md
+++ b/BORROW_HEALTH_PREVIEW.md
@@ -1,0 +1,37 @@
+# Borrow Health Preview
+
+The borrowing form now shows a projected health preview before submission. The preview is intentionally advisory: it warns when a position is close to liquidation, but it keeps the existing 150% minimum-collateral validation as the hard form rule.
+
+## Formula
+
+The form estimates position health from USD values:
+
+```text
+loanValueUsd = loanAmount * borrowAssetPrice
+collateralValueUsd = collateralAmount * collateralAssetPrice
+healthFactor = collateralValueUsd / (loanValueUsd * 1.2)
+liquidationPrice = (loanValueUsd * 1.2) / collateralAmount
+```
+
+The `1.2` multiplier matches the displayed 120% liquidation threshold. Health bands match `PositionSummary`:
+
+- `healthy`: health factor >= 2.0
+- `at-risk`: health factor >= 1.0 and < 2.0
+- `critical`: health factor < 1.0
+
+## Price Source
+
+`BorrowingForm` fetches `/api/prices?assets=<borrow>,<collateral>` after asset changes with a short debounce. If the request fails, the preview uses local fallback prices so the user still sees an estimate instead of a blank section.
+
+## Example
+
+Borrowing `100 USDC` with `300 USDC` collateral:
+
+```text
+loanValueUsd = 100 * 1 = 100
+collateralValueUsd = 300 * 1 = 300
+healthFactor = 300 / (100 * 1.2) = 2.50
+liquidationPrice = (100 * 1.2) / 300 = 0.40 USDC
+```
+
+That position is shown as `healthy`.

--- a/components/features/lending/components/BorrowingForm.test.tsx
+++ b/components/features/lending/components/BorrowingForm.test.tsx
@@ -15,10 +15,26 @@ describe("BorrowingForm Component", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    mockOnSubmit.mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          prices: {
+            XLM: 0.12,
+            USDC: 1,
+            BTC: 65000,
+            ETH: 3500,
+          },
+        }),
+      }),
+    );
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("renders correctly", () => {
@@ -35,6 +51,53 @@ describe("BorrowingForm Component", () => {
     
     // Required collateral should be 150 (150% of 100)
     expect(screen.getByText("150 XLM")).toBeInTheDocument();
+  });
+
+  it("shows projected health preview from collateral and price data", async () => {
+    render(<BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/Amount to Borrow/i), {
+      target: { value: "100" },
+    });
+
+    expect(screen.getByText(/Projected Health Preview/i)).toBeInTheDocument();
+    expect(screen.getByText(/Health factor/i)).toBeInTheDocument();
+    expect(screen.getByText(/Critical/i)).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/prices?assets=USDC,XLM",
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+  });
+
+  it("updates the projected band when collateral amount changes", () => {
+    render(
+      <BorrowingForm
+        initialData={{
+          ...mockInitialData,
+          amount: 100,
+          collateral: "USDC",
+          collateralAmount: 300,
+        }}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    expect(screen.getByText(/Healthy/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Collateral Amount/i), {
+      target: { value: "120" },
+    });
+
+    expect(screen.getByText(/At Risk/i)).toBeInTheDocument();
   });
 
   it("validates insufficient collateral balance", async () => {

--- a/components/features/lending/components/BorrowingForm.tsx
+++ b/components/features/lending/components/BorrowingForm.tsx
@@ -2,11 +2,17 @@
 
 import { useState, useEffect } from "react";
 import { LendingData } from "@/app/lending/page";
-import { Input } from "@/components/shared/ui/Input";
 import Button from "@/components/shared/ui/Button";
 import { cn } from "@/lib/utils/cn";
 import { ASSETS } from "@/lib/assets";
 import AssetSelector from "@/components/shared/ui/AssetSelector";
+import { AmountInput } from "@/components/shared/ui/AmountInput";
+import {
+  FALLBACK_PRICES,
+  calculateProjectedBorrowHealth,
+  getHealthBand,
+  type PriceMap,
+} from "@/lib/lending/health";
 
 interface BorrowingFormProps {
   onSubmit: (data: LendingData) => void;
@@ -29,6 +35,30 @@ const LOAN_DURATIONS = [
   { days: 180, label: "6 Months" },
 ];
 
+const HEALTH_BAND_STYLES = {
+  healthy: {
+    label: "Healthy",
+    text: "text-emerald-700",
+    border: "border-emerald-200",
+    bg: "bg-emerald-50",
+    helper: "Projected collateral buffer is comfortably above the liquidation threshold.",
+  },
+  "at-risk": {
+    label: "At Risk",
+    text: "text-amber-700",
+    border: "border-amber-200",
+    bg: "bg-amber-50",
+    helper: "Projected position is close to the liquidation threshold. Consider adding collateral.",
+  },
+  critical: {
+    label: "Critical",
+    text: "text-red-700",
+    border: "border-red-200",
+    bg: "bg-red-50",
+    helper: "Projected position is immediately vulnerable. Add collateral before submitting.",
+  },
+} as const;
+
 export default function BorrowingForm({
   onSubmit,
   initialData,
@@ -40,6 +70,9 @@ export default function BorrowingForm({
     "idle" | "success" | "error"
   >("idle");
   const [submitMessage, setSubmitMessage] = useState("");
+  const [priceMap, setPriceMap] = useState<PriceMap>(FALLBACK_PRICES);
+  const [usingFallbackPrices, setUsingFallbackPrices] = useState(false);
+  const [isLoadingPrices, setIsLoadingPrices] = useState(false);
 
   const selectedAsset = ASSETS.find((a) => a.symbol === formData.asset);
   const collateralAsset = ASSETS.find((a) => a.symbol === formData.collateral);
@@ -48,6 +81,20 @@ export default function BorrowingForm({
 
   // Calculate required collateral (150% of loan amount)
   const requiredCollateral = formData.amount * 1.5;
+  const collateralAmount = formData.collateralAmount ?? 0;
+  const projectedHealth = calculateProjectedBorrowHealth({
+    loanAmount: formData.amount,
+    borrowAsset: formData.asset,
+    collateralAmount: collateralAmount || requiredCollateral,
+    collateralAsset: formData.collateral ?? "",
+    prices: priceMap,
+  });
+  const projectedBand = projectedHealth
+    ? getHealthBand(projectedHealth.healthFactor)
+    : null;
+  const projectedBandStyle = projectedBand
+    ? HEALTH_BAND_STYLES[projectedBand]
+    : null;
 
   useEffect(() => {
     setFormData((prev) => ({
@@ -56,6 +103,49 @@ export default function BorrowingForm({
       collateralAmount: requiredCollateral,
     }));
   }, [formData.amount, interestRate, requiredCollateral]);
+
+  useEffect(() => {
+    if (!formData.asset || !formData.collateral) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setIsLoadingPrices(true);
+      try {
+        const assets = `${formData.asset},${formData.collateral}`;
+        const response = await fetch(`/api/prices?assets=${assets}`, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error("Price request failed");
+        }
+
+        const data = (await response.json()) as { prices?: PriceMap };
+        if (!data.prices) {
+          throw new Error("Missing prices");
+        }
+
+        setPriceMap((prev) => ({ ...prev, ...data.prices }));
+        setUsingFallbackPrices(false);
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          setPriceMap(FALLBACK_PRICES);
+          setUsingFallbackPrices(true);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoadingPrices(false);
+        }
+      }
+    }, 250);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [formData.asset, formData.collateral]);
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -74,10 +164,15 @@ export default function BorrowingForm({
 
     if (
       collateralAsset &&
-      formData.collateralAmount &&
-      formData.collateralAmount > collateralAsset.balance
+      collateralAmount &&
+      collateralAmount > collateralAsset.balance
     ) {
       newErrors.collateralAmount = "Insufficient collateral balance";
+    } else if (
+      formData.amount > 0 &&
+      collateralAmount < requiredCollateral
+    ) {
+      newErrors.collateralAmount = "Collateral must meet the 150% minimum";
     }
 
     setErrors(newErrors);
@@ -137,7 +232,9 @@ export default function BorrowingForm({
       <form onSubmit={handleSubmit} className="space-y-8">
         {/* Borrow Asset Selection */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">Asset to Borrow <Tooltip content="The asset you wish to borrow (must be collateralized)."><IconButton aria-label="Help" size="sm" variant="ghost" /></Tooltip></label>
+          <label className="block text-sm font-medium text-gray-700 mb-3">
+            Asset to Borrow
+          </label>
           <div className="grid grid-cols-2 gap-4">
             <AssetSelector
               assets={ASSETS}
@@ -160,12 +257,12 @@ export default function BorrowingForm({
           type="number"
           step="0.01"
           placeholder="0.00"
-          value={formData.amount || ""}
+          value={formData.amount || 0}
           error={errors.amount}
-          onChange={(e) => {
+          onChange={(amount) => {
             setFormData((prev) => ({
               ...prev,
-              amount: parseFloat(e.target.value) || 0,
+              amount,
             }));
             if (errors.amount) {
               setErrors((prev) => {
@@ -176,8 +273,6 @@ export default function BorrowingForm({
             }
           }}
           precision={selectedAsset?.precision ?? 2}
-          placeholder="0.00"
-          error={errors.amount}
         />
 
         {/* Loan Duration */}
@@ -273,6 +368,31 @@ export default function BorrowingForm({
           )}
         </div>
 
+        {/* Collateral Amount */}
+        <AmountInput
+          label="Collateral Amount"
+          type="number"
+          step="0.01"
+          placeholder="0.00"
+          value={formData.collateralAmount || 0}
+          error={errors.collateralAmount}
+          helperText={`Minimum required: ${requiredCollateral.toLocaleString()} ${formData.collateral}`}
+          onChange={(collateralAmount) => {
+            setFormData((prev) => ({
+              ...prev,
+              collateralAmount,
+            }));
+            if (errors.collateralAmount) {
+              setErrors((prev) => {
+                const next = { ...prev };
+                delete next.collateralAmount;
+                return next;
+              });
+            }
+          }}
+          precision={collateralAsset?.precision ?? 2}
+        />
+
         {/* Collateral Requirements */}
         {formData.amount > 0 && (
           <div className="bg-amber-50 rounded-xl p-5 border border-amber-100 space-y-3">
@@ -316,6 +436,72 @@ export default function BorrowingForm({
                 aria-live="polite"
               >
                 {errors.collateralAmount}
+              </p>
+            )}
+          </div>
+        )}
+
+        {projectedHealth && projectedBandStyle && (
+          <div
+            className={cn(
+              "rounded-xl p-5 border space-y-3",
+              projectedBandStyle.bg,
+              projectedBandStyle.border,
+            )}
+            aria-live="polite"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3
+                  className={cn(
+                    "text-xs font-bold uppercase tracking-wider",
+                    projectedBandStyle.text,
+                  )}
+                >
+                  Projected Health Preview
+                </h3>
+                <p className="text-xs text-gray-600 mt-1">
+                  Uses the live price feed when available, with a local fallback
+                  for preview-only estimates.
+                </p>
+              </div>
+              <span
+                className={cn(
+                  "text-xs font-bold px-2 py-1 rounded-full bg-white/70",
+                  projectedBandStyle.text,
+                )}
+              >
+                {projectedBandStyle.label}
+              </span>
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-xs font-medium">
+              <div className="rounded-lg bg-white/70 p-3">
+                <span className="block text-gray-500">Health factor</span>
+                <span className={cn("text-lg font-bold", projectedBandStyle.text)}>
+                  {projectedHealth.healthFactor.toFixed(2)}x
+                </span>
+              </div>
+              <div className="rounded-lg bg-white/70 p-3">
+                <span className="block text-gray-500">Liquidation price</span>
+                <span className="text-lg font-bold text-gray-900">
+                  ${projectedHealth.liquidationPrice.toFixed(2)}
+                </span>
+                <span className="block text-gray-500">
+                  per {formData.collateral}
+                </span>
+              </div>
+            </div>
+            <p
+              className={cn("text-xs font-semibold", projectedBandStyle.text)}
+              role={projectedBand === "healthy" ? undefined : "alert"}
+            >
+              {projectedBandStyle.helper}
+            </p>
+            {(usingFallbackPrices || isLoadingPrices) && (
+              <p className="text-[11px] text-gray-500">
+                {isLoadingPrices
+                  ? "Refreshing price data..."
+                  : "Using fallback prices because the live feed is unavailable."}
               </p>
             )}
           </div>

--- a/lib/lending/health.test.ts
+++ b/lib/lending/health.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateProjectedBorrowHealth,
+  getHealthBand,
+} from "@/lib/lending/health";
+
+const prices = {
+  USDC: 1,
+  XLM: 0.12,
+  ETH: 3500,
+};
+
+describe("lending health preview", () => {
+  it("calculates projected health factor and liquidation price", () => {
+    const preview = calculateProjectedBorrowHealth({
+      loanAmount: 100,
+      borrowAsset: "USDC",
+      collateralAmount: 300,
+      collateralAsset: "USDC",
+      prices,
+    });
+
+    expect(preview).toEqual(
+      expect.objectContaining({
+        healthFactor: 2.5,
+        liquidationPrice: 0.4,
+        loanValueUsd: 100,
+        collateralValueUsd: 300,
+      }),
+    );
+  });
+
+  it("returns no preview when inputs or prices are missing", () => {
+    expect(
+      calculateProjectedBorrowHealth({
+        loanAmount: 0,
+        borrowAsset: "USDC",
+        collateralAmount: 300,
+        collateralAsset: "USDC",
+        prices,
+      }),
+    ).toBeNull();
+
+    expect(
+      calculateProjectedBorrowHealth({
+        loanAmount: 100,
+        borrowAsset: "BTC",
+        collateralAmount: 300,
+        collateralAsset: "USDC",
+        prices,
+      }),
+    ).toBeNull();
+  });
+
+  it("maps health bands to the PositionSummary thresholds", () => {
+    expect(getHealthBand(2)).toBe("healthy");
+    expect(getHealthBand(1.5)).toBe("at-risk");
+    expect(getHealthBand(0.99)).toBe("critical");
+  });
+});

--- a/lib/lending/health.ts
+++ b/lib/lending/health.ts
@@ -1,0 +1,75 @@
+export type HealthBand = "healthy" | "at-risk" | "critical";
+
+export type PriceMap = Record<string, number>;
+
+export const LIQUIDATION_THRESHOLD_RATIO = 1.2;
+
+export const FALLBACK_PRICES: PriceMap = {
+  XLM: 0.12,
+  USDC: 1,
+  BTC: 65000,
+  ETH: 3500,
+};
+
+export interface BorrowHealthInput {
+  loanAmount: number;
+  borrowAsset: string;
+  collateralAmount: number;
+  collateralAsset: string;
+  prices: PriceMap;
+}
+
+export interface BorrowHealthPreview {
+  healthFactor: number;
+  liquidationPrice: number;
+  loanValueUsd: number;
+  collateralValueUsd: number;
+}
+
+export function getHealthBand(healthFactor: number): HealthBand {
+  if (healthFactor >= 2) {
+    return "healthy";
+  }
+
+  if (healthFactor >= 1) {
+    return "at-risk";
+  }
+
+  return "critical";
+}
+
+export function calculateProjectedBorrowHealth({
+  loanAmount,
+  borrowAsset,
+  collateralAmount,
+  collateralAsset,
+  prices,
+}: BorrowHealthInput): BorrowHealthPreview | null {
+  const borrowPrice = prices[borrowAsset];
+  const collateralPrice = prices[collateralAsset];
+
+  if (
+    loanAmount <= 0 ||
+    collateralAmount <= 0 ||
+    !borrowPrice ||
+    !collateralPrice
+  ) {
+    return null;
+  }
+
+  const loanValueUsd = loanAmount * borrowPrice;
+  const collateralValueUsd = collateralAmount * collateralPrice;
+
+  if (loanValueUsd <= 0) {
+    return null;
+  }
+
+  return {
+    healthFactor:
+      collateralValueUsd / (loanValueUsd * LIQUIDATION_THRESHOLD_RATIO),
+    liquidationPrice:
+      (loanValueUsd * LIQUIDATION_THRESHOLD_RATIO) / collateralAmount,
+    loanValueUsd,
+    collateralValueUsd,
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable lending health preview helpers and tests
- show BorrowingForm users a projected health factor, liquidation price, and health-band warning before submission
- fetch price estimates with a fallback so the preview still renders when the feed is unavailable
- document the formula and example calculation

Closes #357

## Validation
- Added Vitest coverage for the health calculation helper and BorrowingForm preview behavior.
- Not run locally: this desktop does not have Node/npm configured, so I could not execute the project test suite here.