### PR TITLE
test(a11y): cover lending forms with axe

### DIFF
--- a/app/lending/lending-forms.accessibility.test.tsx
+++ b/app/lending/lending-forms.accessibility.test.tsx
@@ -1,0 +1,101 @@
+import axe from "axe-core";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { LendingData } from "@/app/lending/page";
+import BorrowingForm from "@/components/features/lending/components/BorrowingForm";
+import ConfirmModal from "@/components/features/lending/components/ConfirmModal";
+import LendingForm from "@/components/features/lending/components/LendingForm";
+import AssetSelector from "@/components/shared/ui/AssetSelector";
+import { ASSETS } from "@/lib/assets";
+import { render, screen } from "@/test/test-utils";
+
+const lendingData: LendingData = {
+  asset: "XLM",
+  amount: 100,
+  interestRate: 8.5,
+};
+
+const borrowingData: LendingData = {
+  asset: "USDC",
+  amount: 25,
+  collateral: "XLM",
+  collateralAmount: 50,
+  duration: 30,
+  interestRate: 10.5,
+};
+
+async function expectNoAxeViolations(container: HTMLElement) {
+  const results = await axe.run(container);
+  expect(results.violations).toEqual([]);
+}
+
+function OpenConfirmModal() {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <ConfirmModal
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      onConfirm={vi.fn()}
+      data={lendingData}
+      calculation={{ dailyEarnings: 0.03, totalEarnings: 4.2 }}
+      type="lend"
+    />
+  );
+}
+
+describe("lending form accessibility", () => {
+  it("has no automated axe violations in the lending form", async () => {
+    const { container } = render(
+      <LendingForm initialData={lendingData} onSubmit={vi.fn()} />,
+    );
+
+    await expectNoAxeViolations(container);
+  });
+
+  it("has no automated axe violations in the borrowing form", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          prices: {
+            XLM: 0.12,
+            USDC: 1,
+            BTC: 65000,
+            ETH: 3500,
+          },
+        }),
+      }),
+    );
+
+    const { container } = render(
+      <BorrowingForm initialData={borrowingData} onSubmit={vi.fn()} />,
+    );
+
+    await expectNoAxeViolations(container);
+    vi.unstubAllGlobals();
+  });
+
+  it("has no automated axe violations in the shared asset selector", async () => {
+    const { container } = render(
+      <AssetSelector
+        assets={ASSETS}
+        value="XLM"
+        label="Select collateral asset"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("listbox", { name: /select collateral asset/i })).toBeInTheDocument();
+    await expectNoAxeViolations(container);
+  });
+
+  it("has no automated axe violations in the confirmation modal", async () => {
+    const { container } = render(<OpenConfirmModal />);
+
+    expect(screen.getByRole("dialog", { name: /confirm lending transaction/i })).toBeInTheDocument();
+    await expectNoAxeViolations(container);
+  });
+});

--- a/components/features/lending/components/BorrowingForm.tsx
+++ b/components/features/lending/components/BorrowingForm.tsx
@@ -276,15 +276,20 @@ export default function BorrowingForm({
         />
 
         {/* Loan Duration */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">
+        <div
+          role="group"
+          aria-labelledby="loan-duration-label"
+          aria-describedby={errors.duration ? "loan-duration-error" : undefined}
+        >
+          <span id="loan-duration-label" className="block text-sm font-medium text-gray-700 mb-3">
             Loan Duration
-          </label>
+          </span>
           <div className="grid grid-cols-3 gap-3">
             {LOAN_DURATIONS.map((duration) => (
               <button
                 key={duration.days}
                 type="button"
+                aria-pressed={formData.duration === duration.days}
                 onClick={() => {
                   setFormData((prev) => ({ ...prev, duration: duration.days }));
                   if (errors.duration) {
@@ -311,6 +316,7 @@ export default function BorrowingForm({
           </div>
           {errors.duration && (
             <p
+              id="loan-duration-error"
               className="text-xs text-red-500 font-medium mt-2"
               role="alert"
               aria-live="polite"
@@ -321,15 +327,21 @@ export default function BorrowingForm({
         </div>
 
         {/* Collateral Selection */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">
+        <div
+          role="group"
+          aria-labelledby="collateral-asset-label"
+          aria-describedby={errors.collateral ? "collateral-asset-error" : undefined}
+        >
+          <span id="collateral-asset-label" className="block text-sm font-medium text-gray-700 mb-3">
             Collateral Asset
-          </label>
+          </span>
           <div className="grid grid-cols-2 gap-4">
             {ASSETS.map((asset) => (
               <button
                 key={asset.symbol}
                 type="button"
+                aria-pressed={formData.collateral === asset.symbol}
+                aria-label={`${asset.symbol} collateral, balance ${asset.balance.toLocaleString()}`}
                 onClick={() => {
                   setFormData((prev) => ({
                     ...prev,
@@ -359,6 +371,7 @@ export default function BorrowingForm({
           </div>
           {errors.collateral && (
             <p
+              id="collateral-asset-error"
               className="text-xs text-red-500 font-medium mt-2"
               role="alert"
               aria-live="polite"

--- a/components/features/lending/components/ConfirmModal.tsx
+++ b/components/features/lending/components/ConfirmModal.tsx
@@ -351,7 +351,10 @@ export default function ConfirmModal({
               />
               <span className="text-sm text-gray-700">
                 I understand and agree to the{" "}
-                <button className="text-green-600 hover:text-green-700 underline">
+                <button
+                  type="button"
+                  className="text-green-600 hover:text-green-700 underline"
+                >
                   terms and conditions
                 </button>
                 {type === "borrow" && (

--- a/components/features/lending/components/LendingForm.tsx
+++ b/components/features/lending/components/LendingForm.tsx
@@ -2,11 +2,13 @@
 
 import { useState, useEffect } from "react";
 import { LendingData } from "@/app/lending/page";
-import { Input } from "@/components/shared/ui/Input";
 import Button from "@/components/shared/ui/Button";
 import { cn } from "@/lib/utils/cn";
 import { ASSETS } from "@/lib/assets";
 import AssetSelector from "@/components/shared/ui/AssetSelector";
+import { AmountInput } from "@/components/shared/ui/AmountInput";
+import { IconButton } from "@/components/atoms/IconButton";
+import { Tooltip } from "@/components/atoms/Tooltip";
 
 interface LendingFormProps {
   onSubmit: (data: LendingData) => void;
@@ -156,17 +158,17 @@ export default function LendingForm({
             type="number"
             step="0.01"
             placeholder="0.00"
-            value={formData.amount || ""}
+            value={formData.amount || 0}
             error={errors.amount}
             helperText={
               selectedAsset
                 ? `Available: ${selectedAsset.balance.toLocaleString()} ${formData.asset}`
                 : undefined
             }
-            onChange={(e) => {
+            onChange={(amount) => {
               setFormData((prev) => ({
                 ...prev,
-                amount: parseFloat(e.target.value) || 0,
+                amount,
               }));
               if (errors.amount) {
                 setErrors((prev) => {
@@ -177,9 +179,6 @@ export default function LendingForm({
               }
             }}
             precision={selectedAsset?.precision ?? 2}
-            placeholder="0.00"
-            error={errors.amount}
-            helperText={selectedAsset ? `Available: ${selectedAsset.balance.toLocaleString()} ${formData.asset}` : undefined}
             onMax={handleMaxAmount}
           />
         </div>
@@ -190,7 +189,9 @@ export default function LendingForm({
             <label className="text-sm font-medium text-gray-700 flex items-center">
               Interest Rate (% APY)
               <Tooltip content="Annual Percentage Yield (APR) is the annual rate of return, including compounding.">
-                <IconButton aria-label="Help" size="sm" variant="ghost" />
+                <IconButton aria-label="Help" size="sm" variant="ghost">
+                  <span aria-hidden="true">?</span>
+                </IconButton>
               </Tooltip>
             </label>
             <span className="text-sm font-bold text-green-600 bg-green-50 px-2 py-0.5 rounded">
@@ -201,6 +202,9 @@ export default function LendingForm({
           <div className="px-1">
             <input
               type="range"
+              aria-label="Interest Rate (% APY)"
+              aria-describedby={errors.interestRate ? "lend-interest-rate-error" : undefined}
+              aria-invalid={errors.interestRate ? "true" : undefined}
               min={rates.min}
               max={rates.max}
               step="0.1"
@@ -222,6 +226,7 @@ export default function LendingForm({
 
           {errors.interestRate && (
             <p
+              id="lend-interest-rate-error"
               className="text-xs text-red-500 font-medium"
               role="alert"
               aria-live="polite"

--- a/components/shared/ui/AssetSelector.tsx
+++ b/components/shared/ui/AssetSelector.tsx
@@ -49,6 +49,7 @@ export default function AssetSelector({
               type="button"
               role="option"
               aria-selected={selected}
+              aria-label={`${asset.symbol}, ${asset.name}${showBalance ? `, balance ${asset.balance.toLocaleString()}` : ""}`}
               tabIndex={0}
               onClick={() => onChange(asset.symbol)}
               onKeyDown={(e) => {
@@ -67,6 +68,7 @@ export default function AssetSelector({
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
                   <div
+                    aria-hidden="true"
                     className={cn(
                       "w-6 h-6 rounded-full",
                       TOKEN_COLORS[asset.symbol],

--- a/components/shared/ui/Input.tsx
+++ b/components/shared/ui/Input.tsx
@@ -37,6 +37,13 @@ export const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
     } = props;
 
     const inputId = id || (label ? label.toLowerCase().replace(/\s+/g, '-') : undefined);
+    const describedBy =
+      [
+        error && inputId ? `${inputId}-error` : undefined,
+        !error && helperText && inputId ? `${inputId}-helper` : undefined,
+      ]
+        .filter(Boolean)
+        .join(' ') || undefined;
 
     const baseInputStyles = cn(
       'w-full px-4 py-2.5 rounded-lg border transition-all duration-200 outline-none text-sm',
@@ -66,6 +73,8 @@ export const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
             ref={ref as React.ForwardedRef<HTMLTextAreaElement>}
             className={cn(baseInputStyles, 'resize-none')}
             required={required}
+            aria-invalid={error ? 'true' : undefined}
+            aria-describedby={describedBy}
             {...(rest as TextareaHTMLAttributes<HTMLTextAreaElement>)}
           />
         ) : (
@@ -74,6 +83,8 @@ export const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
             ref={ref as React.ForwardedRef<HTMLInputElement>}
             className={baseInputStyles}
             required={required}
+            aria-invalid={error ? 'true' : undefined}
+            aria-describedby={describedBy}
             {...(rest as InputHTMLAttributes<HTMLInputElement>)}
           />
         )}


### PR DESCRIPTION
## Summary
- add axe-core coverage for LendingForm, BorrowingForm, AssetSelector, and ConfirmModal
- associate shared input helper/error text with controls via ria-describedby and ria-invalid
- add accessible names/pressed state for asset and lending option controls, plus a small modal button type fix
- fix the lending amount field to use the shared AmountInput API and provide a concrete help trigger child

Closes #370

## Testing
- git diff --check
- Not run: pnpm install --frozen-lockfile is blocked because pnpm-lock.yaml is out of sync with package.json
- Not run: 
pm ci is blocked in this checkout because npm did not accept the current lockfile for clean install