### PR TITLE
feat: add NotificationPreferences settings page (#512)

### DIFF
--- a/app/account/notifications/page.test.tsx
+++ b/app/account/notifications/page.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Tests for app/account/notifications/page.tsx
+ *
+ * The page renders inside the Sidebar + PageHeader shell.
+ * Actual toggle/API behaviour is covered in
+ * components/features/account/components/NotificationPreferences.test.tsx.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import NotificationsPage from "./page";
+
+// Sidebar uses usePathname / useSidebar hooks – stub them out.
+vi.mock("@/components/shared/layout/Sidebar", () => ({
+  default: () => <nav data-testid="sidebar" />,
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/account/notifications",
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/context/SidebarContext", () => ({
+  useSidebar: () => ({
+    isSidebarOpen: true,
+    isMobile: false,
+    toggleSidebar: vi.fn(),
+    closeSidebar: vi.fn(),
+  }),
+}));
+
+const defaultPrefs = { email: true, push: true, sms: false, inApp: true };
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ notifications: defaultPrefs }),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("NotificationsPage", () => {
+  it("renders the page header title", async () => {
+    render(<NotificationsPage />);
+    expect(screen.getByText("Notification Preferences")).toBeInTheDocument();
+  });
+
+  it("renders the sidebar", () => {
+    render(<NotificationsPage />);
+    expect(screen.getByTestId("sidebar")).toBeInTheDocument();
+  });
+
+  it("renders the NotificationPreferences component", async () => {
+    render(<NotificationsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /toggle email/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/app/account/notifications/page.tsx
+++ b/app/account/notifications/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Sidebar from "@/components/shared/layout/Sidebar";
+import { PageHeader } from "@/components/shared/common";
+import NotificationPreferences from "@/components/features/account/components/NotificationPreferences";
+
+export default function NotificationsPage() {
+  return (
+    <div className="bg-gray-50 min-h-screen p-4 md:p-6 lg:p-8">
+      <div className="flex flex-col md:flex-row gap-6 max-w-6xl mx-auto">
+        <Sidebar />
+
+        <div className="flex-1 bg-white rounded-lg shadow-sm p-4 md:p-6">
+          <PageHeader
+            tone="light"
+            title="Notification Preferences"
+            description="Manage which channels you receive notifications on."
+          />
+          <NotificationPreferences />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/features/account/components/NotificationPreferences.test.tsx
+++ b/components/features/account/components/NotificationPreferences.test.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import NotificationPreferences from "./NotificationPreferences";
+
+const defaultPrefs = { email: true, push: true, sms: false, inApp: true };
+
+const makeFetch = (notifications = defaultPrefs) =>
+  vi.fn().mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ notifications }),
+  });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("NotificationPreferences", () => {
+  it("shows loading state initially", () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<NotificationPreferences />);
+    expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it("renders all four toggle channels after load", async () => {
+    global.fetch = makeFetch();
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle email/i })).toBeInTheDocument()
+    );
+    expect(screen.getByRole("switch", { name: /toggle push/i })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: /toggle sms/i })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: /toggle in-app/i })).toBeInTheDocument();
+  });
+
+  it("reflects loaded preference state in toggles", async () => {
+    global.fetch = makeFetch({ email: true, push: false, sms: false, inApp: true });
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle email/i })).toBeInTheDocument()
+    );
+
+    expect(screen.getByRole("switch", { name: /toggle email/i })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("switch", { name: /toggle push/i })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("switch", { name: /toggle sms/i })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("switch", { name: /toggle in-app/i })).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("shows error state when GET rejects", async () => {
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Network error")
+    );
+  });
+
+  it("shows error when GET returns non-ok", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+    render(<NotificationPreferences />);
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+  });
+
+  it("optimistically toggles a channel on click", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: defaultPrefs }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: { ...defaultPrefs, email: false } }) });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle email/i })).toHaveAttribute("aria-checked", "true")
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: /toggle email/i }));
+
+    // Optimistic update is synchronous
+    expect(screen.getByRole("switch", { name: /toggle email/i })).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("shows success toast after successful save", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: defaultPrefs }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: { ...defaultPrefs, sms: true } }) });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle sms/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: /toggle sms/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(/preferences saved/i)
+    );
+  });
+
+  it("rolls back optimistic toggle on save failure", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: defaultPrefs }) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({ error: "Server error" }) });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle email/i })).toHaveAttribute("aria-checked", "true")
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: /toggle email/i }));
+    // Optimistic toggle to false
+    expect(screen.getByRole("switch", { name: /toggle email/i })).toHaveAttribute("aria-checked", "false");
+
+    // After failed PUT, rolls back to true
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle email/i })).toHaveAttribute("aria-checked", "true")
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(/save failed/i);
+  });
+
+  it("rolls back and shows error toast on network failure during save", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: defaultPrefs }) })
+      .mockRejectedValueOnce(new Error("Network error"));
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle push/i })).toHaveAttribute("aria-checked", "true")
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: /toggle push/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle push/i })).toHaveAttribute("aria-checked", "true")
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(/save failed/i);
+  });
+
+  it("sends PUT with correct notifications body when toggling", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: defaultPrefs }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: { ...defaultPrefs, email: false } }) });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle email/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: /toggle email/i }));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/account/preferences",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ notifications: { ...defaultPrefs, email: false } }),
+        })
+      )
+    );
+  });
+
+  it("all-off state: all toggles show aria-checked=false", async () => {
+    global.fetch = makeFetch({ email: false, push: false, sms: false, inApp: false });
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle email/i })).toBeInTheDocument()
+    );
+
+    for (const name of ["email", "push", "sms", "in-app"]) {
+      expect(
+        screen.getByRole("switch", { name: new RegExp(`toggle ${name}`, "i") })
+      ).toHaveAttribute("aria-checked", "false");
+    }
+  });
+
+  it("toast auto-dismisses after 4 seconds", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: defaultPrefs }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ notifications: { ...defaultPrefs, inApp: false } }) });
+
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("switch", { name: /toggle in-app/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: /toggle in-app/i }));
+
+    await waitFor(() => expect(screen.getByRole("status")).toBeInTheDocument());
+
+    act(() => vi.advanceTimersByTime(4000));
+
+    await waitFor(() =>
+      expect(screen.queryByText(/preferences saved/i)).not.toBeInTheDocument()
+    );
+  });
+});

--- a/components/features/account/components/NotificationPreferences.tsx
+++ b/components/features/account/components/NotificationPreferences.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import Toast from "@/components/shared/common/Toast";
+
+interface NotificationChannels {
+  email: boolean;
+  push: boolean;
+  sms: boolean;
+  inApp: boolean;
+}
+
+interface Toast {
+  variant: "success" | "error";
+  title: string;
+  description?: string;
+}
+
+const CHANNELS: { key: keyof NotificationChannels; label: string; description: string }[] = [
+  { key: "email", label: "Email", description: "Receive notifications via email." },
+  { key: "push", label: "Push", description: "Receive push notifications in your browser." },
+  { key: "sms", label: "SMS", description: "Receive notifications via text message." },
+  { key: "inApp", label: "In-App", description: "Receive notifications inside the app." },
+];
+
+export default function NotificationPreferences() {
+  const [prefs, setPrefs] = useState<NotificationChannels | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<Toast | null>(null);
+
+  const showToast = (t: Toast) => {
+    setToast(t);
+    setTimeout(() => setToast(null), 4000);
+  };
+
+  useEffect(() => {
+    fetch("/api/account/preferences")
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Failed to load preferences.");
+        const data = await res.json();
+        setPrefs(data.notifications);
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const toggle = useCallback(
+    async (channel: keyof NotificationChannels) => {
+      if (!prefs) return;
+
+      const updated = { ...prefs, [channel]: !prefs[channel] };
+      setPrefs(updated); // optimistic
+
+      try {
+        const res = await fetch("/api/account/preferences", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ notifications: updated }),
+        });
+
+        if (!res.ok) throw new Error("Failed to save preferences.");
+
+        showToast({ variant: "success", title: "Preferences saved." });
+      } catch (err) {
+        setPrefs(prefs); // rollback
+        showToast({
+          variant: "error",
+          title: "Save failed.",
+          description: err instanceof Error ? err.message : "Please try again.",
+        });
+      }
+    },
+    [prefs]
+  );
+
+  if (loading) {
+    return (
+      <div role="status" aria-label="Loading preferences" className="py-8 text-center text-sm text-gray-500">
+        Loading preferences…
+      </div>
+    );
+  }
+
+  if (error || !prefs) {
+    return (
+      <div role="alert" className="py-8 text-center text-sm text-red-600">
+        {error ?? "Unable to load preferences."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4 md:p-6 max-w-2xl">
+      <h2 className="text-lg font-semibold text-gray-900 mb-1">Notification Channels</h2>
+      <p className="text-sm text-gray-500 mb-6">Choose how you want to be notified.</p>
+
+      <ul className="divide-y divide-gray-100" role="list">
+        {CHANNELS.map(({ key, label, description }) => (
+          <li key={key} className="flex items-center justify-between py-4">
+            <div>
+              <p className="text-sm font-medium text-gray-800">{label}</p>
+              <p className="text-xs text-gray-500">{description}</p>
+            </div>
+            <button
+              role="switch"
+              aria-checked={prefs[key]}
+              aria-label={`Toggle ${label} notifications`}
+              onClick={() => toggle(key)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[#2600FF] focus:ring-offset-2 ${
+                prefs[key] ? "bg-[#2600FF]" : "bg-gray-200"
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  prefs[key] ? "translate-x-5" : "translate-x-0"
+                }`}
+              />
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {toast && (
+        <Toast variant={toast.variant} title={toast.title} description={toast.description} />
+      )}
+    </div>
+  );
+}

--- a/components/features/account/components/index.ts
+++ b/components/features/account/components/index.ts
@@ -1,2 +1,3 @@
 export { default as ProfileForm } from './ProfileForm';
-export { default as DataExportButton } from './DataExportButton'; 
+export { default as DataExportButton } from './DataExportButton';
+export { default as NotificationPreferences } from './NotificationPreferences'; 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
+  '@sentry/cli': false
   '@tailwindcss/oxide': true
   better-sqlite3: true
   esbuild: false


### PR DESCRIPTION
## Summary

Closes #512

Adds a `/account/notifications` settings page that lets users manage per-channel notification preferences, wired to `GET/PUT /api/account/preferences`.

## Changes

- **`components/features/account/components/NotificationPreferences.tsx`** — new component
  - Loads current preferences via `GET /api/account/preferences`
  - Renders toggle switches for `email`, `push`, `sms`, and `inApp` channels
  - Optimistic toggle with immediate UI update and rollback on failure
  - `Toast` feedback for success and error states; auto-dismisses after 4 s
  - Loading spinner and error state

- **`app/account/notifications/page.tsx`** — new page
  - Mounted in the account route, uses the same `Sidebar` + `PageHeader` layout as `/account/profile`

- **`components/features/account/components/index.ts`** — exports `NotificationPreferences`

## Tests

- `components/features/account/components/NotificationPreferences.test.tsx` — **12 tests** covering: loading state, channel rendering, preference state reflection, GET error/reject, optimistic toggle, success toast, rollback on PUT failure, rollback on network error, correct PUT body, all-off state, toast auto-dismiss
- `app/account/notifications/page.test.tsx` — **3 integration tests** covering: page header, sidebar render, component mount

All 15 new tests pass. Pre-existing failures in `DataExportButton` and `ProfileForm` are unrelated to this PR.

## Testing locally

```bash
pnpm exec vitest run --config vitest.component.config.ts components/features/account/components/NotificationPreferences.test.tsx
pnpm exec vitest run --config vitest.temp-unit.config.ts app/account/notifications/page.test.tsx
```