### PR TITLE
test(lending): cover LendingForm validation lifecycle

### DIFF
--- a/COMPONENT-CHECKLIST.md
+++ b/COMPONENT-CHECKLIST.md
@@ -1,41 +1,42 @@
 ## Component Checklist
 
-### ✅ Structure
+### Structure
 - [ ] Proper file organization
 - [ ] Index file with barrel export
 - [ ] Type definitions in separate file
 
-### ✅ Types
+### Types
 - [ ] Comprehensive TypeScript interfaces
 - [ ] Proper prop types
 - [ ] Event handler types
 
-### ✅ Styling
+### Styling
 - [ ] Consistent Tailwind classes
 - [ ] Responsive design
 - [ ] Dark mode support (if applicable)
 
-### ✅ Functionality
+### Functionality
 - [ ] Core functionality implemented
 - [ ] Error handling
 - [ ] Loading states
 
-### ✅ Testing
+### Testing
 - [ ] Unit tests written
 - [ ] Integration tests (if needed)
 - [ ] Accessibility tests
+- [x] LendingForm covers empty, zero, negative, and over-balance amounts; rate min/max validation and boundaries; asset default-rate switching; max amount; async submit success/error states
 
-### ✅ Documentation
+### Documentation
 - [ ] JSDoc comments
 - [ ] Storybook stories
 - [ ] Usage examples
 
-### ✅ Performance
+### Performance
 - [ ] Memoization where appropriate
 - [ ] Bundle size optimized
 - [ ] No unnecessary re-renders
 
-### ✅ Accessibility
+### Accessibility
 - [ ] ARIA attributes
 - [ ] Keyboard navigation
 - [ ] Screen reader support

--- a/components/features/lending/components/LendingForm.test.tsx
+++ b/components/features/lending/components/LendingForm.test.tsx
@@ -1,213 +1,204 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor, act } from "@/test/test-utils";
+import { fireEvent, render, screen, waitFor } from "@/test/test-utils";
+import type { ComponentProps } from "react";
 import LendingForm from "./LendingForm";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-describe("LendingForm Component", () => {
-  const mockInitialData = {
-    asset: 'XLM',
-    amount: 0,
-    interestRate: 8.5,
-  };
-  const mockOnSubmit = vi.fn();
+const initialData = {
+  asset: "XLM",
+  amount: 0,
+  interestRate: 8.5,
+};
 
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
+function renderLendingForm(
+  onSubmit = vi.fn(),
+  props: Partial<ComponentProps<typeof LendingForm>> = {},
+) {
+  render(
+    <LendingForm
+      initialData={initialData}
+      onSubmit={onSubmit}
+      submitDelayMs={0}
+      {...props}
+    />,
+  );
+  return onSubmit;
+}
 
+function amountInput() {
+  return screen.getByLabelText(/amount to lend/i);
+}
+
+function rateSlider() {
+  return screen.getByRole("slider", { name: /interest rate/i });
+}
+
+function enterAmount(amount: string) {
+  fireEvent.change(amountInput(), { target: { value: amount } });
+}
+
+function submitValidOffer(onSubmit = vi.fn()) {
+  renderLendingForm(onSubmit);
+  enterAmount("100");
+  fireEvent.click(screen.getByRole("button", { name: /review lending offer/i }));
+
+  return onSubmit;
+}
+
+describe("LendingForm", () => {
   afterEach(() => {
-    vi.useRealTimers();
+    vi.clearAllMocks();
   });
 
-  it("renders correctly", () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
-    expect(screen.getByText(/Lend Your Assets/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Amount to Lend/i)).toBeInTheDocument();
+  it("renders the core lending controls with accessible names", () => {
+    renderLendingForm();
+
+    expect(screen.getByRole("heading", { name: /lend your assets/i })).toBeInTheDocument();
+    expect(screen.getByRole("listbox", { name: /select asset/i })).toBeInTheDocument();
+    expect(amountInput()).toBeInTheDocument();
+    expect(rateSlider()).toHaveAttribute("min", "5");
+    expect(rateSlider()).toHaveAttribute("max", "12");
+    expect(screen.getByRole("button", { name: /review lending offer/i })).toBeInTheDocument();
   });
 
-  it("validates amount is positive", async () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
-    const submitButton = screen.getByText(/Review Lending Offer/i);
-    fireEvent.click(submitButton);
-    
-    expect(await screen.findByText(/Please enter a valid amount/i)).toBeInTheDocument();
-    // Verify our new top-level error banner
-    expect(screen.getByText(/Please fix the errors in the form before continuing/i)).toBeInTheDocument();
+  it.each([
+    ["empty amount", ""],
+    ["zero amount", "0"],
+    ["negative amount", "-50"],
+  ])("rejects %s", async (_caseName, value) => {
+    const onSubmit = renderLendingForm();
+
+    enterAmount(value);
+    fireEvent.click(screen.getByRole("button", { name: /review lending offer/i }));
+
+    expect(screen.getByText(/please enter a valid amount/i)).toBeInTheDocument();
+    expect(screen.getByText(/please fix the errors in the form/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("validates balance", async () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
-    const amountInput = screen.getByLabelText(/Amount to Lend/i);
-    fireEvent.change(amountInput, { target: { value: "10000" } }); // Above XLM balance
-    
-    const submitButton = screen.getByText(/Review Lending Offer/i);
-    fireEvent.click(submitButton);
-    
-    expect(await screen.findByText(/Insufficient balance/i)).toBeInTheDocument();
+  it("rejects an amount above the selected asset balance", async () => {
+    const onSubmit = renderLendingForm();
+
+    enterAmount("10000");
+    fireEvent.click(screen.getByRole("button", { name: /review lending offer/i }));
+
+    expect(screen.getByText(/insufficient balance/i)).toHaveTextContent(
+      "Maximum available: 3,750 XLM",
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("handles MAX button click", () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
-    const maxButton = screen.getByText(/MAX/i);
-    fireEvent.click(maxButton);
-    
-    const amountInput = screen.getByLabelText(/Amount to Lend/i) as HTMLInputElement;
-    expect(amountInput.value).toBe("3,750"); // XLM balance is 3750, but it might be formatted. 
-    // Actually the code uses parseFloat so it might be 3750.
-  });
-
-  it("submits successfully with valid data", async () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
-    fireEvent.change(screen.getByLabelText(/Amount to Lend/i), { target: { value: "100" } });
-    
-    const submitButton = screen.getByText(/Review Lending Offer/i);
-    fireEvent.click(submitButton);
-    
-    // Fast-forward through the 800ms simulated loading delay
-    act(() => {
-      vi.advanceTimersByTime(1000);
+  it.each([
+    ["below the minimum", "4.9"],
+    ["above the maximum", "12.1"],
+  ])("rejects an interest rate %s", async (_caseName, rate) => {
+    const onSubmit = renderLendingForm(vi.fn(), {
+      initialData: { ...initialData, interestRate: Number(rate) },
     });
-    
-    await waitFor(() => {
-      // Verify our new success banner
-      expect(screen.getByText(/Details validated successfully/i)).toBeInTheDocument();
-      expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
-        amount: 100,
-        asset: 'XLM'
-      }));
-    });
+
+    enterAmount("100");
+    fireEvent.click(screen.getByRole("button", { name: /review lending offer/i }));
+
+    expect(screen.getByText(/interest rate must be between 5% and 12%/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("rejects zero and negative amounts", async () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
+  it.each([
+    ["minimum", "5"],
+    ["maximum", "12"],
+  ])("accepts the %s interest rate boundary", async (_caseName, rate) => {
+    const onSubmit = renderLendingForm();
 
-    const amountInput = screen.getByLabelText(/Amount to Lend/i);
-
-    // Zero amount
-    fireEvent.change(amountInput, { target: { value: "0" } });
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
-    expect(await screen.findByText(/Please enter a valid amount/i)).toBeInTheDocument();
-
-    // Negative amount
-    fireEvent.change(amountInput, { target: { value: "-50" } });
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
-    expect(await screen.findByText(/Please enter a valid amount/i)).toBeInTheDocument();
-  });
-
-  it("rejects interest rate below minimum", async () => {
-    render(<LendingForm initialData={{ ...mockInitialData, interestRate: 2.0 }} onSubmit={mockOnSubmit} />);
-
-    fireEvent.change(screen.getByLabelText(/Amount to Lend/i), { target: { value: "100" } });
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
-
-    expect(await screen.findByText(/Interest rate must be between/)).toBeInTheDocument();
-  });
-
-  it("rejects interest rate above maximum", async () => {
-    render(<LendingForm initialData={{ ...mockInitialData, interestRate: 15.0 }} onSubmit={mockOnSubmit} />);
-
-    fireEvent.change(screen.getByLabelText(/Amount to Lend/i), { target: { value: "100" } });
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
-
-    expect(await screen.findByText(/Interest rate must be between/)).toBeInTheDocument();
-  });
-
-  it("updates default interest rate when asset changes", async () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-
-    // XLM default is 8.5
-    expect(screen.getByText(/8\.5% APY/)).toBeInTheDocument();
-
-    // Switch to USDC — default should become 6.5
-    const combobox = screen.getByRole("combobox");
-    fireEvent.change(combobox, { target: { value: "USDC" } });
-
-    // After the useEffect fires, the rate should update
-    await waitFor(() => {
-      expect(screen.getByText(/6\.5% APY/)).toBeInTheDocument();
-    });
-  });
-
-  it("resets errors after editing amount", async () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-
-    // Submit empty form to trigger validation
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
-    expect(await screen.findByText(/Please enter a valid amount/i)).toBeInTheDocument();
-
-    // Edit the amount — error should be cleared
-    fireEvent.change(screen.getByLabelText(/Amount to Lend/i), { target: { value: "200" } });
+    enterAmount("100");
+    fireEvent.change(rateSlider(), { target: { value: rate } });
+    fireEvent.click(screen.getByRole("button", { name: /review lending offer/i }));
 
     await waitFor(() => {
-      expect(screen.queryByText(/Please enter a valid amount/i)).not.toBeInTheDocument();
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 100, asset: "XLM", interestRate: Number(rate) }),
+      );
     });
   });
 
-  it("shows submit error banner when validation fails on submit", async () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
+  it("fills the selected asset balance from the MAX action and clears amount errors", async () => {
+    renderLendingForm();
 
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
+    fireEvent.click(screen.getByRole("button", { name: /review lending offer/i }));
+    expect(screen.getByText(/please enter a valid amount/i)).toBeInTheDocument();
 
-    expect(await screen.findByText(/Please fix the errors in the form before continuing/i)).toBeInTheDocument();
-    expect(mockOnSubmit).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /^max$/i }));
+
+    expect(amountInput()).toHaveValue("3,750.0000000");
+    expect(screen.queryByText(/please enter a valid amount/i)).not.toBeInTheDocument();
   });
 
-  it("disables submit button while submitting (loading state)", async () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
+  it("updates the default rate when the selected asset changes", async () => {
+    renderLendingForm();
 
-    fireEvent.change(screen.getByLabelText(/Amount to Lend/i), { target: { value: "100" } });
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
+    expect(screen.getByText("8.5% APY")).toBeInTheDocument();
 
-    // Button should show loading state
+    fireEvent.click(screen.getByRole("option", { name: /usdc/i }));
+
+    expect(screen.getByRole("option", { name: /usdc/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(await screen.findByText("6.5% APY")).toBeInTheDocument();
+    expect(rateSlider()).toHaveAttribute("min", "4");
+    expect(rateSlider()).toHaveAttribute("max", "10");
+  });
+
+  it("disables the submit button while validation is pending", async () => {
+    let resolveSubmit!: () => void;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+
+    submitValidOffer(onSubmit);
+
+    const submitButton = screen.getByRole("button", { name: /review lending offer/i });
+    expect(submitButton).toBeDisabled();
+
+    resolveSubmit();
+
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+  });
+
+  it("submits valid data and shows the success state", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    submitValidOffer(onSubmit);
+
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /review lending offer/i })).toBeDisabled();
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 100, asset: "XLM", interestRate: 8.5 }),
+      );
+      expect(screen.getByRole("alert")).toHaveTextContent("Details validated successfully.");
     });
   });
 
-  it("renders lending terms section", () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
+  it("shows the error state when submit handling fails", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("network unavailable"));
+
+    submitValidOffer(onSubmit);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "An error occurred during validation.",
+      );
+    });
+  });
+
+  it("documents the visible terms and rate markers", () => {
+    renderLendingForm();
 
     expect(screen.getByText("Lending Terms")).toBeInTheDocument();
-    expect(screen.getByText(/Minimum lending period: 7 days/)).toBeInTheDocument();
-    expect(screen.getByText(/Interest is calculated daily and compounded/)).toBeInTheDocument();
-  });
-
-  it("renders interest rate min/max/default markers", () => {
-    render(<LendingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-
-    expect(screen.getByText(/MIN: 5\.0%/)).toBeInTheDocument();
-    expect(screen.getByText(/DEFAULT: 8\.5%/)).toBeInTheDocument();
-    expect(screen.getByText(/MAX: 12\.0%/)).toBeInTheDocument();
-  });
-
-  it("accepts rate at boundary values (min and max)", async () => {
-    const { rerender } = render(
-      <LendingForm initialData={{ ...mockInitialData, interestRate: 5.0 }} onSubmit={mockOnSubmit} />,
-    );
-
-    fireEvent.change(screen.getByLabelText(/Amount to Lend/i), { target: { value: "100" } });
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
-
-    // Rate = min (5.0) should be valid
-    act(() => { vi.advanceTimersByTime(1000); });
-    await waitFor(() => {
-      expect(screen.getByText(/Details validated successfully/i)).toBeInTheDocument();
-    });
-
-    // Now test with rate = max (12.0)
-    rerender(
-      <LendingForm initialData={{ ...mockInitialData, interestRate: 12.0 }} onSubmit={mockOnSubmit} />,
-    );
-
-    fireEvent.click(screen.getByText(/Review Lending Offer/i));
-    act(() => { vi.advanceTimersByTime(1000); });
-    await waitFor(() => {
-      expect(screen.getByText(/Details validated successfully/i)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/minimum lending period: 7 days/i)).toBeInTheDocument();
+    expect(screen.getByText(/interest is calculated daily and compounded/i)).toBeInTheDocument();
+    expect(screen.getByText("MIN: 5%")).toBeInTheDocument();
+    expect(screen.getByText("DEFAULT: 8.5%")).toBeInTheDocument();
+    expect(screen.getByText("MAX: 12%")).toBeInTheDocument();
   });
 });

--- a/components/features/lending/components/LendingForm.tsx
+++ b/components/features/lending/components/LendingForm.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { LendingData } from "@/app/lending/page";
-import { Input } from "@/components/shared/ui/Input";
+import { AmountInput } from "@/components/shared/ui/AmountInput";
 import Button from "@/components/shared/ui/Button";
 import { cn } from "@/lib/utils/cn";
 import { ASSETS } from "@/lib/assets";
 import AssetSelector from "@/components/shared/ui/AssetSelector";
+import { Tooltip } from "@/components/atoms/Tooltip";
+import { IconButton } from "@/components/atoms/IconButton";
 
 interface LendingFormProps {
-  onSubmit: (data: LendingData) => void;
+  onSubmit: (data: LendingData) => void | Promise<void>;
   initialData: LendingData;
+  submitDelayMs?: number;
 }
 
 const INTEREST_RATES = {
@@ -23,6 +26,7 @@ const INTEREST_RATES = {
 export default function LendingForm({
   onSubmit,
   initialData,
+  submitDelayMs = 800,
 }: LendingFormProps) {
   const [formData, setFormData] = useState<LendingData>(initialData);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -34,12 +38,6 @@ export default function LendingForm({
 
   const selectedAsset = ASSETS.find((a) => a.symbol === formData.asset);
   const rates = INTEREST_RATES[formData.asset as keyof typeof INTEREST_RATES];
-
-  useEffect(() => {
-    if (rates) {
-      setFormData((prev) => ({ ...prev, interestRate: rates.default }));
-    }
-  }, [formData.asset, rates]);
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -69,11 +67,12 @@ export default function LendingForm({
     if (validateForm()) {
       setIsSubmitting(true);
       try {
-        // Simulate validation/processing
-        await new Promise((resolve) => setTimeout(resolve, 800));
+        if (submitDelayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, submitDelayMs));
+        }
+        await onSubmit(formData);
         setSubmitStatus("success");
         setSubmitMessage("Details validated successfully.");
-        onSubmit(formData);
       } catch (err) {
         setSubmitStatus("error");
         setSubmitMessage("An error occurred during validation.");
@@ -138,9 +137,12 @@ export default function LendingForm({
               value={formData.asset}
               label="Select Asset"
               onChange={(asset) => {
+                const nextRates =
+                  INTEREST_RATES[asset as keyof typeof INTEREST_RATES];
                 setFormData((prev) => ({
                   ...prev,
                   asset,
+                  interestRate: nextRates?.default ?? prev.interestRate,
                 }));
 
                 setErrors({});
@@ -156,17 +158,17 @@ export default function LendingForm({
             type="number"
             step="0.01"
             placeholder="0.00"
-            value={formData.amount || ""}
+            value={formData.amount}
             error={errors.amount}
             helperText={
               selectedAsset
                 ? `Available: ${selectedAsset.balance.toLocaleString()} ${formData.asset}`
                 : undefined
             }
-            onChange={(e) => {
+            onChange={(amount) => {
               setFormData((prev) => ({
                 ...prev,
-                amount: parseFloat(e.target.value) || 0,
+                amount,
               }));
               if (errors.amount) {
                 setErrors((prev) => {
@@ -177,9 +179,6 @@ export default function LendingForm({
               }
             }}
             precision={selectedAsset?.precision ?? 2}
-            placeholder="0.00"
-            error={errors.amount}
-            helperText={selectedAsset ? `Available: ${selectedAsset.balance.toLocaleString()} ${formData.asset}` : undefined}
             onMax={handleMaxAmount}
           />
         </div>
@@ -190,7 +189,9 @@ export default function LendingForm({
             <label className="text-sm font-medium text-gray-700 flex items-center">
               Interest Rate (% APY)
               <Tooltip content="Annual Percentage Yield (APR) is the annual rate of return, including compounding.">
-                <IconButton aria-label="Help" size="sm" variant="ghost" />
+                <IconButton aria-label="Help" size="sm" variant="ghost">
+                  ?
+                </IconButton>
               </Tooltip>
             </label>
             <span className="text-sm font-bold text-green-600 bg-green-50 px-2 py-0.5 rounded">
@@ -200,6 +201,7 @@ export default function LendingForm({
 
           <div className="px-1">
             <input
+              aria-label="Interest Rate (% APY)"
               type="range"
               min={rates.min}
               max={rates.max}

--- a/components/shared/ui/AmountInput.tsx
+++ b/components/shared/ui/AmountInput.tsx
@@ -148,6 +148,9 @@ export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(
           {...rest}
           id={id}
           ref={inputRef}
+          label={label}
+          error={error}
+          helperText={helperText}
           type="text"
           inputMode="decimal"
           value={displayValue}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
             "components/shared/layout/**/*.test.tsx",
             "components/shared/common/**/*.test.tsx",
             "components/shared/ui/**/*.test.tsx",
+            "components/features/lending/components/**/*.test.tsx",
           ],
         },
       },


### PR DESCRIPTION
## Summary
- include lending component tests in the accessibility Vitest project
- replace LendingForm coverage with deterministic tests for amount validation, balance limits, rate bounds, asset default-rate switching, MAX, and async submit success/error states
- fix the LendingForm/AmountInput accessibility and async-submit behavior exposed by those tests
- document the covered LendingForm scenarios in `COMPONENT-CHECKLIST.md`

Closes #361

## Validation
- `node_modules/.bin/vitest.cmd run components/features/lending/components/LendingForm.test.tsx --project accessibility` (15 passed)
- `node_modules/.bin/vitest.cmd run components/shared/ui/AmountInput.test.tsx components/features/lending/components/LendingForm.test.tsx --project accessibility` (22 passed)
- `git diff --check`

## Notes
- `node_modules/.bin/vitest.cmd run --project accessibility` still has unrelated existing failures in Pagination, EmptyState, TopNav, Navigation, Transaction, BorrowingForm, and InterestCalculator tooltip tests.
- `node_modules/.bin/tsc.cmd --noEmit` is blocked by existing syntax errors in files such as `app/api/health/route.ts`, `app/lending/page.tsx`, `lib/api/handler.ts`, `lib/auth.ts`, `lib/http/client.ts`, `lib/metrics/registry.ts`, and `lib/notifications/repository.ts`.
- Direct ESLint is blocked because the repo has ESLint 9 but no `eslint.config.*` file.