### PR TITLE
test(api): add notification mark-read route tests

### DIFF
--- a/app/api/notifications/[id]/route.test.ts
+++ b/app/api/notifications/[id]/route.test.ts
@@ -1,0 +1,120 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock('@/lib/notifications/repository', () => ({
+  markNotificationRead: vi.fn(),
+}));
+
+vi.mock('@/lib/api/handler', () => ({
+  withCsrfProtection: <T extends (...args: any[]) => any>(handler: T) => handler,
+}));
+
+import { PATCH } from './route';
+import { getUser } from '@/lib/auth';
+import { markNotificationRead } from '@/lib/notifications/repository';
+import type { Notification } from '@/lib/notifications/types';
+
+const mockGetUser = vi.mocked(getUser);
+const mockMarkNotificationRead = vi.mocked(markNotificationRead);
+
+function patchRequest(id = 'notif-1') {
+  return new NextRequest(`http://localhost:3000/api/notifications/${id}`, {
+    method: 'PATCH',
+  });
+}
+
+function routeContext(id: string) {
+  return {
+    params: Promise.resolve({ id }),
+  };
+}
+
+function notification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: 'notif-1',
+    userId: 'user-1',
+    title: 'Deposit Confirmed',
+    message: 'Your deposit has been confirmed.',
+    read: true,
+    createdAt: '2026-05-26T10:00:00.000Z',
+    type: 'success',
+    ...overrides,
+  };
+}
+
+describe('PATCH /api/notifications/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when the user is not authenticated', async () => {
+    mockGetUser.mockResolvedValueOnce(null as any);
+
+    const response = await PATCH(patchRequest(), routeContext('notif-1'));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: 'Unauthorized' });
+    expect(mockMarkNotificationRead).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a blank notification id', async () => {
+    mockGetUser.mockResolvedValueOnce({ id: 'user-1' } as any);
+
+    const response = await PATCH(patchRequest('blank'), routeContext('   '));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: 'Invalid notification id' });
+    expect(mockMarkNotificationRead).not.toHaveBeenCalled();
+  });
+
+  it('marks the current user notification read and returns the updated record', async () => {
+    const updated = notification();
+    mockGetUser.mockResolvedValueOnce({ id: 'user-1' } as any);
+    mockMarkNotificationRead.mockResolvedValueOnce(updated);
+
+    const response = await PATCH(patchRequest(), routeContext('notif-1'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockMarkNotificationRead).toHaveBeenCalledWith('user-1', 'notif-1');
+    expect(body).toEqual({ notification: updated });
+  });
+
+  it('trims the route id before sending it to the repository', async () => {
+    const updated = notification({ id: 'notif-trimmed' });
+    mockGetUser.mockResolvedValueOnce({ id: 'user-1' } as any);
+    mockMarkNotificationRead.mockResolvedValueOnce(updated);
+
+    const response = await PATCH(patchRequest('notif-trimmed'), routeContext(' notif-trimmed '));
+
+    expect(response.status).toBe(200);
+    expect(mockMarkNotificationRead).toHaveBeenCalledWith('user-1', 'notif-trimmed');
+  });
+
+  it('returns 404 when the notification id is unknown for the current user', async () => {
+    mockGetUser.mockResolvedValueOnce({ id: 'user-1' } as any);
+    mockMarkNotificationRead.mockResolvedValueOnce(null);
+
+    const response = await PATCH(patchRequest('missing'), routeContext('missing'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({ error: 'Notification not found' });
+  });
+
+  it('does not expose another user notification when the repository denies ownership', async () => {
+    mockGetUser.mockResolvedValueOnce({ id: 'user-2' } as any);
+    mockMarkNotificationRead.mockResolvedValueOnce(null);
+
+    const response = await PATCH(patchRequest('notif-1'), routeContext('notif-1'));
+
+    expect(response.status).toBe(404);
+    expect(mockMarkNotificationRead).toHaveBeenCalledWith('user-2', 'notif-1');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
             "types/enums.test.ts",
             "app/api/transactions/route.test.ts",
             "app/api/liquidations/route.test.ts",
+            "app/api/notifications/[id]/route.test.ts",
             "__tests__/**/*.test.ts",
           ],
         },


### PR DESCRIPTION
## Summary
- Adds focused server-unit coverage for PATCH /api/notifications/[id].
- Covers unauthenticated access, blank ids, successful mark-as-read, id trimming, missing notifications, and ownership denial.
- Adds the route test path to the server-unit project include list so 	est:server can discover it.

## Validation
- itest run --project server-unit app/api/notifications/[id]/route.test.ts --reporter=basic passes: 1 file, 6 tests.
- git diff --check passes.
- Broader server-unit collection currently hits unrelated existing failures in other suites/files, so I kept validation focused on this route.

Closes #364
## CI note
The targeted route test passes locally. The current GitHub Actions failures appear to be repository baseline issues, not this PR's route-test change:
- Recent main runs for the same workflows are also failing on commit 2c945e.
- 
pm ci fails because the committed package-lock.json contains unresolved merge markers and cannot be parsed.
- Build and Test / Security Scan also fail at setup because they still use deprecated ctions/upload-artifact@v3.

I kept this PR focused on #364 instead of expanding it into a broader CI/workflow repair.