### PR TITLE
test: add unit tests for lib/request-context AsyncLocalStorage propagation

### DIFF
--- a/lib/request-context.test.ts
+++ b/lib/request-context.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  runWithRequestContext,
+  getRequestContext,
+  getActiveRequestId,
+} from '@/lib/request-context';
+
+describe('request-context AsyncLocalStorage propagation', () => {
+  it('getRequestContext returns undefined outside a run', () => {
+    expect(getRequestContext()).toBeUndefined();
+  });
+
+  it('getActiveRequestId returns undefined outside a run', () => {
+    expect(getActiveRequestId()).toBeUndefined();
+  });
+
+  it('runWithRequestContext propagates context inside the callback', () => {
+    const ctx = { requestId: 'TEST-ID-001' };
+    runWithRequestContext(ctx, () => {
+      expect(getRequestContext()).toEqual(ctx);
+      expect(getActiveRequestId()).toBe('TEST-ID-001');
+    });
+  });
+
+  it('context is no longer available after the callback returns', () => {
+    runWithRequestContext({ requestId: 'EPHEMERAL' }, () => {
+      // confirm it's set inside
+      expect(getActiveRequestId()).toBe('EPHEMERAL');
+    });
+    // confirm it's gone outside
+    expect(getRequestContext()).toBeUndefined();
+  });
+
+  it('returns the callback return value', () => {
+    const result = runWithRequestContext({ requestId: 'RET-ID' }, () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('propagates context into nested async callbacks', async () => {
+    const ctx = { requestId: 'ASYNC-ID' };
+    await runWithRequestContext(ctx, async () => {
+      await Promise.resolve();
+      expect(getActiveRequestId()).toBe('ASYNC-ID');
+    });
+  });
+
+  it('isolates context between concurrent async runs', async () => {
+    const results: string[] = [];
+
+    await Promise.all([
+      runWithRequestContext({ requestId: 'A' }, async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        results.push(getActiveRequestId()!);
+      }),
+      runWithRequestContext({ requestId: 'B' }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        results.push(getActiveRequestId()!);
+      }),
+    ]);
+
+    expect(results).toContain('A');
+    expect(results).toContain('B');
+  });
+
+  it('inner run does not leak into outer run after inner completes', () => {
+    runWithRequestContext({ requestId: 'OUTER' }, () => {
+      runWithRequestContext({ requestId: 'INNER' }, () => {
+        expect(getActiveRequestId()).toBe('INNER');
+      });
+      // After inner run completes, outer context is restored
+      expect(getActiveRequestId()).toBe('OUTER');
+    });
+  });
+
+  it('nested runWithRequestContext uses innermost context', () => {
+    runWithRequestContext({ requestId: 'PARENT' }, () => {
+      runWithRequestContext({ requestId: 'CHILD' }, () => {
+        expect(getActiveRequestId()).toBe('CHILD');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #525

Adds unit tests for `lib/request-context.ts`, which wraps Node.js `AsyncLocalStorage` to propagate per-request context (request ID, etc.) through async call stacks without manual threading.

## What is tested

`lib/request-context.test.ts` — 9 tests:

| # | Test | Behaviour verified |
|---|------|--------------------|
| 1 | returns undefined outside a run | `getRequestContext()` is `undefined` when no storage context is active |
| 2 | `getActiveRequestId` returns undefined outside a run | convenience shorthand also returns `undefined` outside a run |
| 3 | propagates context inside the callback | `getRequestContext()` and `getActiveRequestId()` return the correct value inside `runWithRequestContext` |
| 4 | context is no longer available after the callback returns | storage is cleared once the synchronous callback exits |
| 5 | returns the callback return value | `runWithRequestContext` transparently passes through the return value |
| 6 | propagates context into nested async callbacks | context survives `await` / microtask boundaries |
| 7 | isolates context between concurrent async runs | two overlapping `runWithRequestContext` calls with different IDs do not bleed into each other |
| 8 | inner run does not leak into outer run after inner completes | after an inner `runWithRequestContext` exits, the outer context is restored |
| 9 | nested `runWithRequestContext` uses innermost context | inner context shadows outer during its own execution |

## Test output

```
vitest run --config vitest.server.config.ts lib/request-context.test.ts

 ✓  server  lib/request-context.test.ts (9 tests) 16ms

 Test Files  1 passed (1)
       Tests  9 passed (9)
   Duration  1.14s
```

## Checklist

- [x] Tests only — no production code changed
- [x] All 9 tests pass locally
- [x] Follows existing `vitest` server-config pattern used throughout `lib/`