### PR TITLE
feat: add account data export button

### DIFF
--- a/app/account/profile/page.tsx
+++ b/app/account/profile/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import ProfileForm from "@/components/features/account/components/ProfileForm";
+import { DataExportButton, ProfileForm } from "@/components/features/account/components";
 import Sidebar from "@/components/shared/layout/Sidebar";
 import { PageHeader } from "@/components/shared/common";
 import { usePathname } from "next/navigation";
@@ -18,7 +18,12 @@ export default function Account() {
             title="Profile"
             description="Manage your personal details, security settings, and notification preferences."
           />
-          {pathname === "/account/profile" && <ProfileForm />}
+          {pathname === "/account/profile" && (
+            <div className="space-y-6">
+              <ProfileForm />
+              <DataExportButton />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/components/features/account/components/DataExportButton.test.tsx
+++ b/components/features/account/components/DataExportButton.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/test/test-utils";
+import DataExportButton from "./DataExportButton";
+
+const successPayload = {
+  success: true,
+  message: "Export compilation complete.",
+  downloadUrl:
+    "https://storage.stellarlend.com/exports/user_test_9921/dsar.zip?X-Amz-Expires=900",
+  expiresInSeconds: 900,
+};
+
+function mockFetch(response: Partial<Response>) {
+  const fetchMock = vi.fn().mockResolvedValue(response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("DataExportButton", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("requests a DSAR export and downloads the signed bundle", async () => {
+    const fetchMock = mockFetch({
+      ok: true,
+      status: 202,
+      json: async () => successPayload,
+    });
+    const download = vi.fn();
+
+    render(<DataExportButton onDownload={download} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export my data/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/account/export", {
+        method: "POST",
+      });
+      expect(download).toHaveBeenCalledWith(successPayload.downloadUrl);
+    });
+
+    expect(screen.getByText(/data export ready/i)).toBeInTheDocument();
+  });
+
+  it("announces busy state and prevents duplicate concurrent requests", async () => {
+    let resolveResponse: (value: Partial<Response>) => void = () => {};
+    const pendingResponse = new Promise<Partial<Response>>((resolve) => {
+      resolveResponse = resolve;
+    });
+    const fetchMock = vi.fn().mockReturnValue(pendingResponse);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DataExportButton onDownload={vi.fn()} />);
+
+    const button = screen.getByRole("button", { name: /export my data/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).toHaveTextContent(/exporting data/i);
+
+    resolveResponse({
+      ok: true,
+      status: 202,
+      json: async () => successPayload,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /export my data/i })).not.toBeDisabled();
+    });
+  });
+
+  it("shows an error toast when the export request fails", async () => {
+    mockFetch({
+      ok: false,
+      status: 429,
+      json: async () => ({
+        error: "DSAR export rate limit exceeded. Please wait 24 hour(s) before requesting again.",
+      }),
+    });
+    const download = vi.fn();
+
+    render(<DataExportButton onDownload={download} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export my data/i }));
+
+    expect(await screen.findByText(/export failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/rate limit exceeded/i)).toBeInTheDocument();
+    expect(download).not.toHaveBeenCalled();
+  });
+});

--- a/components/features/account/components/DataExportButton.tsx
+++ b/components/features/account/components/DataExportButton.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/shared/ui/Button";
+import Toast, { type ToastVariant } from "@/components/shared/common/Toast";
+
+type ExportResponse = {
+  success?: boolean;
+  message?: string;
+  downloadUrl?: string;
+  expiresInSeconds?: number;
+  error?: string;
+};
+
+type ToastState = {
+  title: string;
+  description: string;
+  variant: ToastVariant;
+};
+
+export interface DataExportButtonProps {
+  endpoint?: string;
+  onDownload?: (downloadUrl: string) => void;
+}
+
+function readCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+
+  const match = document.cookie
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .find((cookie) => cookie.startsWith(`${name}=`));
+
+  return match ? decodeURIComponent(match.slice(name.length + 1)) : null;
+}
+
+function buildExportRequest(): RequestInit {
+  const csrfToken = readCookie("csrf-token");
+
+  if (!csrfToken) {
+    return { method: "POST" };
+  }
+
+  return {
+    method: "POST",
+    headers: {
+      "x-csrf-token": csrfToken,
+    },
+  };
+}
+
+function downloadSignedBundle(downloadUrl: string) {
+  const anchor = document.createElement("a");
+  anchor.href = downloadUrl;
+  anchor.download = "stellarlend-account-export.zip";
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+async function parseExportResponse(response: Response): Promise<ExportResponse> {
+  try {
+    return (await response.json()) as ExportResponse;
+  } catch {
+    return {};
+  }
+}
+
+export default function DataExportButton({
+  endpoint = "/api/account/export",
+  onDownload = downloadSignedBundle,
+}: DataExportButtonProps) {
+  const [isExporting, setIsExporting] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const handleExport = async () => {
+    if (isExporting) return;
+
+    setIsExporting(true);
+    setToast({
+      title: "Preparing data export",
+      description: "Compiling your account archive and signed download.",
+      variant: "processing",
+    });
+
+    try {
+      const response = await fetch(endpoint, buildExportRequest());
+      const payload = await parseExportResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload.error || "The export request could not be completed.");
+      }
+
+      if (!payload.downloadUrl) {
+        throw new Error("The export response did not include a signed download URL.");
+      }
+
+      onDownload(payload.downloadUrl);
+      setToast({
+        title: "Data export ready",
+        description: payload.expiresInSeconds
+          ? `Your signed download link is valid for ${Math.round(payload.expiresInSeconds / 60)} minutes.`
+          : "Your signed account export is ready to download.",
+        variant: "success",
+      });
+    } catch (error) {
+      setToast({
+        title: "Export failed",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Your account export could not be generated. See docs/dsar-export-runbook.md for operations guidance.",
+        variant: "error",
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">Account data export</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            Generate a signed GDPR/DSAR archive for your profile, preferences, transactions,
+            and notifications.
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          onClick={handleExport}
+          disabled={isExporting}
+          isLoading={isExporting}
+          aria-busy={isExporting}
+          aria-describedby="data-export-status"
+          className="shrink-0"
+        >
+          {isExporting ? "Exporting data" : "Export my data"}
+        </Button>
+      </div>
+
+      <p id="data-export-status" className="mt-3 text-xs text-gray-500" aria-live="polite">
+        Exports are rate-limited to one request per account every 24 hours. Signed links expire
+        after 15 minutes.
+      </p>
+
+      {toast && (
+        <Toast
+          title={toast.title}
+          description={toast.description}
+          variant={toast.variant}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/features/account/components/index.ts
+++ b/components/features/account/components/index.ts
@@ -1,1 +1,2 @@
-export { default as ProfileForm } from './ProfileForm'; 
+export { default as DataExportButton } from './DataExportButton';
+export { default as ProfileForm } from './ProfileForm';

--- a/docs/dsar-export-runbook.md
+++ b/docs/dsar-export-runbook.md
@@ -6,6 +6,21 @@ The `/api/account/export` route triggers data collection tasks across core data 
 ## Operational Rate-Limiting Controls
 To minimize stress on data processing pipelines from arbitrary generation sweeps, a strict **24-hour request limit** is imposed per credential hash token.
 
+## User-Initiated Export Flow
+Users can request an export from the account profile screen through the `DataExportButton`.
+The button sends `POST /api/account/export`, enters a disabled busy state while the
+archive is generated, and then opens the returned signed `downloadUrl`. The UI announces
+the busy state for assistive technology and shows a success or failure toast when the
+request completes.
+
+The signed URL returned by the route is short-lived. The UI currently communicates the
+15-minute expiry window and reminds users that account exports are limited to one request
+per account every 24 hours.
+
 ## Failure Troubleshooting Vectors
 * **S3/Storage Unreachable:** If connection dropouts stall file pushes, the processing task aborts without modifying the rate limiter checkpoint. This ensures users can retry immediately when systems restore.
 * **Stale Artifact Cleanup:** Artifact lifecycle policies inside cloud buckets are configured to automatically erase records after 24 hours to prevent permanent data exposure.
+* **UI Request Failure:** If the account page shows an export failure toast, inspect the
+  `/api/account/export` response. `403` usually indicates a missing CSRF token, `429`
+  indicates the 24-hour account throttle, and `500` indicates export bundle generation
+  failed before a signed URL was issued.


### PR DESCRIPTION
## Summary
- add `DataExportButton` to request `POST /api/account/export`, prevent duplicate requests, show busy state, and trigger the signed download URL
- surface processing/success/error feedback through the existing `Toast` component
- mount the export affordance on the account profile screen
- update `docs/dsar-export-runbook.md` with the user-initiated UI flow and troubleshooting notes

## Verification
- `vitest run --config vitest.component.config.ts components/features/account/components/DataExportButton.test.tsx` (3 tests passing)
- `git diff --check`
- `git diff --cached --check`

## Notes
- `tsc --noEmit --pretty false` currently fails on existing syntax errors outside this change, including `app/api/health/route.ts`, `lib/api/handler.ts`, `lib/auth.ts`, `lib/http/client.ts`, `lib/metrics/registry.ts`, and `lib/notifications/repository.ts`.
- The targeted component test emits an existing package warning about duplicate `drizzle-kit` keys in `package.json`.

Closes #413