### PR TITLE
test: cover hooks/useNotificationStream reconnect and cleanup

### DIFF
--- a/hooks/useNotificationStream.test.ts
+++ b/hooks/useNotificationStream.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useNotificationStream } from "./useNotificationStream";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  static reset() {
+    MockEventSource.instances = [];
+  }
+
+  url: string;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onopen: (() => void) | null = null;
+  close = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  receiveMessage(data: unknown) {
+    this.onmessage?.(
+      new MessageEvent("message", { data: JSON.stringify(data) }),
+    );
+  }
+
+  receiveRawMessage(data: string) {
+    this.onmessage?.(new MessageEvent("message", { data }));
+  }
+
+  triggerError() {
+    this.onerror?.(new Event("error"));
+  }
+
+  triggerOpen() {
+    this.onopen?.(new Event("open"));
+  }
+}
+
+describe("useNotificationStream", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockEventSource.reset();
+    vi.stubGlobal("EventSource", MockEventSource);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("creates EventSource with correct URL on mount", () => {
+    renderHook(() => useNotificationStream());
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe("/api/notifications/stream");
+  });
+
+  it("updates unreadCount when valid message is received", () => {
+    const { result } = renderHook(() => useNotificationStream());
+
+    act(() => {
+      MockEventSource.instances[0].receiveMessage({ unreadCount: 5 });
+    });
+
+    expect(result.current.unreadCount).toBe(5);
+  });
+
+  it("ignores malformed JSON without crashing", () => {
+    const { result } = renderHook(() => useNotificationStream());
+
+    act(() => {
+      MockEventSource.instances[0].receiveRawMessage("not-valid-json");
+    });
+
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it("ignores non-numeric unreadCount payload", () => {
+    const { result } = renderHook(() => useNotificationStream());
+
+    act(() => {
+      MockEventSource.instances[0].receiveMessage({ unreadCount: "abc" });
+    });
+    expect(result.current.unreadCount).toBe(0);
+
+    act(() => {
+      MockEventSource.instances[0].receiveMessage({ unreadCount: null });
+    });
+    expect(result.current.unreadCount).toBe(0);
+
+    act(() => {
+      MockEventSource.instances[0].receiveMessage({ unreadCount: undefined });
+    });
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it("closes source before scheduling reconnect on error", () => {
+    renderHook(() => useNotificationStream());
+    const instance = MockEventSource.instances[0];
+
+    act(() => {
+      instance.triggerError();
+    });
+
+    expect(instance.close).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(MockEventSource.instances).toHaveLength(2);
+  });
+
+  it("reconnects with exponential backoff up to 30s cap", () => {
+    renderHook(() => useNotificationStream());
+
+    act(() => {
+      MockEventSource.instances[0].triggerError();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    act(() => {
+      MockEventSource.instances[1].triggerError();
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(MockEventSource.instances).toHaveLength(3);
+
+    act(() => {
+      MockEventSource.instances[2].triggerError();
+    });
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(MockEventSource.instances).toHaveLength(4);
+
+    act(() => {
+      MockEventSource.instances[3].triggerError();
+    });
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+    expect(MockEventSource.instances).toHaveLength(5);
+
+    act(() => {
+      MockEventSource.instances[4].triggerError();
+    });
+    act(() => {
+      vi.advanceTimersByTime(16000);
+    });
+    expect(MockEventSource.instances).toHaveLength(6);
+
+    act(() => {
+      MockEventSource.instances[5].triggerError();
+    });
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+    expect(MockEventSource.instances).toHaveLength(7);
+
+    act(() => {
+      MockEventSource.instances[6].triggerError();
+    });
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+    expect(MockEventSource.instances).toHaveLength(8);
+  });
+
+  it("resets backoff to 1s after successful reconnect", () => {
+    renderHook(() => useNotificationStream());
+
+    act(() => {
+      MockEventSource.instances[0].triggerError();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    act(() => {
+      MockEventSource.instances[1].triggerOpen();
+    });
+
+    act(() => {
+      MockEventSource.instances[1].triggerError();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(MockEventSource.instances).toHaveLength(3);
+  });
+
+  it("unmount closes EventSource and clears pending reconnect timer", () => {
+    const { unmount } = renderHook(() => useNotificationStream());
+    const instance = MockEventSource.instances[0];
+
+    unmount();
+
+    expect(instance.close).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(MockEventSource.instances).toHaveLength(1);
+  });
+
+  it("does not create duplicate reconnect timers on multiple rapid errors", () => {
+    renderHook(() => useNotificationStream());
+    const instance = MockEventSource.instances[0];
+
+    act(() => {
+      instance.triggerError();
+      instance.triggerError();
+      instance.triggerError();
+    });
+
+    expect(instance.close).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(MockEventSource.instances).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #526

This PR adds a dedicated unit test suite for `useNotificationStream`, covering the hook's SSE lifecycle, reconnect behavior, message parsing, and cleanup without modifying any production code.

## What changed

* [x] Added `hooks/useNotificationStream.test.ts`
* [x] Mocked `EventSource` for deterministic SSE testing
* [x] Used fake timers to verify reconnect scheduling and cleanup
* [x] Kept the implementation unchanged (tests only)

## Test coverage

The new test suite covers:

* [x] Creates an `EventSource` for `/api/notifications/stream`
* [x] Updates `unreadCount` from valid SSE messages
* [x] Ignores malformed JSON without throwing
* [x] Ignores non-numeric `unreadCount` payloads
* [x] Closes the current connection before scheduling reconnects
* [x] Verifies exponential reconnect backoff (up to the 30s cap)
* [x] Resets reconnect backoff after a successful connection
* [x] Cleans up the `EventSource` and pending reconnect timer on unmount
* [x] Prevents duplicate reconnect timers during rapid consecutive errors

## Validation

* [x] Zero production code changes
* [x] No real network requests (mocked `EventSource`)
* [x] Hook lifecycle verified using React Testing Library
* [x] Reconnect behavior verified using fake timers

## Security Notes

This change is test-only. It validates the notification stream's reconnect and cleanup behavior while ensuring malformed payloads are safely ignored and no duplicate reconnect timers are created.
