### PR TITLE
security: constant-time CSRF token comparison in verifyCsrfToken

### DIFF
--- a/lib/security/csrf.test.ts
+++ b/lib/security/csrf.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { verifyCsrfToken } from '@/lib/security/csrf';
+
+function makeRequest(opts: {
+  cookie?: string;
+  header?: string;
+  authorization?: string;
+}): NextRequest {
+  const headers: Record<string, string> = {};
+  const cookieParts: string[] = [];
+  if (opts.cookie !== undefined) cookieParts.push(`csrf-token=${opts.cookie}`);
+  if (cookieParts.length > 0) headers['Cookie'] = cookieParts.join('; ');
+  if (opts.header !== undefined) headers['x-csrf-token'] = opts.header;
+  if (opts.authorization !== undefined) headers['authorization'] = opts.authorization;
+
+  return new NextRequest('http://localhost/api/whatever', { headers });
+}
+
+describe('verifyCsrfToken', () => {
+  it('returns true when cookie and header tokens match', () => {
+    const req = makeRequest({ cookie: 'abc123', header: 'abc123' });
+    expect(verifyCsrfToken(req)).toBe(true);
+  });
+
+  it('returns false when cookie and header tokens differ (same length)', () => {
+    const req = makeRequest({ cookie: 'abc123', header: 'xyz789' });
+    expect(verifyCsrfToken(req)).toBe(false);
+  });
+
+  it('returns false when cookie and header tokens differ in length', () => {
+    const req = makeRequest({ cookie: 'abc123', header: 'abc123extra' });
+    expect(verifyCsrfToken(req)).toBe(false);
+  });
+
+  it('returns false when the cookie is missing', () => {
+    const req = makeRequest({ header: 'abc123' });
+    expect(verifyCsrfToken(req)).toBe(false);
+  });
+
+  it('returns false when the header is missing', () => {
+    const req = makeRequest({ cookie: 'abc123' });
+    expect(verifyCsrfToken(req)).toBe(false);
+  });
+
+  it('returns false when both cookie and header are missing', () => {
+    const req = makeRequest({});
+    expect(verifyCsrfToken(req)).toBe(false);
+  });
+
+  it('returns true for a Bearer authorization header even without csrf cookie/header', () => {
+    const req = makeRequest({ authorization: 'Bearer some-token' });
+    expect(verifyCsrfToken(req)).toBe(true);
+  });
+
+  it('does not bypass via Bearer prefix when authorization header is malformed', () => {
+    const req = makeRequest({ authorization: 'bearer-not-real', cookie: 'abc', header: 'xyz' });
+    expect(verifyCsrfToken(req)).toBe(false);
+  });
+});

--- a/lib/security/csrf.ts
+++ b/lib/security/csrf.ts
@@ -1,6 +1,23 @@
+import { timingSafeEqual } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 
 const CSRF_COOKIE_NAME = process.env.CSRF_COOKIE_NAME || 'csrf-token';
+
+/**
+ * Constant-time string comparison to avoid leaking token contents via
+ * timing side-channels. `timingSafeEqual` requires equal-length buffers,
+ * so unequal-length inputs are rejected before comparison (this length
+ * check itself is not secret-dependent, so it doesn't reintroduce a
+ * meaningful timing leak).
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a);
+  const bufferB = Buffer.from(b);
+  if (bufferA.length !== bufferB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufferA, bufferB);
+}
 
 export function generateCsrfToken(): string {
   const array = new Uint8Array(16);
@@ -34,5 +51,5 @@ export function verifyCsrfToken(request: NextRequest): boolean {
     return false;
   }
 
-  return csrfCookie.value === csrfHeader;
+  return constantTimeEqual(csrfCookie.value, csrfHeader);
 }


### PR DESCRIPTION
## Summary
- Replace the `===` equality check in `verifyCsrfToken` (lib/security/csrf.ts) with a length-guarded `crypto.timingSafeEqual` comparison, matching the pattern already used by the webhook signature verifier (`lib/webhooks/verify.ts`).
- Bearer-bypass and missing-cookie/header behaviour is preserved exactly.

Closes #534

## Test plan
- [x] Added `lib/security/csrf.test.ts` covering: matching tokens, mismatched same-length tokens, mismatched-length tokens, missing cookie, missing header, missing both, Bearer bypass, and malformed authorization header (no bypass).
- [x] `npx tsc --noEmit` passes with no errors in the changed files.
- Note: `vitest` could not be executed in this sandbox due to a pre-existing Vite 7 (ESM-only) / Node 20 CJS config-loading incompatibility affecting all tests in this repo (reproduced with the existing `lib/webhooks/verify.test.ts` as well); this is unrelated to this change. The comparison helper's logic was manually verified with a standalone script.