### PR TITLE
perf: memoise PositionSummary rendering

### DIFF
--- a/POSITION_SUMMARY_QUICK_REFERENCE.md
+++ b/POSITION_SUMMARY_QUICK_REFERENCE.md
@@ -82,6 +82,12 @@ The component is already integrated into the dashboard:
 4. Component renders with appropriate styling
 5. Displays breakdown of supplied/borrowed amounts
 
+## Performance
+
+- `PositionSummary` memoises derived net-position and health-status display values from the specific input fields (`suppliedFunds`, `borrowedAmount`, `healthFactor`, and `isLoading`) instead of the full `data` object reference.
+- The exported component is wrapped in `React.memo` with a field-level comparator, so dashboard polling that returns a new object with unchanged values does not force the summary card to render again.
+- Before: identical polling payloads with new object references could still re-enter the component subtree. After: the comparator skips those renders until one of the displayed health inputs or loading state changes.
+
 ## 🎨 Styling
 
 - **Container**: Dark green gradient with border

--- a/components/features/dashboard/components/PositionSummary.test.tsx
+++ b/components/features/dashboard/components/PositionSummary.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@/test/test-utils";
-import PositionSummary from "./PositionSummary";
+import PositionSummary, { arePositionSummaryPropsEqual } from "./PositionSummary";
 import { describe, it, expect } from "vitest";
 
 describe("PositionSummary Component", () => {
@@ -410,6 +410,40 @@ describe("PositionSummary Component", () => {
 
       const container = screen.getByRole("region");
       expect(container).toHaveClass("transition-colors");
+    });
+  });
+
+  describe("Performance memoisation", () => {
+    it("treats equivalent position data objects as unchanged during polling", () => {
+      expect(
+        arePositionSummaryPropsEqual(
+          { data: mockHealthyData, isLoading: false },
+          {
+            data: {
+              suppliedFunds: mockHealthyData.suppliedFunds,
+              borrowedAmount: mockHealthyData.borrowedAmount,
+              healthFactor: mockHealthyData.healthFactor,
+            },
+            isLoading: false,
+          },
+        ),
+      ).toBe(true);
+    });
+
+    it("rerenders when health inputs or loading state change", () => {
+      expect(
+        arePositionSummaryPropsEqual(
+          { data: mockHealthyData, isLoading: false },
+          { data: mockAtRiskData, isLoading: false },
+        ),
+      ).toBe(false);
+
+      expect(
+        arePositionSummaryPropsEqual(
+          { data: mockHealthyData, isLoading: false },
+          { data: mockHealthyData, isLoading: true },
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/components/features/dashboard/components/PositionSummary.tsx
+++ b/components/features/dashboard/components/PositionSummary.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { useMemo } from "react";
+import { memo, useMemo, type FC } from "react";
 import { AlertCircle, TrendingUp } from "lucide-react";
 
-interface PositionData {
+export interface PositionData {
   suppliedFunds: string;
   borrowedAmount: string;
   healthFactor: number;
 }
 
-interface PositionSummaryProps {
+export interface PositionSummaryProps {
   data: PositionData | null;
   isLoading?: boolean;
 }
@@ -88,6 +88,29 @@ function formatCurrencyValue(value: number): string {
   }).format(value);
 }
 
+export function arePositionSummaryPropsEqual(
+  previous: PositionSummaryProps,
+  next: PositionSummaryProps,
+): boolean {
+  if (previous.isLoading !== next.isLoading) {
+    return false;
+  }
+
+  if (previous.data === next.data) {
+    return true;
+  }
+
+  if (!previous.data || !next.data) {
+    return false;
+  }
+
+  return (
+    previous.data.suppliedFunds === next.data.suppliedFunds &&
+    previous.data.borrowedAmount === next.data.borrowedAmount &&
+    previous.data.healthFactor === next.data.healthFactor
+  );
+}
+
 /**
  * PositionSummary Component
  *
@@ -100,39 +123,42 @@ function formatCurrencyValue(value: number): string {
  * - High contrast for health indicators
  * - Non-color-dependent status communication
  */
-export const PositionSummary: React.FC<PositionSummaryProps> = ({
+const PositionSummaryComponent: FC<PositionSummaryProps> = ({
   data,
   isLoading = false,
 }) => {
+  const suppliedFunds = data?.suppliedFunds ?? "";
+  const borrowedAmount = data?.borrowedAmount ?? "";
+  const healthFactor = data?.healthFactor ?? 0;
+
   const {
-    netPosition,
     formattedNetPosition,
+    formattedHealthFactor,
     healthStatus,
-    supplied,
-    borrowed,
+    isPositive,
   } = useMemo(() => {
-    if (!data || isLoading) {
+    if (!suppliedFunds || !borrowedAmount || isLoading) {
       return {
         netPosition: 0,
         formattedNetPosition: "$0.00",
+        formattedHealthFactor: "0.00",
         healthStatus: getHealthStatus(0),
-        supplied: 0,
-        borrowed: 0,
+        isPositive: true,
       };
     }
 
-    const suppliedNum = parseFormattedCurrency(data.suppliedFunds);
-    const borrowedNum = parseFormattedCurrency(data.borrowedAmount);
+    const suppliedNum = parseFormattedCurrency(suppliedFunds);
+    const borrowedNum = parseFormattedCurrency(borrowedAmount);
     const net = suppliedNum - borrowedNum;
 
     return {
       netPosition: net,
       formattedNetPosition: formatCurrencyValue(net),
-      healthStatus: getHealthStatus(data.healthFactor),
-      supplied: suppliedNum,
-      borrowed: borrowedNum,
+      formattedHealthFactor: healthFactor.toFixed(2),
+      healthStatus: getHealthStatus(healthFactor),
+      isPositive: net >= 0,
     };
-  }, [data, isLoading]);
+  }, [borrowedAmount, healthFactor, isLoading, suppliedFunds]);
 
   if (isLoading) {
     return (
@@ -160,9 +186,6 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({
       </div>
     );
   }
-
-  const isPositive = netPosition >= 0;
-  const trend = data.healthFactor >= 2.0 ? "improving" : "worsening";
 
   return (
     <div
@@ -231,9 +254,9 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({
             </h3>
             <span
               className={`${healthStatus.color} text-xs font-semibold px-2 py-1 rounded`}
-              aria-label={`Health factor: ${data.healthFactor.toFixed(2)}`}
+              aria-label={`Health factor: ${formattedHealthFactor}`}
             >
-              {data.healthFactor.toFixed(2)}x
+              {formattedHealthFactor}x
             </span>
           </div>
           <p className="text-[#AAABAB] text-sm font-medium">
@@ -274,5 +297,12 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({
     </div>
   );
 };
+
+PositionSummaryComponent.displayName = "PositionSummary";
+
+export const PositionSummary = memo(
+  PositionSummaryComponent,
+  arePositionSummaryPropsEqual,
+);
 
 export default PositionSummary;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
             "components/shared/layout/**/*.test.tsx",
             "components/shared/common/**/*.test.tsx",
             "components/shared/ui/**/*.test.tsx",
+            "components/features/dashboard/components/PositionSummary.test.tsx",
           ],
         },
       },


### PR DESCRIPTION
## Summary
- Memoises PositionSummary derived display values from stable primitive inputs instead of the whole `data` object reference.
- Wraps PositionSummary in `React.memo` with a field-level comparator so polling payloads with unchanged values skip rerendering the card.
- Adds comparator tests, includes the component test in the jsdom/accessibility Vitest project, and documents the before/after polling behaviour.

Closes #373

## Validation
- `vitest run --project accessibility components/features/dashboard/components/PositionSummary.test.tsx` ? 46 tests passed
- `git diff --check`
- Targeted TypeScript transpile check for `PositionSummary.tsx`, `PositionSummary.test.tsx`, and `vitest.config.ts`

## Notes
- `tsc --noEmit --pretty false` is currently blocked by pre-existing syntax errors in unrelated files such as `app/api/health/route.ts`, `app/lending/page.tsx`, `lib/api/handler.ts`, and others.
- `pnpm run lint` is currently blocked by pre-existing parse/lint errors in unrelated files, including `app/api/health/route.ts`, `components/features/lending/components/LendingForm.tsx`, `lib/api/handler.ts`, and others.
