### PR TITLE
security: verify DB TLS by default and gate insecure mode behind a flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,10 @@ STELLAR_SIGNING_SECRET=replace-with-stellar-signing-secret
 
 # Database and cache configuration
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/stellarlend
+# Set to "true" ONLY to disable TLS cert verification (insecure, production opt-in with explicit sign-off)
+DATABASE_SSL_INSECURE=false
+# PEM CA certificate for private-CA TLS verification (leave blank to use system CAs)
+DATABASE_CA_CERT=
 REDIS_URL=redis://localhost:6379
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/__tests__/db/pool.test.ts
+++ b/__tests__/db/pool.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock pg so no real DB connection is needed
+vi.mock('pg', () => {
+  const Pool = vi.fn().mockImplementation(() => ({}));
+  return { Pool };
+});
+
+// Mock logger to capture warnings
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn() },
+}));
+
+describe('buildSslConfig', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns false in non-production', async () => {
+    process.env.NODE_ENV = 'development';
+    const { buildSslConfig } = await import('@/lib/db/pool');
+    expect(buildSslConfig()).toBe(false);
+  });
+
+  it('returns { rejectUnauthorized: true } in production by default', async () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.DATABASE_SSL_INSECURE;
+    delete process.env.DATABASE_CA_CERT;
+    const { buildSslConfig } = await import('@/lib/db/pool');
+    expect(buildSslConfig()).toEqual({ rejectUnauthorized: true });
+  });
+
+  it('includes ca when DATABASE_CA_CERT is set in production', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DATABASE_CA_CERT = '-----BEGIN CERTIFICATE-----\nMIIBxxx\n-----END CERTIFICATE-----';
+    delete process.env.DATABASE_SSL_INSECURE;
+    const { buildSslConfig } = await import('@/lib/db/pool');
+    expect(buildSslConfig()).toEqual({
+      rejectUnauthorized: true,
+      ca: process.env.DATABASE_CA_CERT,
+    });
+  });
+
+  it('disables verification when DATABASE_SSL_INSECURE=true and emits a warning', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DATABASE_SSL_INSECURE = 'true';
+    delete process.env.DATABASE_CA_CERT;
+    const { buildSslConfig } = await import('@/lib/db/pool');
+    const { logger } = await import('@/lib/logger');
+    expect(buildSslConfig()).toEqual({ rejectUnauthorized: false });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('ignores DATABASE_SSL_INSECURE=true in non-production (returns false)', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.DATABASE_SSL_INSECURE = 'true';
+    const { buildSslConfig } = await import('@/lib/db/pool');
+    expect(buildSslConfig()).toBe(false);
+  });
+});

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -34,6 +34,8 @@ This reference keeps `.env.example`, client bundle safety checks, and server-onl
 | `WEBHOOK_SECRET` | Yes for webhooks | placeholder secret | HMAC secret for transaction webhooks. Do not prefix with `NEXT_PUBLIC_`. |
 | `STELLAR_SIGNING_SECRET` | Wallet auth deployments | placeholder secret | Server-side Stellar signing secret. |
 | `DATABASE_URL` | Yes for persistence | local Postgres URL | Postgres connection for Drizzle-backed data. |
+| `DATABASE_SSL_INSECURE` | No | `false` | Set to `true` to disable TLS certificate verification for the database connection. **Insecure — opt-in only.** A warning is logged whenever this is enabled. |
+| `DATABASE_CA_CERT` | No | — | PEM-encoded CA certificate to verify the database server's TLS certificate. Use this to satisfy verification with a private CA instead of disabling verification. |
 | `REDIS_URL` | Background jobs | local Redis URL | BullMQ/job cache connection string. |
 | `REDIS_HOST` / `REDIS_PORT` | Background workers | `localhost` / `6379` | Host/port fallback for worker Redis connections. |
 | `CSRF_COOKIE_NAME` | No | `csrf-token` | CSRF cookie name. |

--- a/lib/db/pool.ts
+++ b/lib/db/pool.ts
@@ -1,8 +1,25 @@
-import { Pool } from 'pg';
+import { Pool, type PoolConfig } from 'pg';
+import { logger } from '@/lib/logger';
+
+export function buildSslConfig(): PoolConfig['ssl'] {
+  const isProd = process.env.NODE_ENV === 'production';
+
+  if (!isProd) {
+    return false;
+  }
+
+  if (process.env.DATABASE_SSL_INSECURE === 'true') {
+    logger.warn('DATABASE_SSL_INSECURE is enabled — TLS certificate verification is disabled. Do not use in production without explicit sign-off.');
+    return { rejectUnauthorized: false };
+  }
+
+  const ca = process.env.DATABASE_CA_CERT;
+  return ca ? { rejectUnauthorized: true, ca } : { rejectUnauthorized: true };
+}
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  ssl: buildSslConfig(),
 });
 
 export default pool;


### PR DESCRIPTION
## Summary

Fixes #535

`lib/db/pool.ts` was creating the Postgres pool with `ssl: { rejectUnauthorized: false }` unconditionally in production, silently disabling TLS certificate verification and exposing connections to MITM attacks.

## Changes

### `lib/db/pool.ts`
- Exports `buildSslConfig()` for testability
- **Production (default):** `{ rejectUnauthorized: true }` — verifies the server certificate
- **Production + `DATABASE_CA_CERT`:** `{ rejectUnauthorized: true, ca }` — private CA pinning
- **Production + `DATABASE_SSL_INSECURE=true`:** `{ rejectUnauthorized: false }` — explicit opt-in escape hatch, emits a `logger.warn`
- **Non-production:** `false` — unchanged local behaviour

### `__tests__/db/pool.test.ts`
5 tests covering every env combination:
- Non-production → `false`
- Production default → `{ rejectUnauthorized: true }`
- Production + CA cert → `{ rejectUnauthorized: true, ca }`
- Production + insecure flag → `{ rejectUnauthorized: false }` + warning logged
- Non-production + insecure flag → still `false` (flag is no-op outside prod)

### `docs/ENVIRONMENT.md` / `.env.example`
Documents `DATABASE_SSL_INSECURE` and `DATABASE_CA_CERT` with security notes.

## Test results

```
✓ server-unit  __tests__/db/pool.test.ts (5 tests) 37ms
Test Files  1 passed (1)
      Tests  5 passed (5)
```

Env-example sync check also passes (2/2).