### PR TITLE
feat: add useWallet hook over lib/auth/wallet.ts

### DIFF
--- a/hooks/useWallet.test.tsx
+++ b/hooks/useWallet.test.tsx
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useWallet, WalletProvider } from "./useWallet";
+import { createElement, type ReactNode } from "react";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(WalletProvider, null, children);
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as any).stellar;
+});
+
+describe("useWallet", () => {
+  it("returns initial disconnected state", () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    expect(result.current.account).toBeNull();
+    expect(result.current.network).toBe("testnet");
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("loads existing session on mount", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        session: { user: { walletAddress: "GABCDEF1234567890" } },
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.account).toBe("GABCDEF1234567890");
+    });
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it("handles no session on mount", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.account).toBeNull();
+    });
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("handles session fetch error gracefully", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.account).toBeNull();
+    });
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("reads network from config", () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    expect(result.current.network).toBe("testnet");
+  });
+
+  it("connects successfully", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const mockStellar = {
+      getPublicKey: vi.fn().mockResolvedValue("GABCDEF1234567890"),
+      signTransaction: vi.fn().mockResolvedValue("signed-xdr"),
+    };
+    (window as any).stellar = mockStellar;
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ transaction: "challenge-xdr" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ walletAddress: "GABCDEF1234567890" }),
+      } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.account).toBe("GABCDEF1234567890");
+    expect(result.current.isConnected).toBe(true);
+    expect(mockStellar.getPublicKey).toHaveBeenCalledOnce();
+    expect(mockStellar.signTransaction).toHaveBeenCalledOnce();
+  });
+
+  it("throws and sets error when Freighter is not available", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    delete (window as any).stellar;
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.connect();
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).toBe(
+          "Stellar wallet provider (Freighter) not detected",
+        );
+      }
+    });
+
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("throws and sets error when Freighter returns no public key", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue(null),
+      signTransaction: vi.fn(),
+    };
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.connect();
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).toBe("No public key returned from wallet");
+      }
+    });
+
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("throws and sets error when challenge API fails", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue("GABCDEF1234567890"),
+      signTransaction: vi.fn(),
+    };
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Server error" }),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.connect();
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).toBe("Server error");
+      }
+    });
+
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("throws and sets error when challenge API fails with no error message", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue("GABCDEF1234567890"),
+      signTransaction: vi.fn(),
+    };
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.connect();
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).toBe("Failed to generate challenge");
+      }
+    });
+
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("throws and sets error when verify API fails", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue("GABCDEF1234567890"),
+      signTransaction: vi.fn().mockResolvedValue("signed-xdr"),
+    };
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ transaction: "challenge-xdr" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "Invalid signature" }),
+      } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.connect();
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).toBe("Invalid signature");
+      }
+    });
+
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("disconnects successfully", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        session: { user: { walletAddress: "GABCDEF1234567890" } },
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(result.current.account).toBeNull();
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("throws and sets error when disconnect fails", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        session: { user: { walletAddress: "GABCDEF1234567890" } },
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    await act(async () => {
+      try {
+        await result.current.disconnect();
+        expect.fail("Should have thrown");
+      } catch (e: any) {
+        expect(e.message).toBe("Failed to disconnect");
+      }
+    });
+
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it("clears error on subsequent connect attempt", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    delete (window as any).stellar;
+
+    const { result } = renderHook(() => useWallet(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.connect();
+      } catch {
+        // expected
+      }
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.error).toBe(
+      "Stellar wallet provider (Freighter) not detected",
+    );
+
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue("GABCDEF1234567890"),
+      signTransaction: vi.fn().mockResolvedValue("signed-xdr"),
+    };
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ transaction: "challenge-xdr" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ walletAddress: "GABCDEF1234567890" }),
+      } as Response);
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("throws when used outside WalletProvider", () => {
+    expect(() => renderHook(() => useWallet())).toThrow(
+      "useWallet must be used within a WalletProvider",
+    );
+  });
+});

--- a/hooks/useWallet.tsx
+++ b/hooks/useWallet.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type ReactNode,
+} from "react";
+import { publicConfig } from "@/lib/config";
+
+export interface UseWalletResult {
+  account: string | null;
+  network: string;
+  isConnected: boolean;
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+}
+
+interface WalletState {
+  account: string | null;
+  isConnecting: boolean;
+  error: string | null;
+}
+
+const WalletContext = createContext<
+  | (UseWalletResult & { isConnecting: boolean; error: string | null })
+  | undefined
+>(undefined);
+
+const isBrowser = typeof window !== "undefined";
+
+interface WalletProviderProps {
+  children: ReactNode;
+}
+
+export function WalletProvider({ children }: WalletProviderProps) {
+  const [state, setState] = useState<WalletState>({
+    account: null,
+    isConnecting: false,
+    error: null,
+  });
+  const checkedSession = useRef(false);
+
+  const network = publicConfig.stellar.network;
+
+  useEffect(() => {
+    if (!isBrowser || checkedSession.current) return;
+    checkedSession.current = true;
+
+    fetch("/api/auth/session")
+      .then((res) => {
+        if (!res.ok) throw new Error("No session");
+        return res.json();
+      })
+      .then((data) => {
+        if (data?.session?.user?.walletAddress) {
+          setState((prev) => ({
+            ...prev,
+            account: data.session.user.walletAddress,
+          }));
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (!isBrowser) throw new Error("Cannot connect wallet during SSR");
+    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+
+    try {
+      const stellar = (window as any).stellar;
+      if (!stellar?.getPublicKey) {
+        throw new Error("Stellar wallet provider (Freighter) not detected");
+      }
+
+      const pubKey = await stellar.getPublicKey();
+      if (!pubKey) throw new Error("No public key returned from wallet");
+
+      const challengeRes = await fetch("/api/auth/challenge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ walletAddress: pubKey }),
+      });
+
+      if (!challengeRes.ok) {
+        const errData = await challengeRes.json().catch(() => ({}));
+        throw new Error(errData.error || "Failed to generate challenge");
+      }
+
+      const { transaction } = await challengeRes.json();
+      const networkPassphrase =
+        network === "mainnet" ? "PUBLIC" : "TESTNET";
+      const signedTransaction = await stellar.signTransaction(transaction, {
+        network: networkPassphrase,
+      });
+
+      const verifyRes = await fetch("/api/auth/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transaction: signedTransaction }),
+      });
+
+      if (!verifyRes.ok) {
+        const errData = await verifyRes.json().catch(() => ({}));
+        throw new Error(errData.error || "Verification failed");
+      }
+
+      const { walletAddress: verifiedAddress } = await verifyRes.json();
+      setState((prev) => ({
+        ...prev,
+        account: verifiedAddress,
+        isConnecting: false,
+      }));
+    } catch (err: any) {
+      const msg = err.message || "Wallet connection failed";
+      setState((prev) => ({ ...prev, error: msg, isConnecting: false }));
+      throw err;
+    }
+  }, [network]);
+
+  const disconnect = useCallback(async () => {
+    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+
+    try {
+      const res = await fetch("/api/auth/session", { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to disconnect");
+      setState((prev) => ({
+        ...prev,
+        account: null,
+        isConnecting: false,
+      }));
+    } catch (err: any) {
+      const msg = err.message || "Failed to disconnect";
+      setState((prev) => ({ ...prev, error: msg, isConnecting: false }));
+      throw err;
+    }
+  }, []);
+
+  const value = {
+    account: state.account,
+    network,
+    isConnected: state.account !== null,
+    connect,
+    disconnect,
+    isConnecting: state.isConnecting,
+    error: state.error,
+  };
+
+  return (
+    <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
+  );
+}
+
+export function useWallet(): UseWalletResult & {
+  isConnecting: boolean;
+  error: string | null;
+} {
+  const context = useContext(WalletContext);
+  if (!context) {
+    throw new Error("useWallet must be used within a WalletProvider");
+  }
+  return context;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
             "components/shared/ui/**/*.test.tsx",
             "lib/utils/clipboard.test.ts",
             "components/features/lending/**/*.test.tsx",
-            "hooks/**/*.test.ts",
+            "hooks/**/*.test.{ts,tsx}",
           ],
         },
       },


### PR DESCRIPTION
Adds a useWallet React hook (and WalletProvider context) wrapping the existing wallet connection logic from lib/auth/wallet.ts via client-side API routes.

hooks/useWallet.tsx — WalletProvider + useWallet exposing { account, network, isConnected, connect, disconnect, isConnecting, error }. SSR-safe, Freighter-based SEP-10 auth.

hooks/useWallet.test.tsx — 15 tests (initial state, session load, connect/disconnect flows, error handling, missing provider guard).

vitest.config.ts — Updated include pattern to hooks/**/*.test.{ts,tsx}.

Closes #492