### PR TITLE
feat: add liquidation risk panel

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,10 +1,9 @@
 "use client";
-import { useEffect, useState } from "react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
 import MetricsCards from "@/components/features/dashboard/components/MetricsCards";
-import PositionSummary from "@/components/features/dashboard/components/PositionSummary";
+import LiquidationsPanel from "@/components/features/dashboard/components/LiquidationsPanel";
 import { DashboardLayout } from "@/components";
 import { AlertBanner, PageHeader } from "@/components/shared/common";
 import { RecentTransactions } from "@/components/shared/common/RecentTransactions";
@@ -165,6 +164,9 @@ export default function Dashboard() {
           ) : null}
 
           <MetricsCards />
+          <div className="mt-6">
+            <LiquidationsPanel />
+          </div>
         </div>
 
         <div className="pt-8 ">

--- a/components/features/dashboard/components/LiquidationsPanel.test.tsx
+++ b/components/features/dashboard/components/LiquidationsPanel.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import LiquidationsPanel, {
+  getDistanceToLiquidationPercent,
+} from "./LiquidationsPanel";
+import type { LiquidationPosition } from "@/lib/positions/liquidation";
+
+const position = (
+  overrides: Partial<LiquidationPosition>,
+): LiquidationPosition => ({
+  asset: "XLM",
+  borrowedAmount: 100,
+  collateralAsset: "XLM",
+  collateralAmount: 200,
+  collateralFactor: 0.8,
+  healthFactor: 1.6,
+  liquidationPriceFactor: 0.63,
+  riskScore: 0.4,
+  ...overrides,
+});
+
+describe("LiquidationsPanel", () => {
+  it("renders liquidation price and distance columns from API outputs", () => {
+    render(
+      <LiquidationsPanel
+        initialPositions={[
+          position({
+            asset: "USDC",
+            borrowedAmount: 250,
+            collateralAsset: "XLM",
+            collateralAmount: 500,
+            healthFactor: 1.25,
+            liquidationPriceFactor: 0.5,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Liquidation Risk" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Liquidation price" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Distance" })).toBeInTheDocument();
+    expect(screen.getByText("0.50x")).toBeInTheDocument();
+    expect(screen.getByText("25.0%")).toBeInTheDocument();
+  });
+
+  it("sorts by distance ascending while preserving stable order for ties", () => {
+    render(
+      <LiquidationsPanel
+        initialPositions={[
+          position({ asset: "XLM", healthFactor: 1.2, liquidationPriceFactor: 0.7 }),
+          position({ asset: "USDC", healthFactor: 0.95, liquidationPriceFactor: 1.05 }),
+          position({ asset: "ETH", healthFactor: 1.2, liquidationPriceFactor: 0.7 }),
+          position({
+            asset: "BTC",
+            healthFactor: Number.POSITIVE_INFINITY,
+            liquidationPriceFactor: 0,
+          }),
+        ]}
+      />,
+    );
+
+    const rows = screen.getAllByRole("row").slice(1);
+
+    expect(within(rows[0]).getByText("100 USDC")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("100 XLM")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("100 ETH")).toBeInTheDocument();
+    expect(within(rows[3]).getByText("100 BTC")).toBeInTheDocument();
+  });
+
+  it("shows color-safe text labels for near and past liquidation rows", () => {
+    render(
+      <LiquidationsPanel
+        initialPositions={[
+          position({ asset: "USDC", healthFactor: 0.9, liquidationPriceFactor: 1.11 }),
+          position({ asset: "XLM", healthFactor: 1.08, liquidationPriceFactor: 0.93 }),
+          position({ asset: "ETH", healthFactor: 1.2, liquidationPriceFactor: 0.83 }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Past liquidation")).toBeInTheDocument();
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByText("Warning")).toBeInTheDocument();
+  });
+
+  it("places missing price and distance data after measurable positions", () => {
+    render(
+      <LiquidationsPanel
+        initialPositions={[
+          position({
+            asset: "BTC",
+            healthFactor: Number.POSITIVE_INFINITY,
+            liquidationPriceFactor: 0,
+          }),
+          position({ asset: "XLM", healthFactor: 1.1, liquidationPriceFactor: 0.91 }),
+        ]}
+      />,
+    );
+
+    const rows = screen.getAllByRole("row").slice(1);
+
+    expect(within(rows[0]).getByText("100 XLM")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("100 BTC")).toBeInTheDocument();
+    expect(within(rows[1]).getAllByText("N/A")).toHaveLength(2);
+    expect(within(rows[1]).getAllByText("Unavailable")).toHaveLength(2);
+  });
+
+  it("returns null distance for positions without a finite health factor", () => {
+    expect(
+      getDistanceToLiquidationPercent({
+        healthFactor: Number.POSITIVE_INFINITY,
+      }),
+    ).toBeNull();
+  });
+});

--- a/components/features/dashboard/components/LiquidationsPanel.tsx
+++ b/components/features/dashboard/components/LiquidationsPanel.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type {
+  LiquidationPosition,
+  LiquidationsResponse,
+} from "@/lib/positions/liquidation";
+
+interface LiquidationsPanelProps {
+  initialPositions?: LiquidationPosition[];
+  fetcher?: typeof fetch;
+  walletAddress?: string;
+}
+
+interface LiquidationRow extends LiquidationPosition {
+  distanceToLiquidation: number | null;
+  originalIndex: number;
+}
+
+type Severity = {
+  label: "Past liquidation" | "Critical" | "Warning" | "Buffer" | "Unavailable";
+  className: string;
+};
+
+export function getDistanceToLiquidationPercent(
+  position: Pick<LiquidationPosition, "healthFactor">,
+): number | null {
+  if (!Number.isFinite(position.healthFactor)) {
+    return null;
+  }
+
+  return Math.round((position.healthFactor - 1) * 1000) / 10;
+}
+
+function formatAmount(amount: number, asset: string): string {
+  return `${new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  }).format(amount)} ${asset}`;
+}
+
+function formatLiquidationPriceFactor(factor: number): string {
+  if (!Number.isFinite(factor) || factor <= 0) {
+    return "N/A";
+  }
+
+  return `${factor.toFixed(2)}x`;
+}
+
+function formatDistance(distance: number | null): string {
+  if (distance === null) {
+    return "Unavailable";
+  }
+
+  return `${distance.toFixed(1)}%`;
+}
+
+function getSeverity(distance: number | null): Severity {
+  if (distance === null) {
+    return {
+      label: "Unavailable",
+      className: "border-slate-600 bg-slate-900 text-slate-200",
+    };
+  }
+
+  if (distance <= 0) {
+    return {
+      label: "Past liquidation",
+      className: "border-red-500 bg-red-950 text-red-200",
+    };
+  }
+
+  if (distance <= 10) {
+    return {
+      label: "Critical",
+      className: "border-red-500 bg-red-950 text-red-200",
+    };
+  }
+
+  if (distance <= 25) {
+    return {
+      label: "Warning",
+      className: "border-amber-500 bg-amber-950 text-amber-100",
+    };
+  }
+
+  return {
+    label: "Buffer",
+    className: "border-emerald-600 bg-emerald-950 text-emerald-100",
+  };
+}
+
+function toSortedRows(positions: LiquidationPosition[]): LiquidationRow[] {
+  return positions
+    .map((position, originalIndex) => ({
+      ...position,
+      distanceToLiquidation: getDistanceToLiquidationPercent(position),
+      originalIndex,
+    }))
+    .sort((a, b) => {
+      if (a.distanceToLiquidation === null && b.distanceToLiquidation === null) {
+        return a.originalIndex - b.originalIndex;
+      }
+
+      if (a.distanceToLiquidation === null) {
+        return 1;
+      }
+
+      if (b.distanceToLiquidation === null) {
+        return -1;
+      }
+
+      if (a.distanceToLiquidation === b.distanceToLiquidation) {
+        return a.originalIndex - b.originalIndex;
+      }
+
+      return a.distanceToLiquidation - b.distanceToLiquidation;
+    });
+}
+
+export default function LiquidationsPanel({
+  initialPositions,
+  fetcher = fetch,
+  walletAddress,
+}: LiquidationsPanelProps) {
+  const [positions, setPositions] = useState<LiquidationPosition[]>(
+    initialPositions ?? [],
+  );
+  const [isLoading, setIsLoading] = useState(initialPositions === undefined);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialPositions !== undefined) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const query = walletAddress ? `?wallet=${encodeURIComponent(walletAddress)}` : "";
+
+    setIsLoading(true);
+    fetcher(`/api/liquidations${query}`, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Unable to load liquidation risk");
+        }
+
+        return response.json() as Promise<LiquidationsResponse>;
+      })
+      .then((data) => {
+        setPositions(data.positions);
+        setError(null);
+      })
+      .catch((cause) => {
+        if (cause instanceof DOMException && cause.name === "AbortError") {
+          return;
+        }
+
+        setError("Unable to load liquidation risk");
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [fetcher, initialPositions, walletAddress]);
+
+  const rows = useMemo(() => toSortedRows(positions), [positions]);
+
+  if (isLoading) {
+    return (
+      <section
+        className="rounded-xl border border-[#71B48D33] bg-[#0A3D1E] p-6 text-white"
+        aria-label="Liquidation risk"
+      >
+        <div role="status" aria-label="Loading liquidation risk">
+          Loading liquidation risk...
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section
+        className="rounded-xl border border-[#71B48D33] bg-[#0A3D1E] p-6 text-white"
+        aria-label="Liquidation risk"
+      >
+        <p role="alert" className="text-sm font-medium text-red-200">
+          {error}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="rounded-xl border border-[#71B48D33] bg-[#0A3D1E] p-6 text-white"
+      aria-labelledby="liquidations-panel-title"
+    >
+      <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 id="liquidations-panel-title" className="text-xl font-bold">
+            Liquidation Risk
+          </h2>
+          <p className="text-sm font-medium text-[#D4F3E6]">
+            Most at-risk positions are sorted first.
+          </p>
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="rounded-lg border border-[#71B48D33] bg-[#072815] p-4 text-sm text-[#D4F3E6]">
+          No liquidation risk positions found.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-separate border-spacing-y-2 text-left text-sm">
+            <caption className="sr-only">
+              Liquidation positions sorted by distance to liquidation
+            </caption>
+            <thead className="text-xs uppercase tracking-normal text-[#AAABAB]">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Borrowed
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Collateral
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Health
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Liquidation price
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Distance
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((position) => {
+                const severity = getSeverity(position.distanceToLiquidation);
+
+                return (
+                  <tr
+                    key={`${position.asset}-${position.collateralAsset}-${position.originalIndex}`}
+                    className="bg-[#072815]"
+                  >
+                    <td className="rounded-l-lg px-3 py-3 font-semibold">
+                      {formatAmount(position.borrowedAmount, position.asset)}
+                    </td>
+                    <td className="px-3 py-3">
+                      {formatAmount(
+                        position.collateralAmount,
+                        position.collateralAsset,
+                      )}
+                    </td>
+                    <td className="px-3 py-3 font-mono">
+                      {Number.isFinite(position.healthFactor)
+                        ? `${position.healthFactor.toFixed(2)}x`
+                        : "N/A"}
+                    </td>
+                    <td className="px-3 py-3 font-mono">
+                      {formatLiquidationPriceFactor(
+                        position.liquidationPriceFactor,
+                      )}
+                    </td>
+                    <td className="px-3 py-3 font-mono">
+                      {formatDistance(position.distanceToLiquidation)}
+                    </td>
+                    <td className="rounded-r-lg px-3 py-3">
+                      <span
+                        className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${severity.className}`}
+                      >
+                        {severity.label}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/features/dashboard/components/index.ts
+++ b/components/features/dashboard/components/index.ts
@@ -1,2 +1,3 @@
 export { default as MetricsCards } from './MetricsCards';
+export { default as LiquidationsPanel } from './LiquidationsPanel';
 export { default as PositionSummary } from './PositionSummary';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
             "components/shared/layout/**/*.test.tsx",
             "components/shared/common/**/*.test.tsx",
             "components/shared/ui/**/*.test.tsx",
+            "components/features/dashboard/**/*.test.tsx",
             "lib/utils/clipboard.test.ts",
             "components/features/lending/**/*.test.tsx",
             "hooks/**/*.test.ts",


### PR DESCRIPTION
Closes #485

## Summary
- Adds a dashboard LiquidationsPanel that reads /api/liquidations output and displays liquidation price and distance-to-liquidation columns
- Sorts positions by distance ascending so the most at-risk rows appear first, with stable ordering for ties and missing values last
- Adds color-safe severity labels for past-liquidation, critical, warning, buffer, and unavailable rows
- Adds focused RTL coverage for columns, sorting, missing-price handling, and severity labels

## Validation
- ./node_modules/.bin/vitest run --project accessibility components/features/dashboard/components/LiquidationsPanel.test.tsx
- git diff --check

Note: full `tsc --noEmit` currently fails on pre-existing unrelated repo errors in API/session/assets/transactions/lending modules.