### PR TITLE
perf: lazy-load TransactionDetail to trim the dashboard bundle

### DIFF
--- a/components/shared/common/Transaction.test.tsx
+++ b/components/shared/common/Transaction.test.tsx
@@ -1,76 +1,161 @@
 import React from 'react';
-import { render, screen, waitFor } from "@/test/test-utils";
+import { render, screen, waitFor, fireEvent } from "@/test/test-utils";
 import { Transactions } from "./Transaction";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Mocking Image since it's a Next.js component
+// ── Hoisted mock data (must be declared before vi.mock calls are hoisted) ───
+
+const mockFetchTransactions = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    transactions: [
+      { id: "TXN-001", type: "Deposit",    amount: 100,  asset: "XLM",  date: "2024-04-01", time: "10:00AM", status: "Completed" },
+      { id: "TXN-002", type: "Withdrawal", amount: -50,  asset: "USDC", date: "2024-04-02", time: "11:00AM", status: "Processing" },
+      { id: "TXN-003", type: "Lend",       amount: 200,  asset: "BTC",  date: "2024-04-03", time: "12:00PM", status: "Completed" },
+    ],
+    total: 3,
+  })
+);
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: (loader: () => Promise<{ default: React.ComponentType<unknown> }>) => {
+    let Comp: React.ComponentType<unknown> | null = null;
+    loader().then((m) => { Comp = m.default; });
+    return function DynamicResolved(props: unknown) {
+      return Comp
+        ? React.createElement(Comp, props as Record<string, unknown>)
+        : React.createElement("div", null, "Loading\u2026");
+    };
+  },
+}));
+
 vi.mock("next/image", () => ({
-  default: ({ src, alt, width, height, className }: any) => (
+  default: ({ src, alt, width, height, className }: { src: string; alt: string; width: number; height: number; className?: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
     <img src={src} alt={alt} width={width} height={height} className={className} />
   ),
 }));
 
+vi.mock("@/types/Transaction", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/types/Transaction")>();
+  return { ...original, fetchTransactions: mockFetchTransactions };
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
 describe("Transactions Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Re-assert the resolved value after clearAllMocks resets it
+    mockFetchTransactions.mockResolvedValue({
+      transactions: [
+        { id: "TXN-001", type: "Deposit",    amount: 100,  asset: "XLM",  date: "2024-04-01", time: "10:00AM", status: "Completed" },
+        { id: "TXN-002", type: "Withdrawal", amount: -50,  asset: "USDC", date: "2024-04-02", time: "11:00AM", status: "Processing" },
+        { id: "TXN-003", type: "Lend",       amount: 200,  asset: "BTC",  date: "2024-04-03", time: "12:00PM", status: "Completed" },
+      ],
+      total: 3,
+    });
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 0; });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders skeleton loading state initially", () => {
     render(<Transactions />);
-    // Skeleton renders the table headers and an aria-labeled container immediately
     expect(screen.getByText("Transaction Type")).toBeInTheDocument();
     expect(screen.getByLabelText("Loading transactions")).toBeInTheDocument();
   });
 
-  it("renders transaction table on desktop", async () => {
-    // We simulate desktop by checking for table elements which are hidden on mobile
+  it("renders transaction table headers after data loads", async () => {
     render(<Transactions />);
-    
+
     await waitFor(() => {
-      expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
     });
 
-    // Check for table headers
     expect(screen.getByText("Transaction Type")).toBeInTheDocument();
-    expect(screen.getByText("Amount")).toBeInTheDocument();
-    expect(screen.getByText("Asset")).toBeInTheDocument();
-    expect(screen.getByText("Date")).toBeInTheDocument();
-    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getAllByText("Amount").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Asset").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Date").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Status").length).toBeGreaterThan(0);
   });
 
-  it("renders transaction cards on mobile", async () => {
+  it("renders transaction rows with loaded data", async () => {
     render(<Transactions />);
-    
+
     await waitFor(() => {
-      expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
     });
 
-    // On mobile, labels like "Type", "Asset", "Amount" are shown in cards
-    const typeLabels = screen.getAllByText("Type");
-    expect(typeLabels.length).toBeGreaterThan(0);
-    
-    const assetLabels = screen.getAllByText("Asset");
-    expect(assetLabels.length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Deposit").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Withdrawal").length).toBeGreaterThan(0);
   });
 
-  it("filters transactions by search term", async () => {
+  it("renders mobile cards with Type and Asset labels", async () => {
     render(<Transactions />);
-    
+
     await waitFor(() => {
-      expect(screen.queryByText(/Loading.../i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
     });
 
-    // Initial check - should have multiple transactions
-    expect(screen.getByText("Deposit")).toBeInTheDocument();
-    expect(screen.getByText("Withdrawal")).toBeInTheDocument();
+    expect(screen.getAllByText("Type").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Asset").length).toBeGreaterThan(0);
+  });
 
-    // Trigger search
-    // Since search input is hidden behind a toggle, we need to click it first
-    const searchToggle = screen.getByText("Search");
-    searchToggle.click();
+  it("shows the search input when Search is clicked", async () => {
+    render(<Transactions />);
 
-    const searchInput = screen.getByPlaceholderText(/Search by type/i);
-    // Note: In a real test environment with full DOM support, we would use fireEvent.change
-    // For now, we are just verifying the structure is testable
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Search"));
+    expect(screen.getByPlaceholderText(/Search by type/i)).toBeInTheDocument();
+  });
+
+  it("opens TransactionDetail modal (lazy-loaded) when Details is clicked", async () => {
+    render(<Transactions />);
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+    });
+
+    const detailButtons = await screen.findAllByRole("button", { name: /details/i });
+    expect(detailButtons.length).toBeGreaterThan(0);
+    fireEvent.click(detailButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Transaction Details")).toBeInTheDocument();
+    });
+  });
+
+  it("closes TransactionDetail modal when close button is clicked", async () => {
+    render(<Transactions />);
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+    });
+
+    const detailButtons = await screen.findAllByRole("button", { name: /details/i });
+    fireEvent.click(detailButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Transaction Details")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Transaction Details")).not.toBeInTheDocument();
+    });
   });
 });

--- a/components/shared/common/Transaction.tsx
+++ b/components/shared/common/Transaction.tsx
@@ -17,8 +17,21 @@ import { Pagination } from "./Pagination";
 import { EmptyState } from "./EmptyState";
 import { TransactionsSkeleton } from "./Skeleton";
 import { StatusBadge, transactionStatusToVariant } from "@/components/shared/ui/StatusBadge";
-import TransactionDetail from "@/components/features/dashboard/components/TransactionDetail";
-import { Dialog } from "@headlessui/react";
+import dynamic from "next/dynamic";
+
+const TransactionDetail = dynamic(
+  () => import("@/components/features/dashboard/components/TransactionDetail"),
+  {
+    loading: () => (
+      <div className="fixed inset-0 flex items-center justify-center z-50">
+        <div className="bg-white rounded-xl shadow-lg max-w-md w-full p-6 text-center text-sm text-gray-400">
+          Loading…
+        </div>
+      </div>
+    ),
+    ssr: false,
+  }
+);
 
 import {
   fetchTransactions,
@@ -184,7 +197,7 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
     <section className="h-full bg-white rounded-t-xl shadow md:p-8 p-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 py-3 border pb-2 gap-2">
         <div className="flex gap-6 items-center flex-wrap text-gray-400 font-normal text-base select-none">
-          <Dialog as="div" className="relative z-50" onClose={() => {}} id="transaction-detail-drawer">
+          <div className="relative" ref={searchRef} id="transaction-detail-drawer">
             <div
               className="flex items-center gap-1 cursor-pointer"
               onClick={() => setShowSearch((v) => !v)}
@@ -204,7 +217,7 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
                 />
               </div>
             )}
-          </Dialog>
+          </div>
           <div className="relative" ref={filterRef}>
             <div
               className="flex items-center gap-1 cursor-pointer"


### PR DESCRIPTION
## Summary

Fixes #540

Lazy-loads `TransactionDetail` (and its Headless UI `Dialog`/`Transition` dependency) via `next/dynamic` so the code is deferred until a user opens a transaction row — it is no longer part of the dashboard initial bundle.

## Changes

### `components/shared/common/Transaction.tsx`
- Replace static `import TransactionDetail` with `next/dynamic(..., { ssr: false })`
- Add a lightweight inline loading fallback (plain `div`) shown while the chunk fetches
- Remove the unused `import { Dialog } from '@headlessui/react'`
- Replace the misused `<Dialog>` wrapper around the Search dropdown with a semantically correct `<div ref={searchRef}>`

### `components/shared/common/Transaction.test.tsx`
- Mock `next/navigation` to resolve the pre-existing `invariant expected app router to be mounted` crash
- Mock `next/dynamic` to resolve the lazy component synchronously in JSDOM
- Mock `fetchTransactions` to avoid live network calls in unit tests
- Add 7 tests covering skeleton state, table headers, row data, mobile cards, search toggle, modal open, and modal close

## Test results
- Before (main): 22 failing test files / 92 failing tests
- After (this PR): 21 failing test files / 89 failing tests
- Our 2 directly affected test files: **14 / 14 pass**

The remaining pre-existing failures are unrelated to these changes.

## What was tested
- `Transaction.test.tsx` — 7 tests ✅
- `TransactionDetail.test.tsx` — 7 tests ✅
- No behavioural or a11y regressions on the modal
- Headless UI is no longer imported at the `Transactions` component level