### PR TITLE
test: cover transaction validator clamping

### DIFF
--- a/lib/transactions/validator.test.ts
+++ b/lib/transactions/validator.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseTransactionParams } from './validator';
+
+function parse(query = '') {
+  return parseTransactionParams(new URLSearchParams(query));
+}
+
+describe('parseTransactionParams', () => {
+  it('applies defaults when query params are absent', () => {
+    expect(parse()).toEqual({
+      params: {
+        page: 1,
+        pageSize: 10,
+        sort: 'date-desc',
+        status: null,
+        asset: null,
+        startDate: null,
+        endDate: null,
+      },
+      errors: null,
+    });
+  });
+
+  it('clamps page below 1 and non-numeric page values to 1', () => {
+    expect(parse('page=-3').params.page).toBe(1);
+    expect(parse('page=abc').params.page).toBe(1);
+    expect(parse('page=2').params.page).toBe(2);
+  });
+
+  it('clamps pageSize into the 1..100 range and falls back for non-numeric values', () => {
+    expect(parse('pageSize=0').params.pageSize).toBe(1);
+    expect(parse('pageSize=101').params.pageSize).toBe(100);
+    expect(parse('pageSize=50').params.pageSize).toBe(50);
+    expect(parse('pageSize=abc').params.pageSize).toBe(10);
+  });
+
+  it('passes valid status and asset values with no errors', () => {
+    expect(parse('status=Completed&asset=XLM')).toEqual({
+      params: {
+        page: 1,
+        pageSize: 10,
+        sort: 'date-desc',
+        status: 'Completed',
+        asset: 'XLM',
+        startDate: null,
+        endDate: null,
+      },
+      errors: null,
+    });
+  });
+
+  it('collects exact errors for invalid status and asset values', () => {
+    expect(parse('status=Pending&asset=ETH').errors).toEqual([
+      'Invalid status',
+      'Invalid asset',
+    ]);
+  });
+
+  it('passes startDate and endDate through unmodified', () => {
+    expect(parse('startDate=2026-01-02&endDate=2026-02-03').params).toMatchObject({
+      startDate: '2026-01-02',
+      endDate: '2026-02-03',
+    });
+  });
+});

--- a/lib/transactions/validator.ts
+++ b/lib/transactions/validator.ts
@@ -3,9 +3,14 @@ import { TransactionStatus } from "../../types/Transaction";
 const VALID_STATUSES = new Set(["Completed", "Processing", "Failed"]);
 const VALID_ASSETS = new Set(["XLM", "BTC", "STRK"]);
 
+function parseIntegerParam(value: string | null, fallback: number) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 export function parseTransactionParams(searchParams: URLSearchParams) {
-  const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
-  const rawPageSize = parseInt(searchParams.get("pageSize") || "10", 10);
+  const page = Math.max(1, parseIntegerParam(searchParams.get("page"), 1));
+  const rawPageSize = parseIntegerParam(searchParams.get("pageSize"), 10);
   const pageSize = Math.min(100, Math.max(1, rawPageSize)); // Clamped to 100 max
   const sort = searchParams.get("sort") || "date-desc";
   const status = searchParams.get("status") as TransactionStatus | null;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -99,6 +99,7 @@ export default defineConfig({
             "app/api/notifications/[id]/route.test.ts",
             "__tests__/**/*.test.ts",
             "lib/streams/**/*.test.ts",
+            "lib/transactions/validator.test.ts",
           ],
         },
       },


### PR DESCRIPTION
## Summary
- add focused coverage for `parseTransactionParams` defaults, paging clamps, validation errors, and date passthrough
- handle non-numeric `page` and `pageSize` values with safe fallbacks instead of returning `NaN`
- include the validator test in the `server-unit` Vitest project

## Tests
- `vitest run --config vitest.server.config.ts lib/transactions/validator.test.ts`
- `vitest run --config vitest.config.ts --project server-unit lib/transactions/validator.test.ts`

Closes #516.

Reward/payment reference if applicable: USDT ERC-20 `0x06f44f4839fd5df4f4670036d028b29dec939363`.