### PR TITLE
security: verify database TLS by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,8 @@ STELLAR_SIGNING_SECRET=replace-with-stellar-signing-secret
 
 # Database and cache configuration
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/stellarlend
+DATABASE_SSL_INSECURE=false
+DATABASE_CA_CERT=
 REDIS_URL=redis://localhost:6379
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -34,6 +34,8 @@ This reference keeps `.env.example`, client bundle safety checks, and server-onl
 | `WEBHOOK_SECRET` | Yes for webhooks | placeholder secret | HMAC secret for transaction webhooks. Do not prefix with `NEXT_PUBLIC_`. |
 | `STELLAR_SIGNING_SECRET` | Wallet auth deployments | placeholder secret | Server-side Stellar signing secret. |
 | `DATABASE_URL` | Yes for persistence | local Postgres URL | Postgres connection for Drizzle-backed data. |
+| `DATABASE_SSL_INSECURE` | No | `false` | Production-only escape hatch to disable Postgres TLS certificate verification; logs a warning when set to `true`. |
+| `DATABASE_CA_CERT` | Private CA deployments | PEM certificate | Optional CA bundle used to keep production Postgres TLS verification enabled with a private CA. Literal `\n` sequences are converted to newlines. |
 | `REDIS_URL` | Background jobs | local Redis URL | BullMQ/job cache connection string. |
 | `REDIS_HOST` / `REDIS_PORT` | Background workers | `localhost` / `6379` | Host/port fallback for worker Redis connections. |
 | `CSRF_COOKIE_NAME` | No | `csrf-token` | CSRF cookie name. |

--- a/lib/db/pool-config.ts
+++ b/lib/db/pool-config.ts
@@ -1,0 +1,29 @@
+export type DbSslConfig = false | {
+  ca?: string;
+  rejectUnauthorized: boolean;
+};
+
+const INSECURE_SSL_WARNING =
+  'DATABASE_SSL_INSECURE=true disables PostgreSQL TLS certificate verification. Use only as a temporary escape hatch.';
+
+function normalizeCaCert(value?: string) {
+  const cert = value?.trim();
+  return cert ? cert.replace(/\\n/g, '\n') : undefined;
+}
+
+export function resolveDbSslConfig(env: NodeJS.ProcessEnv = process.env): DbSslConfig {
+  if (env.NODE_ENV !== 'production') {
+    return false;
+  }
+
+  if (env.DATABASE_SSL_INSECURE?.toLowerCase() === 'true') {
+    console.warn(INSECURE_SSL_WARNING);
+    return { rejectUnauthorized: false };
+  }
+
+  const ca = normalizeCaCert(env.DATABASE_CA_CERT);
+
+  return ca
+    ? { rejectUnauthorized: true, ca }
+    : { rejectUnauthorized: true };
+}

--- a/lib/db/pool.test.ts
+++ b/lib/db/pool.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveDbSslConfig } from './pool-config';
+
+describe('resolveDbSslConfig', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps local non-production connections unchanged', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(resolveDbSslConfig({ NODE_ENV: 'development' })).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('verifies production database certificates by default', () => {
+    expect(resolveDbSslConfig({ NODE_ENV: 'production' })).toEqual({
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('requires an explicit insecure flag before disabling certificate verification', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(resolveDbSslConfig({
+      DATABASE_SSL_INSECURE: 'true',
+      NODE_ENV: 'production',
+    })).toEqual({
+      rejectUnauthorized: false,
+    });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('DATABASE_SSL_INSECURE=true'));
+  });
+
+  it('uses a provided CA certificate while keeping verification enabled', () => {
+    expect(resolveDbSslConfig({
+      DATABASE_CA_CERT: '-----BEGIN CERTIFICATE-----\\nabc123\\n-----END CERTIFICATE-----',
+      NODE_ENV: 'production',
+    })).toEqual({
+      ca: '-----BEGIN CERTIFICATE-----\nabc123\n-----END CERTIFICATE-----',
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('does not treat false-like insecure flag values as opt-in', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(resolveDbSslConfig({
+      DATABASE_SSL_INSECURE: 'false',
+      NODE_ENV: 'production',
+    })).toEqual({
+      rejectUnauthorized: true,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/lib/db/pool.ts
+++ b/lib/db/pool.ts
@@ -1,8 +1,10 @@
 import { Pool } from 'pg';
 
+import { resolveDbSslConfig } from './pool-config';
+
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  ssl: resolveDbSslConfig(),
 });
 
 export default pool;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -98,6 +98,7 @@ export default defineConfig({
             "app/api/liquidations/route.test.ts",
             "app/api/notifications/[id]/route.test.ts",
             "__tests__/**/*.test.ts",
+            "lib/db/pool.test.ts",
             "lib/streams/**/*.test.ts",
           ],
         },


### PR DESCRIPTION
## Summary
- derive the Postgres pool TLS config from a tested helper instead of disabling certificate verification by default
- keep non-production local behaviour unchanged
- require `DATABASE_SSL_INSECURE=true` before disabling verification, with a warning
- support `DATABASE_CA_CERT` for private CA verification and document both flags
- include the pool TLS test in the `server-unit` Vitest project

## Tests
- `vitest run --config vitest.server.config.ts lib/db/pool.test.ts`
- `vitest run --config vitest.config.ts --project server-unit lib/db/pool.test.ts`

Closes #535.

Reward/payment reference if applicable: USDT ERC-20 `0x06f44f4839fd5df4f4670036d028b29dec939363`.