### PR TITLE
test: e2e coverage for transactions CSV export download

### DIFF
--- a/test/e2e/TRANSACTIONS_EXPORT_E2E.md
+++ b/test/e2e/TRANSACTIONS_EXPORT_E2E.md
@@ -1,0 +1,84 @@
+# Transactions CSV Export — E2E Test Guide
+
+## Overview
+
+`test/e2e/transactions-export.spec.ts` provides end-to-end coverage for the
+transactions CSV export feature exposed at `GET /api/transactions/export`.
+
+Network responses are **stubbed via `page.route()`** so the suite is fully
+deterministic and runnable without a live backend.
+
+---
+
+## Scenarios Covered
+
+| # | Scenario | What is asserted |
+|---|----------|-----------------|
+| 1 | **Button visibility** | `Export CSV` button renders on `/dashboard/transactions` |
+| 2 | **Download triggered** | Clicking the button fires a browser download; suggested filename matches `transactions*.csv` |
+| 3 | **CSV header** | First row of the downloaded file equals `ID,Type,Amount,Asset,Date,Time,Status` |
+| 4 | **Filter scoping** | When `?status=Completed` is active, every data row in the CSV has `Status = Completed` |
+| 5 | **Empty export** | A filtered result with no matches yields a file containing only the header row |
+| 6 | **Large export** | 100-row export downloads fully without truncation |
+| 7 | **Export failure** | A 500 response from the API does not crash the page or throw uncaught JS errors |
+
+---
+
+## Running the Suite
+
+```bash
+# Run only this spec against the default (Chromium) project
+npx playwright test test/e2e/transactions-export.spec.ts
+
+# Run against all configured browsers
+npx playwright test test/e2e/transactions-export.spec.ts --project=chromium --project=firefox --project=webkit
+
+# Run with the Playwright UI (interactive)
+npx playwright test test/e2e/transactions-export.spec.ts --ui
+
+# Show the HTML report after a run
+npx playwright show-report .next/playwright-report
+```
+
+The suite requires no running server — `page.route()` intercepts all
+`/api/transactions/export*` requests at the network layer.
+
+---
+
+## How Stubbing Works
+
+Each test calls one of three helper functions defined at the top of the spec:
+
+| Helper | Behaviour |
+|--------|-----------|
+| `stubExport(page, rows)` | Returns a 200 CSV built from `rows` |
+| `stubEmptyExport(page)` | Returns a 200 CSV with the header only |
+| `stubExportError(page)` | Returns a 500 JSON error body |
+
+The filter-scoping test uses an inline route handler that inspects the
+`status` query parameter and selects the matching row set, simulating real
+server-side filtering.
+
+---
+
+## CSV Column Contract
+
+The export API (`app/api/transactions/export/route.ts`) delegates serialisation
+to `lib/transactions/csv.ts → serializeTransactionsToCSV()`. The expected
+columns are:
+
+```
+ID, Type, Amount, Asset, Date, Time, Status
+```
+
+All fields are double-quoted and formula-injection characters (`= + - @ \t \r`)
+are prefixed with a single quote per RFC 4180.
+
+---
+
+## Edge Cases
+
+- **Empty result set** — header row only; no blank trailing line.
+- **Large export** — 100 rows; verifies the download stream is not silently truncated.
+- **Server error** — `Export CSV` button remains interactive; no uncaught page
+  exceptions related to the export operation.

--- a/test/e2e/transactions-export.spec.ts
+++ b/test/e2e/transactions-export.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from '@playwright/test';
+
+const EXPORT_API = '/api/transactions/export';
+const TRANSACTIONS_PAGE = '/dashboard/transactions';
+
+// Minimal stubs for deterministic CSV content
+const STUB_COMPLETED = [
+  { id: 'TXN001', type: 'Lend',   amount: 100, asset: 'XLM',  date: '2025-01-10', time: '10:00', status: 'Completed' },
+  { id: 'TXN002', type: 'Borrow', amount: 200, asset: 'BTC',  date: '2025-01-11', time: '11:00', status: 'Completed' },
+];
+const STUB_MIXED = [
+  ...STUB_COMPLETED,
+  { id: 'TXN003', type: 'Repay',    amount: 50,  asset: 'XLM',  date: '2025-01-12', time: '12:00', status: 'Processing' },
+  { id: 'TXN004', type: 'Withdraw', amount: 75,  asset: 'STRK', date: '2025-01-13', time: '13:00', status: 'Failed' },
+];
+
+const CSV_HEADER = '"ID","Type","Amount","Asset","Date","Time","Status"';
+
+/** Parse a quoted CSV row into fields */
+function parseCsvRow(line: string): string[] {
+  return line.split(',').map((f) => f.replace(/^"|"$/g, ''));
+}
+
+test.describe('Transactions CSV Export', () => {
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  /** Stub the export endpoint to return a known CSV body */
+  async function stubExport(page: Parameters<typeof test>[1] extends { page: infer P } ? P : never, rows: typeof STUB_MIXED) {
+    const csv = [
+      CSV_HEADER,
+      ...rows.map((r) =>
+        [`"${r.id}"`, `"${r.type}"`, `"${r.amount}"`, `"${r.asset}"`, `"${r.date}"`, `"${r.time}"`, `"${r.status}"`].join(',')
+      ),
+    ].join('\r\n');
+
+    await page.route(`**${EXPORT_API}**`, (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': `attachment; filename="transactions-2025-01-10.csv"`,
+        },
+        body: csv,
+      })
+    );
+  }
+
+  /** Stub the export endpoint to return an empty CSV (header only) */
+  async function stubEmptyExport(page: Parameters<typeof test>[1] extends { page: infer P } ? P : never) {
+    await page.route(`**${EXPORT_API}**`, (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': `attachment; filename="transactions-2025-01-10.csv"`,
+        },
+        body: CSV_HEADER,
+      })
+    );
+  }
+
+  /** Stub the export endpoint to return a server error */
+  async function stubExportError(page: Parameters<typeof test>[1] extends { page: infer P } ? P : never) {
+    await page.route(`**${EXPORT_API}**`, (route) =>
+      route.fulfill({ status: 500, body: JSON.stringify({ error: 'Internal Server Error' }) })
+    );
+  }
+
+  // ── tests ─────────────────────────────────────────────────────────────────
+
+  test('Export CSV button is visible on the transactions page', async ({ page }) => {
+    await page.route(`**${EXPORT_API}**`, (route) => route.fulfill({ status: 200, body: CSV_HEADER }));
+    await page.goto(TRANSACTIONS_PAGE);
+    await expect(page.getByRole('button', { name: /export csv/i })).toBeVisible();
+  });
+
+  test('clicking Export CSV triggers a download', async ({ page }) => {
+    await stubExport(page, STUB_MIXED);
+    await page.goto(TRANSACTIONS_PAGE);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: /export csv/i }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/transactions.*\.csv$/i);
+  });
+
+  test('downloaded CSV has the correct header row', async ({ page }) => {
+    await stubExport(page, STUB_MIXED);
+    await page.goto(TRANSACTIONS_PAGE);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: /export csv/i }).click(),
+    ]);
+
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+    const content = Buffer.concat(chunks).toString('utf-8');
+
+    const firstLine = content.split(/\r?\n/)[0];
+    const cols = parseCsvRow(firstLine);
+    expect(cols).toEqual(['ID', 'Type', 'Amount', 'Asset', 'Date', 'Time', 'Status']);
+  });
+
+  test('downloaded CSV rows respect an active status filter (Completed only)', async ({ page }) => {
+    // The page sends the active filter as a query param; stub only Completed rows
+    await page.route(`**${EXPORT_API}**`, async (route) => {
+      const url = new URL(route.request().url());
+      const status = url.searchParams.get('status') ?? 'All';
+      const rows = status === 'Completed' ? STUB_COMPLETED : STUB_MIXED;
+      const csv = [
+        CSV_HEADER,
+        ...rows.map((r) =>
+          [`"${r.id}"`, `"${r.type}"`, `"${r.amount}"`, `"${r.asset}"`, `"${r.date}"`, `"${r.time}"`, `"${r.status}"`].join(',')
+        ),
+      ].join('\r\n');
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/csv; charset=utf-8', 'Content-Disposition': 'attachment; filename="transactions.csv"' },
+        body: csv,
+      });
+    });
+
+    await page.goto(`${TRANSACTIONS_PAGE}?status=Completed`);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: /export csv/i }).click(),
+    ]);
+
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+    const lines = Buffer.concat(chunks).toString('utf-8').split(/\r?\n/).filter(Boolean);
+
+    // header + two Completed rows
+    expect(lines).toHaveLength(3);
+    const dataRows = lines.slice(1).map(parseCsvRow);
+    for (const row of dataRows) {
+      expect(row[6]).toBe('Completed');
+    }
+  });
+
+  test('empty-filtered export yields header row only', async ({ page }) => {
+    await stubEmptyExport(page);
+    await page.goto(TRANSACTIONS_PAGE);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: /export csv/i }).click(),
+    ]);
+
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+    const lines = Buffer.concat(chunks).toString('utf-8').split(/\r?\n/).filter(Boolean);
+
+    expect(lines).toHaveLength(1);
+    expect(parseCsvRow(lines[0])).toEqual(['ID', 'Type', 'Amount', 'Asset', 'Date', 'Time', 'Status']);
+  });
+
+  test('large export (100 rows) downloads without truncation', async ({ page }) => {
+    const largeRows = Array.from({ length: 100 }, (_, i) => ({
+      id: `TXN${String(i + 1).padStart(3, '0')}`,
+      type: 'Lend',
+      amount: i + 1,
+      asset: 'XLM',
+      date: '2025-01-01',
+      time: '00:00',
+      status: 'Completed',
+    }));
+    await stubExport(page, largeRows);
+    await page.goto(TRANSACTIONS_PAGE);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: /export csv/i }).click(),
+    ]);
+
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+    const lines = Buffer.concat(chunks).toString('utf-8').split(/\r?\n/).filter(Boolean);
+
+    // header + 100 data rows
+    expect(lines).toHaveLength(101);
+  });
+
+  test('export failure surfaces an error / does not crash the page', async ({ page }) => {
+    await stubExportError(page);
+    await page.goto(TRANSACTIONS_PAGE);
+
+    // Listen for unexpected uncaught errors
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    // Click the button; the route returns 500
+    await page.getByRole('button', { name: /export csv/i }).click();
+
+    // Page should remain intact (no hard crash)
+    await expect(page.getByRole('button', { name: /export csv/i })).toBeVisible();
+
+    // No uncaught JS exceptions from a fetch error
+    expect(errors.filter((e) => /export/i.test(e))).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Playwright end-to-end test suite for the transactions CSV export feature.

### Changes
- `test/e2e/transactions-export.spec.ts` - 7 fully-stubbed Playwright tests covering:
  - Export CSV button visibility on `/dashboard/transactions`
  - Download triggered on button click (filename validated)
  - CSV header row: `ID, Type, Amount, Asset, Date, Time, Status`
  - Filter scoping - rows respect the active `status` filter
  - Empty-filtered export yields header-only CSV
  - Large export (100 rows) downloads without truncation
  - Export failure (HTTP 500) does not crash the page
- `test/e2e/TRANSACTIONS_EXPORT_E2E.md` - scenario table, run instructions, stub strategy, CSV column contract

### Testing
```bash
npx playwright test test/e2e/transactions-export.spec.ts
```

Closes #640