### PR TITLE
test(api): cover markets route contract

### DIFF
--- a/MARKETS_API.md
+++ b/MARKETS_API.md
@@ -1,0 +1,49 @@
+# Markets API
+
+`GET /api/markets` returns the lending-market rates consumed by the lending and borrowing forms.
+
+## Query
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `asset` | No | Comma-separated asset symbols. Values are case-insensitive and normalized to the canonical symbols `XLM`, `USDC`, `BTC`, and `ETH`. Omit the parameter to request every supported market. |
+
+Unknown symbols return `400` with a list of supported assets.
+
+## Response
+
+Successful responses use this shape:
+
+```json
+{
+  "markets": [
+    {
+      "asset": "XLM",
+      "supplyApr": 8.5,
+      "borrowApr": 12,
+      "utilization": 0.71,
+      "totalSupply": 2500000,
+      "totalBorrow": 1775000
+    }
+  ],
+  "timestamp": "2026-06-21T12:00:00.000Z",
+  "source": "Soroban RPC stub (server relay)"
+}
+```
+
+`supplyApr` and `borrowApr` are annual percentage rates. `utilization` is a decimal from `0` to `1`.
+
+## Caching
+
+Public requests are cached for `30` seconds with `60` seconds of stale-while-revalidate support:
+
+```http
+Cache-Control: public, max-age=30, stale-while-revalidate=60
+```
+
+Requests with an `Authorization` header, `session` or `token` cookie, or `x-user-id` header bypass shared caching and return:
+
+```http
+Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate
+X-Cache: BYPASS
+```

--- a/app/api/markets/route.test.ts
+++ b/app/api/markets/route.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import { globalCache } from '@/lib/cache';
+import { fetchMarkets } from '@/lib/markets/repository';
+import type { MarketsResponse } from '@/lib/markets/types';
+
+vi.mock('@/lib/cache', () => ({
+  globalCache: {
+    getOrFetch: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/markets/repository', () => ({
+  fetchMarkets: vi.fn(),
+}));
+
+const marketsResponse: MarketsResponse = {
+  markets: [
+    {
+      asset: 'XLM',
+      supplyApr: 8.5,
+      borrowApr: 12,
+      utilization: 0.71,
+      totalSupply: 2_500_000,
+      totalBorrow: 1_775_000,
+    },
+    {
+      asset: 'USDC',
+      supplyApr: 5.2,
+      borrowApr: 7.8,
+      utilization: 0.65,
+      totalSupply: 10_000_000,
+      totalBorrow: 6_500_000,
+    },
+  ],
+  timestamp: '2026-06-21T12:00:00.000Z',
+  source: 'Soroban RPC stub (server relay)',
+};
+
+function makeRequest(path = '/api/markets', headers?: HeadersInit) {
+  return new NextRequest(`http://localhost:3000${path}`, { headers });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(globalCache.getOrFetch).mockResolvedValue({
+    value: marketsResponse,
+    status: 'MISS',
+  });
+  vi.mocked(fetchMarkets).mockResolvedValue(marketsResponse);
+});
+
+describe('GET /api/markets', () => {
+  it('returns the markets response contract for all supported assets', async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=30, stale-while-revalidate=60');
+    expect(response.headers.get('X-Cache')).toBe('MISS');
+    expect(body).toEqual(marketsResponse);
+    expect(body.markets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          asset: 'XLM',
+          supplyApr: expect.any(Number),
+          borrowApr: expect.any(Number),
+        }),
+        expect.objectContaining({
+          asset: 'USDC',
+          supplyApr: expect.any(Number),
+          borrowApr: expect.any(Number),
+        }),
+      ]),
+    );
+    expect(globalCache.getOrFetch).toHaveBeenCalledWith(
+      'markets:assets:BTC,ETH,USDC,XLM',
+      expect.any(Function),
+      { ttl: 30_000, swr: 60_000 },
+    );
+  });
+
+  it('normalizes and filters requested assets case-insensitively', async () => {
+    const response = await GET(makeRequest('/api/markets?asset=xlm,%20usdc%20'));
+
+    expect(response.status).toBe(200);
+    expect(globalCache.getOrFetch).toHaveBeenCalledWith(
+      'markets:assets:USDC,XLM',
+      expect.any(Function),
+      { ttl: 30_000, swr: 60_000 },
+    );
+  });
+
+  it('uses an order-invariant cache key for multi-asset filters', async () => {
+    await GET(makeRequest('/api/markets?asset=USDC,XLM'));
+    await GET(makeRequest('/api/markets?asset=XLM,USDC'));
+
+    expect(vi.mocked(globalCache.getOrFetch).mock.calls.map(([cacheKey]) => cacheKey)).toEqual([
+      'markets:assets:USDC,XLM',
+      'markets:assets:USDC,XLM',
+    ]);
+  });
+
+  it('rejects unknown assets before fetching market data', async () => {
+    const response = await GET(makeRequest('/api/markets?asset=XLM,DOGE'));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('Unknown asset(s): DOGE');
+    expect(body.error).toContain('Supported: XLM, USDC, BTC, ETH');
+    expect(globalCache.getOrFetch).not.toHaveBeenCalled();
+    expect(fetchMarkets).not.toHaveBeenCalled();
+  });
+
+  it('bypasses public cache for authenticated requests', async () => {
+    const response = await GET(makeRequest('/api/markets?asset=XLM', { Authorization: 'Bearer test-token' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Cache')).toBe('BYPASS');
+    expect(response.headers.get('Cache-Control')).toBe('no-store, no-cache, must-revalidate, proxy-revalidate');
+    expect(body).toEqual(marketsResponse);
+    expect(fetchMarkets).toHaveBeenCalledWith(['XLM']);
+    expect(globalCache.getOrFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the market repository fails', async () => {
+    vi.mocked(globalCache.getOrFetch).mockRejectedValueOnce(new Error('upstream down'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const response = await GET(makeRequest('/api/markets?asset=XLM'));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: 'Failed to fetch market data' });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
 
           include: [
             "types/enums.test.ts",
+            "app/api/markets/route.test.ts",
             "app/api/transactions/route.test.ts",
             "app/api/liquidations/route.test.ts",
             "__tests__/**/*.test.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -101,7 +101,10 @@ export default defineConfig({
         test: {
           name: "server",
           environment: "node",
-          include: ["test/server/**/*.test.ts"],
+          include: [
+            "test/server/**/*.test.ts",
+            "app/api/markets/route.test.ts",
+          ],
           alias: {
             "@": path.resolve(dirname, "."),
           },


### PR DESCRIPTION
Closes #365

## Summary
- add focused tests for `GET /api/markets` response shape, asset filtering, invalid assets, cache behavior, authenticated cache bypass, and repository failure handling
- document the markets API response contract, query parameter, and caching semantics in `MARKETS_API.md`
- include the markets route test in the server-unit Vitest project so it is exercised by the server test suite

## Validation
- `./node_modules/.bin/vitest run --project server-unit app/api/markets/route.test.ts` — 6 tests passed
- `git diff --check`

## Notes
- `pnpm vitest ...` initially installed dependencies but exited on the repo pnpm build-script policy for `@sentry/cli`; running the installed Vitest binary executed the test successfully.
- `./node_modules/.bin/tsc --noEmit --pretty false` is currently blocked by pre-existing syntax errors outside this change, including `app/api/health/route.ts`, `app/lending/page.tsx`, `lib/api/handler.ts`, and related files.