### PR TITLE
test: cover account export bundle scoping

### DIFF
--- a/lib/account/export-bundle.test.ts
+++ b/lib/account/export-bundle.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { processAccountExport, type ExportDataPayload } from './export-bundle';
+
+const VALID_PAYLOAD: ExportDataPayload = {
+  userId: 'user-123',
+  profile: {
+    id: 'user-123',
+    email: 'user@example.com',
+  },
+  preferences: {
+    currency: 'USD',
+    notifications: true,
+  },
+  transactions: [
+    { id: 'tx-1', userId: 'user-123', amount: '10.00' },
+    { id: 'tx-other', userId: 'user-999', amount: '999.00' },
+  ],
+  notifications: [
+    { id: 'note-1', userId: 'user-123', read: false },
+    { id: 'note-other', userId: 'user-456', read: true },
+  ],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('processAccountExport', () => {
+  it('throws when the user id is missing', async () => {
+    await expect(
+      processAccountExport({
+        ...VALID_PAYLOAD,
+        userId: '',
+      }),
+    ).rejects.toThrow('Missing required user contextual identifier.');
+  });
+
+  it('returns a signed URL scoped to the requesting user and stable export key', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+    const url = await processAccountExport(VALID_PAYLOAD);
+    const parsed = new URL(url);
+
+    expect(parsed.origin).toBe('https://storage.stellarlend.com');
+    expect(parsed.pathname).toBe('/exports/user-123/1700000000000-dsar.zip');
+    expect(parsed.searchParams.get('X-Amz-Algorithm')).toBe('AWS4-HMAC-SHA256');
+    expect(parsed.searchParams.get('X-Amz-Expires')).toBe('900');
+  });
+
+  it('does not leak unrelated user identifiers into the returned storage key or URL', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+    const url = await processAccountExport(VALID_PAYLOAD);
+
+    expect(url).toContain('/exports/user-123/');
+    expect(url).not.toContain('user-999');
+    expect(url).not.toContain('user-456');
+    expect(url).not.toContain('tx-other');
+    expect(url).not.toContain('note-other');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -99,6 +99,7 @@ export default defineConfig({
             "app/api/notifications/[id]/route.test.ts",
             "__tests__/**/*.test.ts",
             "lib/streams/**/*.test.ts",
+            "lib/account/export-bundle.test.ts",
           ],
         },
       },


### PR DESCRIPTION
Closes #541

## Summary
- Add focused coverage for `processAccountExport` missing-user validation.
- Stub `Date.now` for deterministic DSAR export keys.
- Assert the returned signed URL is scoped under `exports/<userId>/...` and includes `X-Amz-Expires=900`.
- Assert unrelated user identifiers from payload data are not embedded in the returned key/URL.
- Include the test in the `server-unit` Vitest project.

## Validation
- `vitest run --config vitest.server.config.ts lib/account/export-bundle.test.ts`
- `vitest run --config vitest.config.ts --project server-unit lib/account/export-bundle.test.ts`

If this PR is considered reward-eligible by the Stellar Wave / GrantFox campaign, payout preference is USDT ERC-20: `0x06f44f4839fd5df4f4670036d028b29dec939363`.