### PR TITLE
refactor: use clipboard helper with fallback and feedback in Transact…

### DIFF
--- a/components/features/dashboard/components/TransactionDetail.test.tsx
+++ b/components/features/dashboard/components/TransactionDetail.test.tsx
@@ -8,6 +8,7 @@ import {
 import TransactionDetail from "./TransactionDetail";
 import type { Transaction } from "@/types/Transaction";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { copyToClipboard } from "@/lib/utils/clipboard";
 
 // Mock next/image so JSDOM does not need the Next.js runtime/config.
 vi.mock("next/image", () => ({
@@ -15,6 +16,11 @@ vi.mock("next/image", () => ({
     // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
     <img {...props} />
   ),
+}));
+
+// Mock the clipboard helper
+vi.mock("@/lib/utils/clipboard", () => ({
+  copyToClipboard: vi.fn(),
 }));
 
 const buildTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
@@ -29,36 +35,20 @@ const buildTransaction = (overrides: Partial<Transaction> = {}): Transaction => 
 });
 
 describe("TransactionDetail Modal", () => {
-  let writeText: ReturnType<typeof vi.fn>;
-
   beforeEach(() => {
-    writeText = vi.fn().mockResolvedValue(undefined);
-    // Patch only the clipboard slice of navigator instead of replacing the
-    // entire object so other navigator APIs (userAgent, language, ...) are
-    // preserved in JSDOM. Direct property assignment is safer than
-    // defineProperty across jsdom versions that may declare `clipboard`
-    // as a non-configurable accessor.
-    (window.navigator as unknown as { clipboard: { writeText: typeof writeText } }).clipboard = {
-      writeText,
-    };
     // Headless UI's Transition relies on requestAnimationFrame; flush it
     // synchronously so the modal content is in the DOM immediately.
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
       cb(0);
       return 0;
     });
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    // Restore jsdom's original clipboard (which is undefined in the test env).
-    try {
-      delete (window.navigator as unknown as { clipboard?: unknown }).clipboard;
-    } catch {
-      // Some jsdom builds treat navigator.clipboard as non-configurable
-      // and refuse the delete; in that case the per-test overwrite above
-      // re-asserts a consistent stub on the next test run.
-    }
+    vi.useRealTimers();
+    vi.clearAllMocks();
   });
 
   it("renders nothing when transaction is null", () => {
@@ -110,7 +100,9 @@ describe("TransactionDetail Modal", () => {
     });
   });
 
-  it("writes the transaction id to the clipboard when copy is clicked", async () => {
+  it("calls the clipboard helper with the transaction id when copy is clicked", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue({ success: true });
+    
     render(
       <TransactionDetail
         transaction={buildTransaction({ id: "TXN-COPY-42" })}
@@ -122,7 +114,95 @@ describe("TransactionDetail Modal", () => {
     fireEvent.click(screen.getByRole("button", { name: /Copy transaction ID/i }));
 
     await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith("TXN-COPY-42");
+      expect(copyToClipboard).toHaveBeenCalledWith("TXN-COPY-42");
+    });
+  });
+
+  it("shows a success toast when copy succeeds", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue({ success: true });
+    
+    render(
+      <TransactionDetail
+        transaction={buildTransaction({ id: "TXN-COPY-42" })}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy transaction ID/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Copied")).toBeInTheDocument();
+      expect(screen.getByText("Transaction ID copied to clipboard")).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error toast when copy fails", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue({ success: false, reason: "clipboard_error" });
+    
+    render(
+      <TransactionDetail
+        transaction={buildTransaction({ id: "TXN-COPY-42" })}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy transaction ID/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy failed")).toBeInTheDocument();
+      expect(screen.getByText("Failed to copy transaction ID")).toBeInTheDocument();
+    });
+  });
+
+  it("removes the toast after 3 seconds on success", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue({ success: true });
+    
+    render(
+      <TransactionDetail
+        transaction={buildTransaction({ id: "TXN-COPY-42" })}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy transaction ID/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Copied")).toBeInTheDocument();
+    });
+
+    // Fast-forward time by 3 seconds
+    vi.advanceTimersByTime(3000);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Copied")).not.toBeInTheDocument();
+    });
+  });
+
+  it("removes the toast after 3 seconds on failure", async () => {
+    vi.mocked(copyToClipboard).mockResolvedValue({ success: false, reason: "clipboard_error" });
+    
+    render(
+      <TransactionDetail
+        transaction={buildTransaction({ id: "TXN-COPY-42" })}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy transaction ID/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy failed")).toBeInTheDocument();
+    });
+
+    // Fast-forward time by 3 seconds
+    vi.advanceTimersByTime(3000);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Copy failed")).not.toBeInTheDocument();
     });
   });
 

--- a/components/features/dashboard/components/TransactionDetail.tsx
+++ b/components/features/dashboard/components/TransactionDetail.tsx
@@ -8,6 +8,8 @@ import type { Transaction } from "../../../../types/Transaction";
 import { sanitiseString } from "@/lib/security/input-sanitizer";
 import { isValidTxHash } from "@/lib/validation/stellar";
 import config from "@/lib/config";
+import { copyToClipboard } from "@/lib/utils/clipboard";
+import Toast from "@/components/shared/common/Toast";
 
 interface TransactionDetailProps {
   transaction: Transaction | null;
@@ -18,6 +20,7 @@ interface TransactionDetailProps {
 export default function TransactionDetail({ transaction, isOpen, onClose }: TransactionDetailProps) {
   const [details, setDetails] = useState<any>(null);
   const [loading, setLoading] = useState(false);
+  const [toast, setToast] = useState<{ title?: string; description?: string; variant?: "success" | "error" } | null>(null);
 
   const id = transaction?.id || "";
 
@@ -50,8 +53,13 @@ export default function TransactionDetail({ transaction, isOpen, onClose }: Tran
   const signedAmount = amount > 0 ? `+$${amount}` : `-$${Math.abs(amount)}`;
 
   const copyId = async () => {
-    await navigator.clipboard.writeText(id);
-    // could show a toast later
+    const result = await copyToClipboard(id);
+    if (result.success) {
+      setToast({ title: "Copied", description: "Transaction ID copied to clipboard", variant: "success" });
+    } else {
+      setToast({ title: "Copy failed", description: "Failed to copy transaction ID", variant: "error" });
+    }
+    setTimeout(() => setToast(null), 3000);
   };
 
   const formatDateTime = (dateStr: string, timeStr: string) => {
@@ -87,19 +95,27 @@ export default function TransactionDetail({ transaction, isOpen, onClose }: Tran
   };
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={onClose}>
-        <Transition.Child
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-        </Transition.Child>
+    <>
+      {toast && (
+        <Toast
+          title={toast.title}
+          description={toast.description}
+          variant={toast.variant}
+        />
+      )}
+      <Transition show={isOpen} as={Fragment}>
+        <Dialog as="div" className="relative z-50" onClose={onClose}>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+          </Transition.Child>
 
         <div className="fixed inset-0 flex items-center justify-center p-4">
           <Transition.Child
@@ -191,9 +207,10 @@ export default function TransactionDetail({ transaction, isOpen, onClose }: Tran
               </div>
             </Dialog.Panel>
           </Transition.Child>
-        </div>
-      </Dialog>
-    </Transition>
+          </div>
+        </Dialog>
+      </Transition>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
Adds clipboard fallback and copy confirmation to TransactionDetail component by using the existing [copyToClipboard](cci:1://file:///c:/Users/USER/Stellarlend-frontend/lib/utils/clipboard.ts:36:0-58:1) helper and providing accessible toast feedback.

## Changes
- **TransactionDetail.tsx**
  - Replaced direct `navigator.clipboard.writeText()` call with [copyToClipboard()](cci:1://file:///c:/Users/USER/Stellarlend-frontend/lib/utils/clipboard.ts:36:0-58:1) helper from [lib/utils/clipboard.ts](cci:7://file:///c:/Users/USER/Stellarlend-frontend/lib/utils/clipboard.ts:0:0-0:0)
  - Added toast state for success/error feedback
  - Shows success toast when copy succeeds with "Copied" message
  - Shows error toast when copy fails with "Copy failed" message
  - Toast auto-dismisses after 3 seconds
  - Toast uses existing Toast component with `aria-live="polite"` for accessibility

- **TransactionDetail.test.tsx**
  - Mocked [copyToClipboard](cci:1://file:///c:/Users/USER/Stellarlend-frontend/lib/utils/clipboard.ts:36:0-58:1) helper instead of `navigator.clipboard`
  - Added test: verifies clipboard helper is called with correct transaction ID
  - Added test: shows success toast when copy succeeds
  - Added test: shows error toast when copy fails
  - Added test: toast auto-dismisses after 3 seconds on success
  - Added test: toast auto-dismisses after 3 seconds on failure

## Motivation
The original implementation used `navigator.clipboard.writeText()` directly, which:
- Has no fallback for browsers/contexts where the async Clipboard API is unavailable (non-secure origins, older browsers)
- Provides no user feedback that the copy succeeded
- Could result in unhandled promise rejections

This change routes the copy through the existing clipboard helper (which has execCommand fallback) and surfaces accessible success/error feedback.

## Testing
- All existing tests pass
- New tests cover clipboard success, clipboard failure, and toast auto-dismissal behavior
- Tests verify the helper is used instead of direct navigator.clipboard calls

## Checklist
- [x] Uses [lib/utils/clipboard.ts](cci:7://file:///c:/Users/USER/Stellarlend-frontend/lib/utils/clipboard.ts:0:0-0:0) with fallback
- [x] Provides accessible feedback (toast with aria-live="polite")
- [x] Handles rejection gracefully (no unhandled promise rejections)
- [x] Dialog behavior otherwise unchanged
- [x] Test coverage added for new functionality

Closes #536