### PR TITLE
fix(dashboard): validate and safely copy wallet address with clipboard fallback

### DIFF
--- a/components/features/dashboard/components/MetricsCards.test.tsx
+++ b/components/features/dashboard/components/MetricsCards.test.tsx
@@ -1,29 +1,121 @@
-import { render, screen } from '@testing-library/react';
-import MetricsCards from '@/components/features/dashboard/components/MetricsCards';
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import MetricsCards from "@/components/features/dashboard/components/MetricsCards";
+
+vi.mock("@/lib/utils/clipboard", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+import { copyToClipboard } from "@/lib/utils/clipboard";
 
 // Mock fetch for metric data
 global.fetch = vi.fn(() =>
   Promise.resolve({
-    json: () => Promise.resolve({
-      availableBalance: '1,000 XLM',
-      copyAddress: 'GABCDEF1234567890',
-      borrowedAmount: '500 XLM',
-      nextDue: '2024-12-31',
-      suppliedFunds: '2,000 XLM',
-      healthFactor: '1.5',
-      earnings: '50 XLM',
-    }),
-  }) as any
+    json: () =>
+      Promise.resolve({
+        availableBalance: "1,000 XLM",
+        copyAddress: "GABCDEF1234567890",
+        borrowedAmount: "500 XLM",
+        nextDue: "2024-12-31",
+        suppliedFunds: "2,000 XLM",
+        healthFactor: "1.5",
+        earnings: "50 XLM",
+      }),
+  }) as any,
 );
 
-test('renders three metric cards and uses responsive grid classes', async () => {
-  render(<MetricsCards />);
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
-  // Wait for data to load
-  const cards = await screen.findAllByRole('heading', { level: 3 });
-  expect(cards).toHaveLength(3);
+describe("MetricsCards", () => {
+  test("renders three metric cards and uses responsive grid classes", async () => {
+    render(<MetricsCards />);
 
-  // Verify grid container has Tailwind responsive classes
-  const grid = screen.getByRole('region', { name: /Scrollable metrics/i }).firstChild as HTMLElement;
-  expect(grid).toHaveClass('grid', 'grid-cols-1', 'sm:grid-cols-2', 'lg:grid-cols-3');
+    const cards = await screen.findAllByRole("heading", { level: 3 });
+    expect(cards).toHaveLength(3);
+
+    const grid = screen.getByRole("region", {
+      name: /Scrollable metrics/i,
+    }).firstChild as HTMLElement;
+    expect(grid).toHaveClass(
+      "grid",
+      "grid-cols-1",
+      "sm:grid-cols-2",
+      "lg:grid-cols-3",
+    );
+  });
+
+  test("copy button calls clipboard helper with validation", async () => {
+    const mockCopy = vi.mocked(copyToClipboard).mockResolvedValue({
+      success: true,
+    });
+
+    render(<MetricsCards />);
+
+    const copyBtn = await screen.findByRole("button", {
+      name: /Copy address to clipboard/i,
+    });
+    await act(() => fireEvent.click(copyBtn));
+
+    expect(mockCopy).toHaveBeenCalledWith("GABCDEF1234567890", true);
+  });
+
+  test("shows 'Copied!' feedback on successful copy", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue({ success: true });
+    vi.useFakeTimers();
+
+    render(<MetricsCards />);
+
+    const copyBtn = await screen.findByRole("button", {
+      name: /Copy address to clipboard/i,
+    });
+    await act(() => fireEvent.click(copyBtn));
+
+    expect(screen.getByText("Copied!")).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.queryByText("Copied!")).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  test("shows error toast when clipboard fails", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue({
+      success: false,
+      reason: "invalid_address",
+    });
+
+    render(<MetricsCards />);
+
+    const copyBtn = await screen.findByRole("button", {
+      name: /Copy address to clipboard/i,
+    });
+    await act(() => fireEvent.click(copyBtn));
+
+    expect(screen.getByText("Invalid Address")).toBeTruthy();
+    expect(
+      screen.getByText("The wallet address could not be validated before copying."),
+    ).toBeTruthy();
+  });
+
+  test("shows error toast for clipboard_error reason", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue({
+      success: false,
+      reason: "clipboard_error",
+    });
+
+    render(<MetricsCards />);
+
+    const copyBtn = await screen.findByRole("button", {
+      name: /Copy address to clipboard/i,
+    });
+    await act(() => fireEvent.click(copyBtn));
+
+    expect(screen.getByText("Copy Failed")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Clipboard access is unavailable. Try copying the address manually.",
+      ),
+    ).toBeTruthy();
+  });
 });

--- a/components/features/dashboard/components/MetricsCards.tsx
+++ b/components/features/dashboard/components/MetricsCards.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react";
 import { Copy } from "lucide-react";
 import ScrollCues from "@/components/atoms/ScrollCues/ScrollCues";
+import { Toast } from "@/components/shared/common";
+import { copyToClipboard, type CopyFailureReason } from "@/lib/utils/clipboard";
 
 interface MetricCardProps {
   icon: React.ReactNode;
@@ -24,13 +26,39 @@ const MetricCard: React.FC<MetricCardProps> = ({
   isPrimary = false,
 }) => {
   const [isCopied, setIsCopied] = useState(false);
+  const [toast, setToast] = useState<{
+    variant: "error" | "info";
+    title: string;
+    description: string;
+  } | null>(null);
 
-  const handleCopy = () => {
-    if (copyValue) {
-      navigator.clipboard.writeText(copyValue);
+  const handleCopy = async () => {
+    if (!copyValue) return;
+
+    const result = await copyToClipboard(copyValue, true);
+
+    if (result.success) {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2000);
+      return;
     }
+
+    const messages: Record<CopyFailureReason, { title: string; description: string }> = {
+      invalid_address: {
+        title: "Invalid Address",
+        description: "The wallet address could not be validated before copying.",
+      },
+      clipboard_error: {
+        title: "Copy Failed",
+        description: "Clipboard access is unavailable. Try copying the address manually.",
+      },
+    };
+
+    setToast({
+      variant: "error",
+      ...messages[result.reason!],
+    });
+    setTimeout(() => setToast(null), 4000);
   };
 
   const cardBg = isPrimary ? "bg-[#0A3D1E]" : "bg-[#097C4C]";
@@ -88,7 +116,7 @@ const MetricCard: React.FC<MetricCardProps> = ({
               </div>
               <button
                 onClick={(e) => {
-                  e.stopPropagation(); // Prevent bubbling to parent
+                  e.stopPropagation();
                   handleCopy();
                 }}
                 className={`${iconBgColor} hover:bg-opacity-80 rounded-md w-9 h-9 flex items-center justify-center transition-all ml-2 shrink-0`}
@@ -103,6 +131,13 @@ const MetricCard: React.FC<MetricCardProps> = ({
             </div>
           ) : null}
         </div>
+      )}
+      {toast && (
+        <Toast
+          variant={toast.variant}
+          title={toast.title}
+          description={toast.description}
+        />
       )}
     </div>
   );

--- a/lib/utils/clipboard.test.ts
+++ b/lib/utils/clipboard.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { copyToClipboard, type CopyResult } from "./clipboard";
+
+function mockSecureContext(secure: boolean) {
+  Object.defineProperty(window, "isSecureContext", {
+    value: secure,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe("copyToClipboard", () => {
+  describe("with address validation", () => {
+    it("rejects invalid Stellar addresses before attempting copy", async () => {
+      const result = await copyToClipboard("not-a-stellar-key", true);
+
+      expect(result).toEqual<CopyResult>({
+        success: false,
+        reason: "invalid_address",
+      });
+    });
+
+    it("accepts valid G-addresses", async () => {
+      mockSecureContext(true);
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        writable: true,
+        configurable: true,
+      });
+
+      const result = await copyToClipboard(
+        "GABCQZ2Q6YPRB5T2Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5A",
+        true,
+      );
+
+      expect(result).toEqual<CopyResult>({ success: true });
+      expect(writeText).toHaveBeenCalledWith(
+        "GABCQZ2Q6YPRB5T2Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5Z5A",
+      );
+    });
+  });
+
+  describe("without address validation", () => {
+    it("copies any string without validating", async () => {
+      mockSecureContext(true);
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        writable: true,
+        configurable: true,
+      });
+
+      const result = await copyToClipboard("anything", false);
+
+      expect(result).toEqual<CopyResult>({ success: true });
+      expect(writeText).toHaveBeenCalledWith("anything");
+    });
+  });
+
+  describe("async clipboard API present", () => {
+    beforeEach(() => {
+      mockSecureContext(true);
+    });
+
+    it("returns success when writeText resolves", async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        writable: true,
+        configurable: true,
+      });
+
+      const result = await copyToClipboard("test-value");
+
+      expect(result).toEqual<CopyResult>({ success: true });
+      expect(writeText).toHaveBeenCalledWith("test-value");
+    });
+
+    it("falls back to execCommand when writeText rejects", async () => {
+      const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        writable: true,
+        configurable: true,
+      });
+      vi.spyOn(document, "execCommand").mockReturnValue(true);
+      vi.spyOn(document, "createElement").mockImplementation(
+        (tag: string) => {
+          if (tag === "textarea") {
+            return {
+              value: "",
+              select: vi.fn(),
+              setSelectionRange: vi.fn(),
+              setAttribute: vi.fn(),
+              style: {},
+            } as unknown as HTMLTextAreaElement;
+          }
+          return document.createElement(tag);
+        },
+      );
+
+      const result = await copyToClipboard("fallback-test");
+
+      expect(result).toEqual<CopyResult>({ success: true });
+    });
+  });
+
+  describe("fallback via execCommand", () => {
+    it("uses execCommand when clipboard API is absent", async () => {
+      mockSecureContext(false);
+      Object.defineProperty(navigator, "clipboard", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      vi.spyOn(document, "execCommand").mockReturnValue(true);
+      vi.spyOn(document, "createElement").mockImplementation(
+        (tag: string) => {
+          if (tag === "textarea") {
+            return {
+              value: "",
+              select: vi.fn(),
+              setSelectionRange: vi.fn(),
+              setAttribute: vi.fn(),
+              style: {},
+            } as unknown as HTMLTextAreaElement;
+          }
+          return document.createElement(tag);
+        },
+      );
+      vi.spyOn(document.body, "appendChild").mockImplementation(vi.fn());
+      vi.spyOn(document.body, "removeChild").mockImplementation(vi.fn());
+
+      const result = await copyToClipboard("fallback-value");
+
+      expect(result).toEqual<CopyResult>({ success: true });
+      expect(document.execCommand).toHaveBeenCalledWith("copy");
+    });
+
+    it("returns clipboard_error when execCommand fails", async () => {
+      mockSecureContext(false);
+      Object.defineProperty(navigator, "clipboard", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      vi.spyOn(document, "execCommand").mockReturnValue(false);
+      vi.spyOn(document, "createElement").mockImplementation(
+        (tag: string) => {
+          if (tag === "textarea") {
+            return {
+              value: "",
+              select: vi.fn(),
+              setSelectionRange: vi.fn(),
+              setAttribute: vi.fn(),
+              style: {},
+            } as unknown as HTMLTextAreaElement;
+          }
+          return document.createElement(tag);
+        },
+      );
+      vi.spyOn(document.body, "appendChild").mockImplementation(vi.fn());
+      vi.spyOn(document.body, "removeChild").mockImplementation(vi.fn());
+
+      const result = await copyToClipboard("will-fail");
+
+      expect(result).toEqual<CopyResult>({
+        success: false,
+        reason: "clipboard_error",
+      });
+    });
+  });
+});

--- a/lib/utils/clipboard.ts
+++ b/lib/utils/clipboard.ts
@@ -1,0 +1,59 @@
+import { isAccountId } from "@/lib/validation/stellar";
+
+export type CopyFailureReason = "invalid_address" | "clipboard_error";
+
+export interface CopyResult {
+  success: boolean;
+  reason?: CopyFailureReason;
+}
+
+function execCommandFallback(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+
+  const range = document.getSelection()?.rangeCount
+    ? document.getSelection()?.getRangeAt(0)
+    : undefined;
+
+  textarea.select();
+  textarea.setSelectionRange(0, 99999);
+
+  const ok = document.execCommand("copy");
+  document.body.removeChild(textarea);
+
+  if (range) {
+    const sel = document.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  }
+
+  return ok;
+}
+
+export async function copyToClipboard(
+  text: string,
+  validateAsAddress = false,
+): Promise<CopyResult> {
+  if (validateAsAddress && !isAccountId(text)) {
+    return { success: false, reason: "invalid_address" };
+  }
+
+  try {
+    if (navigator?.clipboard && window?.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return { success: true };
+    }
+  } catch {
+    // async clipboard unavailable or rejected, try fallback
+  }
+
+  const fallbackOk = execCommandFallback(text);
+
+  return fallbackOk
+    ? { success: true }
+    : { success: false, reason: "clipboard_error" };
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,3 +1,5 @@
 // lib/utils/index.ts
 export { cn } from "./cn";
+export { copyToClipboard } from "./clipboard";
+export type { CopyResult, CopyFailureReason } from "./clipboard";
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
             "components/shared/layout/**/*.test.tsx",
             "components/shared/common/**/*.test.tsx",
             "components/shared/ui/**/*.test.tsx",
+            "lib/utils/clipboard.test.ts",
           ],
         },
       },


### PR DESCRIPTION
Closes #433 

Added a clipboard helper that validates Stellar addresses before copying, falls back to execCommand when the async clipboard API isn't available, and never injects raw text into the DOM. Uses the existing Toast component for error feedback so failures aren't silent.

The copy button in MetricsCards now calls copyToClipboard with validation enabled. Both "invalid address" and "clipboard unavailable" cases render a toast explaining what went wrong.

@1nonlypiece 