### PR TITLE
test: cover feature flag evaluator

### DIFF
--- a/lib/flags/EVALUATOR_TESTS.md
+++ b/lib/flags/EVALUATOR_TESTS.md
@@ -1,0 +1,22 @@
+# Feature Flag Evaluator Test Plan
+
+This suite documents the unit coverage added for `lib/flags/evaluator.ts`.
+
+## Covered behavior
+
+- Unknown flag keys return the safe default `false`.
+- Repeated evaluation for the same user and flag is deterministic.
+- Disabled flags, `0%` rollout, and `100%` rollout are handled explicitly.
+- User overrides take precedence over the global enabled and rollout settings.
+- A deterministic 1,000-user sample keeps a `50%` rollout within a narrow proportional band.
+- `evaluateAllFlags` returns a complete boolean map for every configured flag.
+
+## Verification
+
+Run the focused suite with:
+
+```bash
+npm test -- lib/flags/evaluator.test.ts --run
+```
+
+The test mocks the feature-flag config read so fixtures stay isolated from the checked-in `config/feature-flags.json` file.

--- a/lib/flags/evaluator.test.ts
+++ b/lib/flags/evaluator.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Flags } from "./evaluator";
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+async function loadEvaluator(flags: Flags) {
+  vi.resetModules();
+  process.env.NODE_ENV = "test";
+
+  vi.doMock("fs", () => ({
+    default: {
+      readFileSync: vi.fn(() => JSON.stringify(flags)),
+    },
+  }));
+
+  return import("./evaluator");
+}
+
+afterEach(() => {
+  vi.doUnmock("fs");
+  if (originalNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+});
+
+describe("feature flag evaluator", () => {
+  it("returns a safe disabled default for unknown flag keys", async () => {
+    const { evaluateFlag } = await loadEvaluator({
+      knownFlag: {
+        enabled: true,
+        rollout: 100,
+      },
+    });
+
+    expect(evaluateFlag("missingFlag", "user-1")).toBe(false);
+  });
+
+  it("is deterministic for the same user and flag across repeated calls", async () => {
+    const { evaluateFlag } = await loadEvaluator({
+      betaDashboard: {
+        enabled: true,
+        rollout: 35,
+      },
+    });
+
+    const first = evaluateFlag("betaDashboard", "alice");
+    const second = evaluateFlag("betaDashboard", "alice");
+    const third = evaluateFlag("betaDashboard", "alice");
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
+
+  it("honors disabled, zero-percent, and full-rollout flags", async () => {
+    const { evaluateFlag } = await loadEvaluator({
+      disabledFlag: {
+        enabled: false,
+        rollout: 100,
+      },
+      zeroRollout: {
+        enabled: true,
+        rollout: 0,
+      },
+      fullRollout: {
+        enabled: true,
+        rollout: 100,
+      },
+    });
+
+    expect(evaluateFlag("disabledFlag", "alice")).toBe(false);
+    expect(evaluateFlag("zeroRollout", "alice")).toBe(false);
+    expect(evaluateFlag("fullRollout", "alice")).toBe(true);
+  });
+
+  it("applies user overrides before enabled and rollout checks", async () => {
+    const { evaluateFlag } = await loadEvaluator({
+      inviteOnlyFeature: {
+        enabled: false,
+        rollout: 0,
+        overrides: {
+          alice: true,
+          bob: false,
+        },
+      },
+    });
+
+    expect(evaluateFlag("inviteOnlyFeature", "alice")).toBe(true);
+    expect(evaluateFlag("inviteOnlyFeature", "bob")).toBe(false);
+    expect(evaluateFlag("inviteOnlyFeature", "carol")).toBe(false);
+  });
+
+  it("buckets rollout users proportionally with deterministic sample input", async () => {
+    const { evaluateFlag } = await loadEvaluator({
+      halfRollout: {
+        enabled: true,
+        rollout: 50,
+      },
+    });
+
+    const enabledCount = Array.from(
+      { length: 1000 },
+      (_, index) => `user-${index}`,
+    ).filter((userId) => evaluateFlag("halfRollout", userId)).length;
+
+    expect(enabledCount).toBeGreaterThanOrEqual(450);
+    expect(enabledCount).toBeLessThanOrEqual(550);
+  });
+
+  it("evaluates every configured flag for a user", async () => {
+    const { evaluateAllFlags } = await loadEvaluator({
+      enabledFeature: {
+        enabled: true,
+        rollout: 100,
+      },
+      disabledFeature: {
+        enabled: false,
+      },
+      overriddenFeature: {
+        enabled: false,
+        overrides: {
+          alice: true,
+        },
+      },
+    });
+
+    expect(evaluateAllFlags("alice")).toEqual({
+      enabledFeature: true,
+      disabledFeature: false,
+      overriddenFeature: true,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -99,6 +99,7 @@ export default defineConfig({
             "app/api/liquidations/route.test.ts",
             "app/api/notifications/[id]/route.test.ts",
             "__tests__/**/*.test.ts",
+            "lib/flags/**/*.test.ts",
             "lib/streams/**/*.test.ts",
           ],
         },


### PR DESCRIPTION
Closes #635

## Summary
- adds focused unit coverage for `lib/flags/evaluator.ts`
- covers unknown flags, deterministic bucketing, rollout boundaries, user overrides, proportional rollout distribution, and `evaluateAllFlags`
- registers `lib/flags/**/*.test.ts` in the server-unit Vitest project
- documents the evaluator test plan in `lib/flags/EVALUATOR_TESTS.md`

## Verification
- `npm test -- --run lib/flags/evaluator.test.ts` ?
- `npm test -- evaluator --run` ?
- `npm run type-check` currently fails on existing unrelated repository errors outside this change (missing exports/modules and other pre-existing TS issues across API, lending, queue, config, and worker files).