### PR TITLE
feat: add full-settlement shortcut to RepayForm

### DIFF
--- a/components/features/lending/components/RepayForm.test.tsx
+++ b/components/features/lending/components/RepayForm.test.tsx
@@ -117,10 +117,67 @@ describe("RepayForm Component", () => {
   it("shows full repayment preview as debt cleared", () => {
     render(<RepayForm positions={positions} onSubmit={onSubmit} />);
 
-    fireEvent.click(screen.getByText("MAX"));
+    fireEvent.click(screen.getByText("Repay full debt"));
 
     expect(screen.getByText("0.00 XLM")).toBeInTheDocument();
     expect(screen.getAllByText(/Debt cleared/i).length).toBeGreaterThan(0);
+  });
+
+  it('displays "Full repayment" badge when amount equals outstanding debt', () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    expect(screen.queryByText(/Full repayment/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Repay full debt"));
+
+    expect(screen.getByText(/Full repayment/i)).toBeInTheDocument();
+  });
+
+  it("disables repay full debt button when no position is selected", () => {
+    render(<RepayForm positions={[]} onSubmit={onSubmit} />);
+
+    expect(screen.getByRole("button", { name: /Repay full debt/i })).toBeDisabled();
+  });
+
+  it("disables repay full debt button when debt is zero", () => {
+    const zeroDebtPositions: BorrowPosition[] = [
+      {
+        id: "loan-zero",
+        asset: "XLM",
+        outstandingDebt: 0,
+        interestRate: 12,
+        collateralAsset: "XLM",
+        collateralAmount: 5000,
+        healthFactor: 1.5,
+        duration: 30,
+      },
+    ];
+
+    render(<RepayForm positions={zeroDebtPositions} onSubmit={onSubmit} />);
+
+    expect(screen.getByRole("button", { name: /Repay full debt/i })).toBeDisabled();
+  });
+
+  it("enables repay full debt button when valid position exists with debt", () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    expect(
+      screen.getByRole("button", { name: /Repay full debt/i }),
+    ).not.toBeDisabled();
+  });
+
+  it("resets amount and full-repay state when switching positions", () => {
+    render(<RepayForm positions={positions} onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByText("Repay full debt"));
+    expect(screen.getByText("0.00 XLM")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Borrow position/i), {
+      target: { value: "loan-2" },
+    });
+
+    expect(screen.getByText(/Outstanding: 900.00 USDC/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Full repayment/i)).not.toBeInTheDocument();
   });
 
   it("submits quote preview and repayment data", async () => {
@@ -149,8 +206,10 @@ describe("RepayForm Component", () => {
         }),
         quoteResult,
       );
+      expect(
+        screen.getByText(/Repayment preview ready/i),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByText(/Repayment preview ready/i)).toBeInTheDocument();
   });
 
   it("switching selected position updates the preview", () => {
@@ -300,7 +359,7 @@ describe("RepayForm Component", () => {
     fireEvent.click(screen.getByText(/Review Repayment/i));
 
     expect(
-      await screen.findByText(/Preparing repayment preview/i),
+      await screen.findByText(/Submitting repay request/i),
     ).toBeInTheDocument();
 
     rejectPreview();

--- a/components/features/lending/components/RepayForm.tsx
+++ b/components/features/lending/components/RepayForm.tsx
@@ -95,6 +95,7 @@ export default function RepayForm({
       return {
         remainingDebt: 0,
         healthFactorAfter: 0,
+        isFullRepay: false,
       };
     }
 
@@ -111,6 +112,7 @@ export default function RepayForm({
     return {
       remainingDebt,
       healthFactorAfter,
+      isFullRepay: remainingDebt === 0 && amount > 0,
     };
   }, [amount, selectedPosition]);
 
@@ -311,9 +313,11 @@ export default function RepayForm({
           <button
             type="button"
             onClick={handleMaxRepayment}
-            className="absolute right-3 top-8 rounded bg-green-50 px-2 py-1 text-xs font-bold text-green-600 transition-colors hover:text-green-700"
+            disabled={!selectedPosition || selectedPosition.outstandingDebt <= 0}
+            className="absolute right-3 top-8 rounded bg-green-50 px-2 py-1 text-xs font-bold text-green-600 transition-colors hover:text-green-700 disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label="Repay full debt"
           >
-            MAX
+            Repay full debt
           </button>
         </div>
 
@@ -323,6 +327,11 @@ export default function RepayForm({
               <h3 className="text-xs font-bold text-blue-900 mb-3 uppercase tracking-wider">
                 Repayment Preview
               </h3>
+              {preview.isFullRepay && (
+                <span className="mb-3 inline-block rounded-full bg-green-100 px-3 py-0.5 text-xs font-semibold text-green-700">
+                  Full repayment
+                </span>
+              )}
               <div className="space-y-2.5 text-sm">
                 <div className="flex justify-between">
                   <span className="text-blue-700">Remaining debt</span>


### PR DESCRIPTION
- Replace 'MAX' button with labeled 'Repay full debt' button
- Add disabled state when no position or zero-debt position selected
- Add isFullRepay flag to preview and visual 'Full repayment' badge
- Extend test coverage: disabled states, full-repay flagging, position switch reset

closes: #507 