### PR TITLE
security: compare csrf tokens in constant time

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -270,6 +270,7 @@ openssl rand -base64 32
 ### 3. CSRF Protection
 
 httpOnly cookies with SameSite=Strict provide built-in CSRF protection.
+State-changing API helpers additionally compare CSRF cookie/header tokens with a length-guarded constant-time comparison to avoid token timing side channels.
 
 ### 4. Session Validation
 

--- a/lib/security/csrf.test.ts
+++ b/lib/security/csrf.test.ts
@@ -1,0 +1,74 @@
+import type { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+
+import { verifyCsrfToken } from './csrf';
+
+function createRequest(options: {
+  authorization?: string;
+  cookieToken?: string;
+  headerToken?: string;
+}) {
+  const headers = new Headers();
+
+  if (options.authorization) {
+    headers.set('authorization', options.authorization);
+  }
+
+  if (options.headerToken) {
+    headers.set('x-csrf-token', options.headerToken);
+  }
+
+  return {
+    headers,
+    cookies: {
+      get(name: string) {
+        if (name !== 'csrf-token' || !options.cookieToken) {
+          return undefined;
+        }
+
+        return {
+          name,
+          value: options.cookieToken,
+        };
+      },
+    },
+  } as unknown as NextRequest;
+}
+
+describe('verifyCsrfToken', () => {
+  it('accepts matching cookie and header tokens', () => {
+    expect(verifyCsrfToken(createRequest({
+      cookieToken: 'abc123',
+      headerToken: 'abc123',
+    }))).toBe(true);
+  });
+
+  it('rejects same-length mismatched tokens', () => {
+    expect(verifyCsrfToken(createRequest({
+      cookieToken: 'abc123',
+      headerToken: 'xyz789',
+    }))).toBe(false);
+  });
+
+  it('rejects different-length tokens without throwing', () => {
+    expect(verifyCsrfToken(createRequest({
+      cookieToken: 'short',
+      headerToken: 'a-much-longer-token',
+    }))).toBe(false);
+  });
+
+  it('preserves missing cookie or header rejection behaviour', () => {
+    expect(verifyCsrfToken(createRequest({
+      cookieToken: 'abc123',
+    }))).toBe(false);
+    expect(verifyCsrfToken(createRequest({
+      headerToken: 'abc123',
+    }))).toBe(false);
+  });
+
+  it('preserves the bearer authorization bypass', () => {
+    expect(verifyCsrfToken(createRequest({
+      authorization: 'Bearer api-token',
+    }))).toBe(true);
+  });
+});

--- a/lib/security/csrf.ts
+++ b/lib/security/csrf.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
 
 const CSRF_COOKIE_NAME = process.env.CSRF_COOKIE_NAME || 'csrf-token';
@@ -21,6 +22,17 @@ export function setCsrfCookie(response: NextResponse, token: string) {
   response.cookies.set(CSRF_COOKIE_NAME, token, cookieOptions);
 }
 
+function constantTimeTokenEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, 'utf8');
+  const rightBuffer = Buffer.from(right, 'utf8');
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
 export function verifyCsrfToken(request: NextRequest): boolean {
   const authorizationHeader = request.headers.get('authorization');
   if (authorizationHeader?.startsWith('Bearer ')) {
@@ -34,5 +46,5 @@ export function verifyCsrfToken(request: NextRequest): boolean {
     return false;
   }
 
-  return csrfCookie.value === csrfHeader;
+  return constantTimeTokenEqual(csrfCookie.value, csrfHeader);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -98,6 +98,7 @@ export default defineConfig({
             "app/api/liquidations/route.test.ts",
             "app/api/notifications/[id]/route.test.ts",
             "__tests__/**/*.test.ts",
+            "lib/security/csrf.test.ts",
             "lib/streams/**/*.test.ts",
           ],
         },


### PR DESCRIPTION
## Summary
- replace direct CSRF cookie/header string equality with a length-guarded `timingSafeEqual` comparison
- preserve missing-token rejection and Bearer authorization bypass behaviour
- add focused tests for matching, mismatched, different-length, missing-token, and Bearer-bypass paths
- document the timing-side-channel rationale in the auth docs

## Tests
- `vitest run --config vitest.server.config.ts lib/security/csrf.test.ts`
- `vitest run --config vitest.config.ts --project server-unit lib/security/csrf.test.ts`

Closes #534.

Reward/payment reference if applicable: USDT ERC-20 `0x06f44f4839fd5df4f4670036d028b29dec939363`.