### PR TITLE
Implemented on feature/health-factor-badge

### DIFF
--- a/components/features/lending/components/RepayForm.test.tsx
+++ b/components/features/lending/components/RepayForm.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import RepayForm, { BorrowPosition } from "./RepayForm";
+import RepayForm, {
+  BorrowPosition,
+  computeHealthAfterRepayment,
+} from "./RepayForm";
 
 const positions: BorrowPosition[] = [
   {
@@ -105,7 +108,10 @@ describe("RepayForm Component", () => {
     });
 
     expect(screen.getByText("1,000.00 XLM")).toBeInTheDocument();
-    expect(screen.getByText(/2.25 \(Healthy\)/i)).toBeInTheDocument();
+    expect(screen.getByText("2.25")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: /Projected health: Healthy/i }),
+    ).toBeInTheDocument();
   });
 
   it("shows full repayment preview as debt cleared", () => {
@@ -199,6 +205,10 @@ describe("RepayForm Component", () => {
 
     expect(screen.getByText("0.00 XLM")).toBeInTheDocument();
     expect(screen.getAllByText(/Debt cleared/i).length).toBeGreaterThan(0);
+  });
+
+  it("caps projected health at debt cleared when the input exceeds outstanding debt", () => {
+    expect(computeHealthAfterRepayment(1.5, 1500, 2000)).toBe(Infinity);
   });
 
   it("shows Healthy label for health factor >= 2", () => {

--- a/components/features/lending/components/RepayForm.tsx
+++ b/components/features/lending/components/RepayForm.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import type { CalculationResult, LendingData } from "@/lib/lending/types";
 import { Input } from "@/components/shared/ui/Input";
 import Button from "@/components/shared/ui/Button";
+import HealthFactorBadge from "@/components/shared/ui/HealthFactorBadge";
 import PositionSummary from "@/components/features/dashboard/components/PositionSummary";
 import { cn } from "@/lib/utils/cn";
 
@@ -53,19 +54,16 @@ const formatAmount = (amount: number, asset: string) =>
     maximumFractionDigits: 4,
   })} ${asset}`;
 
-const getHealthLabel = (healthFactor: number) => {
-  if (!Number.isFinite(healthFactor)) return "Debt cleared";
-  if (healthFactor >= 2) return "Healthy";
-  if (healthFactor >= 1) return "At Risk";
-  return "Critical";
-};
-
-const computeHealthAfterRepayment = (
+export const computeHealthAfterRepayment = (
   currentHealthFactor: number,
   outstandingDebt: number,
   repaymentAmount: number,
 ) => {
-  const remainingDebt = Math.max(outstandingDebt - repaymentAmount, 0);
+  const appliedRepayment = Math.min(
+    Math.max(repaymentAmount, 0),
+    outstandingDebt,
+  );
+  const remainingDebt = Math.max(outstandingDebt - appliedRepayment, 0);
 
   if (remainingDebt === 0) return Infinity;
 
@@ -96,7 +94,6 @@ export default function RepayForm({
       return {
         remainingDebt: 0,
         healthFactorAfter: 0,
-        label: "Unavailable",
       };
     }
 
@@ -113,7 +110,6 @@ export default function RepayForm({
     return {
       remainingDebt,
       healthFactorAfter,
-      label: getHealthLabel(healthFactorAfter),
     };
   }, [amount, selectedPosition]);
 
@@ -353,12 +349,14 @@ export default function RepayForm({
                 </div>
                 <div className="flex justify-between">
                   <span className="text-blue-700">Health factor</span>
-                  <span className="font-semibold text-gray-900">
-                    {Number.isFinite(preview.healthFactorAfter)
-                      ? preview.healthFactorAfter.toFixed(2)
-                      : "Debt cleared"}{" "}
-                    ({preview.label})
-                  </span>
+                  <div className="flex items-center gap-2 text-right">
+                    <span className="font-semibold text-gray-900">
+                      {Number.isFinite(preview.healthFactorAfter)
+                        ? preview.healthFactorAfter.toFixed(2)
+                        : "Debt cleared"}
+                    </span>
+                    <HealthFactorBadge healthFactor={preview.healthFactorAfter} />
+                  </div>
                 </div>
                 <div className="flex justify-between border-t border-blue-200 pt-2.5">
                   <span className="text-blue-700">Collateral</span>

--- a/components/features/lending/components/WithdrawForm.test.tsx
+++ b/components/features/lending/components/WithdrawForm.test.tsx
@@ -337,6 +337,9 @@ describe("WithdrawForm", () => {
       // newHF = 1.85 * (5000 - 100) / 5000 = 1.85 * 0.98 = 1.813
       // Use exact string to avoid matching "Health Factor Warning" banner text
       expect(screen.getByText("Health factor")).toBeInTheDocument();
+      expect(
+        screen.getByRole("status", { name: /Projected health: At Risk/i }),
+      ).toBeInTheDocument();
     });
 
     it("hides health factor in the preview for debt-free positions", () => {

--- a/components/features/lending/components/WithdrawForm.tsx
+++ b/components/features/lending/components/WithdrawForm.tsx
@@ -4,7 +4,12 @@ import { useMemo, useState } from "react";
 import type { LendingData } from "@/lib/lending/types";
 import { Input } from "@/components/shared/ui/Input";
 import Button from "@/components/shared/ui/Button";
+import HealthFactorBadge from "@/components/shared/ui/HealthFactorBadge";
 import PositionSummary from "@/components/features/dashboard/components/PositionSummary";
+import {
+  CRITICAL_HEALTH_FACTOR_THRESHOLD,
+  HEALTHY_HEALTH_FACTOR_THRESHOLD,
+} from "@/lib/lending/health";
 import { cn } from "@/lib/utils/cn";
 
 export interface SupplyPosition {
@@ -41,21 +46,11 @@ const DEFAULT_POSITIONS: SupplyPosition[] = [
   },
 ];
 
-const AT_RISK_THRESHOLD = 2.0;
-const CRITICAL_THRESHOLD = 1.0;
-
 const formatAmount = (amount: number, asset: string) =>
   `${amount.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 4,
   })} ${asset}`;
-
-const getHealthLabel = (healthFactor: number, hasDebt: boolean) => {
-  if (!hasDebt) return "N/A";
-  if (healthFactor >= AT_RISK_THRESHOLD) return "Healthy";
-  if (healthFactor >= CRITICAL_THRESHOLD) return "At Risk";
-  return "Critical";
-};
 
 export function computeWithdrawHealthFactor(
   currentHealthFactor: number,
@@ -87,12 +82,15 @@ export default function WithdrawForm({
 
   const selectedPosition = positions.find((p) => p.id === selectedPositionId);
   const withdrawableBalance = selectedPosition
-    ? Math.max(0, selectedPosition.suppliedAmount - selectedPosition.lockedCollateral)
+    ? Math.max(
+        0,
+        selectedPosition.suppliedAmount - selectedPosition.lockedCollateral,
+      )
     : 0;
 
   const preview = useMemo(() => {
     if (!selectedPosition) {
-      return { remainingSupplied: 0, healthFactorAfter: 0, label: "Unavailable" };
+      return { remainingSupplied: 0, healthFactorAfter: 0 };
     }
 
     const remainingSupplied = Math.max(
@@ -105,23 +103,22 @@ export default function WithdrawForm({
       amount,
       selectedPosition.outstandingDebt,
     );
-    const hasDebt = selectedPosition.outstandingDebt > 0;
-
     return {
       remainingSupplied,
       healthFactorAfter,
-      label: getHealthLabel(healthFactorAfter, hasDebt),
     };
   }, [amount, selectedPosition]);
 
   const hasDebt = (selectedPosition?.outstandingDebt ?? 0) > 0;
   const isHealthCritical =
-    hasDebt && amount > 0 && preview.healthFactorAfter < CRITICAL_THRESHOLD;
+    hasDebt &&
+    amount > 0 &&
+    preview.healthFactorAfter < CRITICAL_HEALTH_FACTOR_THRESHOLD;
   const isHealthAtRisk =
     hasDebt &&
     amount > 0 &&
-    preview.healthFactorAfter >= CRITICAL_THRESHOLD &&
-    preview.healthFactorAfter < AT_RISK_THRESHOLD;
+    preview.healthFactorAfter >= CRITICAL_HEALTH_FACTOR_THRESHOLD &&
+    preview.healthFactorAfter < HEALTHY_HEALTH_FACTOR_THRESHOLD;
 
   const positionSummaryData = selectedPosition
     ? {
@@ -378,9 +375,12 @@ export default function WithdrawForm({
                 {hasDebt && (
                   <div className="flex justify-between">
                     <span className="text-green-700">Health factor</span>
-                    <span className="font-semibold text-gray-900">
-                      {preview.healthFactorAfter.toFixed(2)} ({preview.label})
-                    </span>
+                    <div className="flex items-center gap-2 text-right">
+                      <span className="font-semibold text-gray-900">
+                        {preview.healthFactorAfter.toFixed(2)}
+                      </span>
+                      <HealthFactorBadge healthFactor={preview.healthFactorAfter} />
+                    </div>
                   </div>
                 )}
                 <div className="flex justify-between border-t border-green-200 pt-2.5">

--- a/components/shared/ui/HealthFactorBadge.test.tsx
+++ b/components/shared/ui/HealthFactorBadge.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import HealthFactorBadge from "./HealthFactorBadge";
+
+describe("HealthFactorBadge", () => {
+  it("renders the cleared state when debt is fully repaid", () => {
+    render(<HealthFactorBadge healthFactor={Infinity} />);
+
+    expect(screen.getByText("Debt cleared")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-health-band",
+      "cleared",
+    );
+  });
+
+  it("treats exactly 2.0 as healthy", () => {
+    render(<HealthFactorBadge healthFactor={2} />);
+
+    expect(screen.getByText("Healthy")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-health-band",
+      "healthy",
+    );
+  });
+
+  it("treats exactly 1.0 as at risk", () => {
+    render(<HealthFactorBadge healthFactor={1} />);
+
+    expect(screen.getByText("At Risk")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-health-band",
+      "at-risk",
+    );
+  });
+
+  it("renders critical state below the liquidation threshold", () => {
+    render(<HealthFactorBadge healthFactor={0.99} />);
+
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "data-health-band",
+      "critical",
+    );
+  });
+});

--- a/components/shared/ui/HealthFactorBadge.tsx
+++ b/components/shared/ui/HealthFactorBadge.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import {
+  CheckCircle2,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldX,
+} from "lucide-react";
+import {
+  colorNeutral,
+  colorSemantic,
+} from "@/constants/design-tokens";
+import { cn } from "@/lib/utils/cn";
+import { getHealthBand, getHealthLabel, type HealthBand } from "@/lib/lending/health";
+
+export interface HealthFactorBadgeProps {
+  healthFactor: number;
+  className?: string;
+}
+
+type BadgeConfig = {
+  label: string;
+  srPrefix: string;
+  backgroundColor: string;
+  borderColor: string;
+  textColor: string;
+  Icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+};
+
+const HEALTH_FACTOR_BADGE_CONFIG: Record<HealthBand, BadgeConfig> = {
+  healthy: {
+    label: "Healthy",
+    srPrefix: "Projected health",
+    backgroundColor: colorSemantic.successLight,
+    borderColor: colorSemantic.success,
+    textColor: colorSemantic.success,
+    Icon: ShieldCheck,
+  },
+  "at-risk": {
+    label: "At Risk",
+    srPrefix: "Projected health",
+    backgroundColor: colorSemantic.warningLight,
+    borderColor: colorSemantic.warning,
+    textColor: "#9A6700",
+    Icon: ShieldAlert,
+  },
+  critical: {
+    label: "Critical",
+    srPrefix: "Projected health",
+    backgroundColor: colorSemantic.errorLight,
+    borderColor: colorSemantic.error,
+    textColor: colorSemantic.error,
+    Icon: ShieldX,
+  },
+  cleared: {
+    label: "Debt cleared",
+    srPrefix: "Projected health",
+    backgroundColor: colorNeutral[100],
+    borderColor: colorNeutral[400],
+    textColor: colorNeutral[800],
+    Icon: CheckCircle2,
+  },
+};
+
+export default function HealthFactorBadge({
+  healthFactor,
+  className,
+}: HealthFactorBadgeProps) {
+  const band = getHealthBand(healthFactor);
+  const config = HEALTH_FACTOR_BADGE_CONFIG[band];
+  const Icon = config.Icon;
+  const visibleLabel = getHealthLabel(healthFactor);
+  const ariaLabel = `${config.srPrefix}: ${visibleLabel}`;
+
+  return (
+    <span
+      role="status"
+      aria-label={ariaLabel}
+      data-health-band={band}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold",
+        className,
+      )}
+      style={{
+        backgroundColor: config.backgroundColor,
+        borderColor: config.borderColor,
+        color: config.textColor,
+      }}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span>{visibleLabel}</span>
+    </span>
+  );
+}

--- a/components/shared/ui/index.ts
+++ b/components/shared/ui/index.ts
@@ -1,4 +1,5 @@
 export { default as Button } from './Button';
+export { default as HealthFactorBadge } from './HealthFactorBadge';
 export { StatusBadge, transactionStatusToVariant } from './StatusBadge';
 export type { StatusBadgeProps, StatusVariant, StatusBadgeSize } from './StatusBadge';
 export * from './icons';

--- a/lib/lending/health.test.ts
+++ b/lib/lending/health.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   calculateProjectedBorrowHealth,
+  CRITICAL_HEALTH_FACTOR_THRESHOLD,
+  getHealthLabel,
   getHealthBand,
+  HEALTHY_HEALTH_FACTOR_THRESHOLD,
 } from "@/lib/lending/health";
 
 const prices = {
@@ -53,8 +56,17 @@ describe("lending health preview", () => {
   });
 
   it("maps health bands to the PositionSummary thresholds", () => {
-    expect(getHealthBand(2)).toBe("healthy");
+    expect(getHealthBand(HEALTHY_HEALTH_FACTOR_THRESHOLD)).toBe("healthy");
     expect(getHealthBand(1.5)).toBe("at-risk");
+    expect(getHealthBand(CRITICAL_HEALTH_FACTOR_THRESHOLD)).toBe("at-risk");
     expect(getHealthBand(0.99)).toBe("critical");
+    expect(getHealthBand(Infinity)).toBe("cleared");
+  });
+
+  it("returns human-friendly health labels", () => {
+    expect(getHealthLabel(2.5)).toBe("Healthy");
+    expect(getHealthLabel(1.2)).toBe("At Risk");
+    expect(getHealthLabel(0.8)).toBe("Critical");
+    expect(getHealthLabel(Infinity)).toBe("Debt cleared");
   });
 });

--- a/lib/lending/health.ts
+++ b/lib/lending/health.ts
@@ -1,4 +1,7 @@
-export type HealthBand = "healthy" | "at-risk" | "critical";
+export type HealthBand = "healthy" | "at-risk" | "critical" | "cleared";
+
+export const HEALTHY_HEALTH_FACTOR_THRESHOLD = 2;
+export const CRITICAL_HEALTH_FACTOR_THRESHOLD = 1;
 
 export type PriceMap = Record<string, number>;
 
@@ -27,15 +30,32 @@ export interface BorrowHealthPreview {
 }
 
 export function getHealthBand(healthFactor: number): HealthBand {
-  if (healthFactor >= 2) {
+  if (!Number.isFinite(healthFactor)) {
+    return "cleared";
+  }
+
+  if (healthFactor >= HEALTHY_HEALTH_FACTOR_THRESHOLD) {
     return "healthy";
   }
 
-  if (healthFactor >= 1) {
+  if (healthFactor >= CRITICAL_HEALTH_FACTOR_THRESHOLD) {
     return "at-risk";
   }
 
   return "critical";
+}
+
+export function getHealthLabel(healthFactor: number): string {
+  switch (getHealthBand(healthFactor)) {
+    case "healthy":
+      return "Healthy";
+    case "at-risk":
+      return "At Risk";
+    case "critical":
+      return "Critical";
+    case "cleared":
+      return "Debt cleared";
+  }
 }
 
 export function calculateProjectedBorrowHealth({


### PR DESCRIPTION
Summary
add reusable HealthFactorBadge for projected lending health states
show projected post-repay health badge in RepayForm
reuse the badge in WithdrawForm where health preview is applicable
centralize health threshold and label logic, including debt-cleared handling
add tests for cleared debt, threshold boundaries (2.0, 1.0), and over-repayment clamping
Testing
npm test -- --run components/shared/ui/HealthFactorBadge.test.tsx components/features/lending/components/RepayForm.test.tsx components/features/lending/components/WithdrawForm.test.tsx lib/lending/health.test.ts
./node_modules/.bin/vitest --run components/shared/ui/HealthFactorBadge.test.tsx components/features/lending/components/RepayForm.test.tsx components/features/lending/components/WithdrawForm.test.tsx lib/lending/health.test.ts --coverage.enabled --coverage.include=components/shared/ui/HealthFactorBadge.tsx --coverage.include=components/features/lending/components/RepayForm.tsx --coverage.include=components/features/lending/components/WithdrawForm.tsx --coverage.include=lib/lending/health.ts
Closes #482