### PR TITLE
fix(security): use timing-safe webhook signature checks

### DIFF
--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -26,11 +26,19 @@ HMAC-SHA256(WEBHOOK_SECRET, raw-request-body)
 
 > **Important:** The signature is computed over the **raw** request body string — not a re-serialised version. Whitespace, key order, and encoding must be preserved exactly.
 
+### Constant-Time Verification
+
+The server verifies the digest with Node.js `crypto.timingSafeEqual`. Malformed,
+missing, wrong-length, and wrong-value signatures are normalized through the same
+fixed-length comparison path before the request is rejected with `401`. This
+avoids exposing signature validity through simple timing differences. The
+server never logs the shared secret or the full received signature on failure.
+
 ### Environment Variable
 
-| Variable | Required | Description |
-|---|---|---|
-| `WEBHOOK_SECRET` | ✅ Yes | Shared HMAC secret. **Server-only** — do NOT prefix with `NEXT_PUBLIC_`. |
+| Variable         | Required | Description                                                              |
+| ---------------- | -------- | ------------------------------------------------------------------------ |
+| `WEBHOOK_SECRET` | ✅ Yes   | Shared HMAC secret. **Server-only** — do NOT prefix with `NEXT_PUBLIC_`. |
 
 For local development, add to `.env.local`:
 
@@ -42,10 +50,10 @@ WEBHOOK_SECRET=your-secret-key-here
 
 ### Headers
 
-| Header | Required | Description |
-|---|---|---|
-| `Content-Type` | Yes | Must be `application/json` |
-| `x-webhook-signature` | Yes | `sha256=<hex-digest>` HMAC signature |
+| Header                | Required | Description                          |
+| --------------------- | -------- | ------------------------------------ |
+| `Content-Type`        | Yes      | Must be `application/json`           |
+| `x-webhook-signature` | Yes      | `sha256=<hex-digest>` HMAC signature |
 
 ### Body
 
@@ -63,13 +71,13 @@ WEBHOOK_SECRET=your-secret-key-here
 
 ### Field Reference
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `event` | `string` | ✅ | Must be `"transaction.status_updated"` |
-| `timestamp` | `number` | ✅ | Unix timestamp in **milliseconds** (e.g. `Date.now()`). Must be within ±5 minutes of server time. |
-| `nonce` | `string` | ✅ | Unique event ID (UUID v4 recommended). Prevents replay attacks. |
-| `data.transaction_id` | `string` | ✅ | Stellarlend transaction ID (e.g. `"TXN12345"`) |
-| `data.status` | `TransactionStatus` | ✅ | New status. One of: `"Completed"`, `"Processing"`, `"Failed"` |
+| Field                 | Type                | Required | Description                                                                                       |
+| --------------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `event`               | `string`            | ✅       | Must be `"transaction.status_updated"`                                                            |
+| `timestamp`           | `number`            | ✅       | Unix timestamp in **milliseconds** (e.g. `Date.now()`). Must be within ±5 minutes of server time. |
+| `nonce`               | `string`            | ✅       | Unique event ID (UUID v4 recommended). Prevents replay attacks.                                   |
+| `data.transaction_id` | `string`            | ✅       | Stellarlend transaction ID (e.g. `"TXN12345"`)                                                    |
+| `data.status`         | `TransactionStatus` | ✅       | New status. One of: `"Completed"`, `"Processing"`, `"Failed"`                                     |
 
 ## Replay Protection
 
@@ -80,15 +88,15 @@ Two mechanisms prevent replay attacks:
 
 ## Response Codes
 
-| Code | Meaning | When |
-|---|---|---|
-| `200` | Success | Event processed, transaction status updated |
-| `400` | Bad Request | Invalid JSON, unsupported event type, missing fields, or unknown status value |
-| `401` | Unauthorized | Missing or invalid `x-webhook-signature` |
-| `403` | Forbidden | Timestamp outside ±5 minute tolerance window |
-| `404` | Not Found | `transaction_id` does not exist |
-| `409` | Conflict | Duplicate `nonce` (event already processed) |
-| `500` | Internal Server Error | `WEBHOOK_SECRET` environment variable not configured |
+| Code  | Meaning               | When                                                                          |
+| ----- | --------------------- | ----------------------------------------------------------------------------- |
+| `200` | Success               | Event processed, transaction status updated                                   |
+| `400` | Bad Request           | Invalid JSON, unsupported event type, missing fields, or unknown status value |
+| `401` | Unauthorized          | Missing or invalid `x-webhook-signature`                                      |
+| `403` | Forbidden             | Timestamp outside ±5 minute tolerance window                                  |
+| `404` | Not Found             | `transaction_id` does not exist                                               |
+| `409` | Conflict              | Duplicate `nonce` (event already processed)                                   |
+| `500` | Internal Server Error | `WEBHOOK_SECRET` environment variable not configured                          |
 
 ### Success Response
 
@@ -178,9 +186,9 @@ npx vitest run --project unit --coverage
 
 ## File Map
 
-| File | Purpose |
-|---|---|
-| `app/api/webhooks/transactions/route.ts` | Webhook route handler |
-| `lib/webhooks/verify.ts` | Signature verification, timestamp validation, nonce store |
-| `lib/webhooks/types.ts` | `WebhookPayload` interface and constants |
-| `lib/transactions/store.ts` | In-memory transaction data layer |
+| File                                     | Purpose                                                   |
+| ---------------------------------------- | --------------------------------------------------------- |
+| `app/api/webhooks/transactions/route.ts` | Webhook route handler                                     |
+| `lib/webhooks/verify.ts`                 | Signature verification, timestamp validation, nonce store |
+| `lib/webhooks/types.ts`                  | `WebhookPayload` interface and constants                  |
+| `lib/transactions/store.ts`              | In-memory transaction data layer                          |

--- a/app/api/webhooks/transactions/__tests__/route_memo.test.ts
+++ b/app/api/webhooks/transactions/__tests__/route_memo.test.ts
@@ -10,9 +10,14 @@ import {
   deriveAndRegisterMemo,
 } from "@/lib/stellar/memo";
 
+vi.mock("@/lib/notifications/repository", () => ({
+  enqueueNotificationInBackground: vi.fn(),
+}));
+
 // Mock store to control getTransaction in tests precisely
 vi.mock("@/lib/transactions/store", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/lib/transactions/store")>();
+  const original =
+    await importOriginal<typeof import("@/lib/transactions/store")>();
   let mockStore = new Map<string, any>();
 
   return {
@@ -65,7 +70,10 @@ function makePayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeWebhookRequest(body: string, headers: Record<string, string> = {}) {
+function makeWebhookRequest(
+  body: string,
+  headers: Record<string, string> = {},
+) {
   return new NextRequest("http://localhost/api/webhooks/transactions", {
     method: "POST",
     body,
@@ -76,7 +84,10 @@ function makeWebhookRequest(body: string, headers: Record<string, string> = {}) 
   });
 }
 
-function makeSignedRequest(payload: Record<string, unknown>, secret: string = TEST_SECRET) {
+function makeSignedRequest(
+  payload: Record<string, unknown>,
+  secret: string = TEST_SECRET,
+) {
   const body = JSON.stringify(payload);
   const signature = signPayload(body, secret);
   return makeWebhookRequest(body, { [SIGNATURE_HEADER]: signature });
@@ -114,6 +125,27 @@ describe("Webhook Route - Stellar Memo Enforcement", () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.transaction.status).toBe("Completed");
+  });
+
+  it("returns 401 for a wrong-length signature before memo validation", async () => {
+    const payload = makePayload({
+      data: {
+        transaction_id: "TXN12345",
+        status: "Completed",
+        memo: "not-an-unsigned-int",
+        memo_type: "MEMO_ID",
+      },
+    });
+    const body = JSON.stringify(payload);
+    const req = makeWebhookRequest(body, {
+      [SIGNATURE_HEADER]: "sha256=abc123",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const json = await res.json();
+    expect(json.error).toMatch(/signature/i);
   });
 
   it("returns 400 when a malformed memo value is provided", async () => {
@@ -163,7 +195,9 @@ describe("Webhook Route - Stellar Memo Enforcement", () => {
     expect(res.status).toBe(400);
 
     const body = await res.json();
-    expect(body.error).toContain("Strict Mode Rejection: Unknown or unregistered memo");
+    expect(body.error).toContain(
+      "Strict Mode Rejection: Unknown or unregistered memo",
+    );
   });
 
   it("returns 400 when Deposit transaction lacks a memo in strict mode", async () => {
@@ -180,7 +214,9 @@ describe("Webhook Route - Stellar Memo Enforcement", () => {
     expect(res.status).toBe(400);
 
     const body = await res.json();
-    expect(body.error).toContain("Strict Mode Rejection: Inbound deposits must have a valid memo");
+    expect(body.error).toContain(
+      "Strict Mode Rejection: Inbound deposits must have a valid memo",
+    );
   });
 
   it("succeeds when non-Deposit transaction lacks a memo in strict mode", async () => {

--- a/app/api/webhooks/transactions/route.test.ts
+++ b/app/api/webhooks/transactions/route.test.ts
@@ -1,9 +1,55 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { POST } from "@/app/api/webhooks/transactions/route";
-import { signPayload } from "@/lib/webhooks/verify";
+import { signPayload, verifyWebhookSignature } from "@/lib/webhooks/verify";
 import { SIGNATURE_HEADER } from "@/lib/webhooks/types";
 import { resetStore, getTransaction } from "@/lib/transactions/store";
+
+vi.mock("@/lib/notifications/repository", () => ({
+  enqueueNotificationInBackground: vi.fn(),
+}));
+
+vi.mock("@/lib/transactions/store", () => {
+  let mockStore = new Map<string, any>();
+
+  return {
+    getTransaction: vi.fn(async (id: string) => mockStore.get(id)),
+    updateTransactionStatus: vi.fn(async (id: string, status: any) => {
+      const tx = mockStore.get(id);
+      if (!tx) return null;
+      tx.status = status;
+      return tx;
+    }),
+    resetStore: vi.fn(() => {
+      mockStore = new Map([
+        [
+          "TXN12345",
+          {
+            id: "TXN12345",
+            type: "Loan Payment",
+            amount: -250,
+            asset: "BTC",
+            date: "2025-03-10",
+            time: "11:15AM",
+            status: "Completed",
+          },
+        ],
+        [
+          "TXN12346",
+          {
+            id: "TXN12346",
+            type: "Loan Payment",
+            amount: -250,
+            asset: "BTC",
+            date: "2025-03-10",
+            time: "11:15AM",
+            status: "Processing",
+          },
+        ],
+      ]);
+    }),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -58,6 +104,46 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// Signature helper
+// ---------------------------------------------------------------------------
+
+describe("verifyWebhookSignature", () => {
+  it("accepts a valid sha256 signature", () => {
+    const body = JSON.stringify(makePayload());
+    const signature = signPayload(body, TEST_SECRET);
+
+    expect(verifyWebhookSignature(body, signature, TEST_SECRET)).toBe(true);
+  });
+
+  it("rejects missing, malformed, wrong-length, and wrong-value signatures", () => {
+    const body = JSON.stringify(makePayload());
+    const validSignature = signPayload(body, TEST_SECRET);
+
+    expect(verifyWebhookSignature(body, null, TEST_SECRET)).toBe(false);
+    expect(
+      verifyWebhookSignature(body, "not-a-sha256-signature", TEST_SECRET),
+    ).toBe(false);
+    expect(verifyWebhookSignature(body, "sha256=abc123", TEST_SECRET)).toBe(
+      false,
+    );
+    const wrongValueSignature =
+      validSignature.slice(0, -1) + (validSignature.endsWith("0") ? "1" : "0");
+    expect(verifyWebhookSignature(body, wrongValueSignature, TEST_SECRET)).toBe(
+      false,
+    );
+  });
+
+  it("rejects a signature after the signed body is tampered", () => {
+    const body = JSON.stringify(makePayload());
+    const signature = signPayload(body, TEST_SECRET);
+
+    expect(verifyWebhookSignature(`${body} `, signature, TEST_SECRET)).toBe(
+      false,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -131,6 +217,36 @@ describe("POST /api/webhooks/transactions – signature verification", () => {
     const signature = signPayload(body, "wrong-secret");
     const req = makeWebhookRequest(body, { [SIGNATURE_HEADER]: signature });
     const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when signature has the right prefix but the wrong length", async () => {
+    const payload = makePayload();
+    const body = JSON.stringify(payload);
+    const req = makeWebhookRequest(body, {
+      [SIGNATURE_HEADER]: "sha256=abc123",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/signature/i);
+  });
+
+  it("returns 401 when the body changes after signing", async () => {
+    const originalPayload = makePayload();
+    const originalBody = JSON.stringify(originalPayload);
+    const signature = signPayload(originalBody, TEST_SECRET);
+    const tamperedBody = JSON.stringify({
+      ...originalPayload,
+      data: { transaction_id: "TXN12346", status: "Failed" },
+    });
+
+    const req = makeWebhookRequest(tamperedBody, {
+      [SIGNATURE_HEADER]: signature,
+    });
+    const res = await POST(req);
+
     expect(res.status).toBe(401);
   });
 });
@@ -282,7 +398,9 @@ describe("POST /api/webhooks/transactions – body read error", () => {
     const req = new NextRequest("http://localhost/api/webhooks/transactions", {
       method: "POST",
     });
-    vi.spyOn(req, "text").mockRejectedValue(new Error("Simulated stream read error"));
+    vi.spyOn(req, "text").mockRejectedValue(
+      new Error("Simulated stream read error"),
+    );
     const res = await POST(req);
     expect(res.status).toBe(400);
 

--- a/app/api/webhooks/transactions/route.ts
+++ b/app/api/webhooks/transactions/route.ts
@@ -7,8 +7,16 @@ import {
 } from "@/lib/webhooks/verify";
 import { SIGNATURE_HEADER } from "@/lib/webhooks/types";
 import type { WebhookPayload } from "@/lib/webhooks/types";
-import { updateTransactionStatus } from "@/lib/transactions/store";
+import {
+  getTransaction,
+  updateTransactionStatus,
+} from "@/lib/transactions/store";
 import { enqueueNotificationInBackground } from "@/lib/notifications/repository";
+import {
+  isStrictModeEnabled,
+  resolveAccountByMemo,
+  validateMemo,
+} from "@/lib/stellar/memo";
 
 export const runtime = "nodejs";
 
@@ -49,7 +57,7 @@ export async function POST(req: NextRequest) {
 
   // ── 3. Verify signature ─────────────────────────────────────────────────
   const signature = req.headers.get(SIGNATURE_HEADER);
-  if (!signature || !verifyWebhookSignature(rawBody, signature, secret)) {
+  if (!verifyWebhookSignature(rawBody, signature, secret)) {
     return NextResponse.json(
       { error: "Invalid or missing webhook signature" },
       { status: 401 },
@@ -61,10 +69,7 @@ export async function POST(req: NextRequest) {
   try {
     payload = JSON.parse(rawBody);
   } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
   if (payload.event !== "transaction.status_updated") {
@@ -125,8 +130,8 @@ export async function POST(req: NextRequest) {
   const memoType = rawData.memo_type;
 
   if (memo || memoType) {
-    const type = (memoType || 'MEMO_TEXT') as any;
-    const value = memo || '';
+    const type = (memoType || "MEMO_TEXT") as any;
+    const value = memo || "";
 
     // Validate format
     if (!validateMemo(value, type)) {
@@ -140,16 +145,20 @@ export async function POST(req: NextRequest) {
     const accountId = resolveAccountByMemo(value, type);
     if (!accountId && isStrictModeEnabled()) {
       return NextResponse.json(
-        { error: `Strict Mode Rejection: Unknown or unregistered memo: "${value}"` },
+        {
+          error: `Strict Mode Rejection: Unknown or unregistered memo: "${value}"`,
+        },
         { status: 400 },
       );
     }
   } else if (isStrictModeEnabled()) {
     // If in strict mode, ensure inbound deposits always specify a memo.
     const existingTx = await getTransaction(payload.data.transaction_id);
-    if (existingTx && existingTx.type === 'Deposit') {
+    if (existingTx && existingTx.type === "Deposit") {
       return NextResponse.json(
-        { error: `Strict Mode Rejection: Inbound deposits must have a valid memo` },
+        {
+          error: `Strict Mode Rejection: Inbound deposits must have a valid memo`,
+        },
         { status: 400 },
       );
     }
@@ -169,10 +178,15 @@ export async function POST(req: NextRequest) {
   }
 
   // Enqueue notification fan-out job (fire-and-forget)
-  enqueueNotificationInBackground('demo-user', {
-    title: 'Transaction Status Update',
+  enqueueNotificationInBackground("demo-user", {
+    title: "Transaction Status Update",
     message: `Your transaction ${payload.data.transaction_id} is now ${payload.data.status}.`,
-    type: payload.data.status === 'Completed' ? 'success' : payload.data.status === 'Failed' ? 'error' : 'info',
+    type:
+      payload.data.status === "Completed"
+        ? "success"
+        : payload.data.status === "Failed"
+          ? "error"
+          : "info",
   });
 
   return NextResponse.json({ success: true, transaction: updated });

--- a/lib/webhooks/verify.ts
+++ b/lib/webhooks/verify.ts
@@ -4,6 +4,9 @@ import { createHmac, timingSafeEqual } from "crypto";
  * Default tolerance for timestamp validation (5 minutes in milliseconds).
  */
 export const DEFAULT_TOLERANCE_MS = 5 * 60 * 1000;
+const SIGNATURE_PREFIX = "sha256=";
+const SHA256_HEX_LENGTH = 64;
+const SHA256_BYTE_LENGTH = 32;
 
 // ---------------------------------------------------------------------------
 // Signature verification
@@ -22,32 +25,34 @@ export const DEFAULT_TOLERANCE_MS = 5 * 60 * 1000;
  */
 export function verifyWebhookSignature(
   payload: string,
-  signature: string,
+  signature: string | null | undefined,
   secret: string,
 ): boolean {
-  if (!signature || !secret || !payload) {
+  if (!secret || typeof payload !== "string") {
     return false;
   }
 
-  const prefix = "sha256=";
-  if (!signature.startsWith(prefix)) {
-    return false;
-  }
-
-  const receivedHex = signature.slice(prefix.length);
   const expectedHex = createHmac("sha256", secret)
     .update(payload)
     .digest("hex");
+  const expected = Buffer.from(expectedHex, "hex");
 
-  // timingSafeEqual requires equal-length buffers
-  if (receivedHex.length !== expectedHex.length) {
-    return false;
-  }
+  const receivedHex =
+    signature?.startsWith(SIGNATURE_PREFIX) === true
+      ? signature.slice(SIGNATURE_PREFIX.length)
+      : "";
+  const hasValidFormat = /^[0-9a-f]{64}$/i.test(receivedHex);
+  const received = hasValidFormat
+    ? Buffer.from(receivedHex, "hex")
+    : Buffer.alloc(SHA256_BYTE_LENGTH);
 
-  return timingSafeEqual(
-    Buffer.from(receivedHex, "hex"),
-    Buffer.from(expectedHex, "hex"),
-  );
+  // Always compare equal-length buffers so malformed, missing, and wrong-length
+  // signatures take the same verification path before returning false.
+  const isSameLength =
+    receivedHex.length === SHA256_HEX_LENGTH &&
+    received.length === expected.length;
+  const signaturesMatch = timingSafeEqual(received, expected);
+  return hasValidFormat && isSameLength && signaturesMatch;
 }
 
 /**


### PR DESCRIPTION
Closes #368

## Summary
- Harden webhook HMAC verification so missing, malformed, wrong-length, and wrong-value signatures all flow through a fixed-length `crypto.timingSafeEqual` comparison path before returning `401`.
- Remove the route-level missing-signature short circuit and import the memo helpers used by the existing route logic.
- Extend webhook route and memo tests for valid signatures, wrong-length signatures, tampered bodies, and helper-level rejection cases.
- Document the constant-time verification behavior in `WEBHOOKS.md`.

## Tests
- `node_modules/.bin/vitest.cmd run --config vitest.server.config.ts app/api/webhooks/transactions/route.test.ts app/api/webhooks/transactions/__tests__/route_memo.test.ts`

## Notes
- The test command passes with 32 tests. It emits a pre-existing package warning about duplicate `drizzle-kit` keys in `package.json`.
- `pnpm install --frozen-lockfile` is currently blocked by an existing package/lockfile mismatch; no lockfile changes are included in this PR.