### PR TITLE
test: integration coverage for account sessions list and revoke

### DIFF
--- a/app/api/account/sessions/SESSIONS_TESTS.md
+++ b/app/api/account/sessions/SESSIONS_TESTS.md
@@ -1,0 +1,66 @@
+# Account Sessions Routes — Integration Test Plan
+
+## Files
+
+| File | Route tested |
+|------|-------------|
+| `app/api/account/sessions/route.test.ts` | `GET /api/account/sessions` |
+| `app/api/account/sessions/[id]/route.test.ts` | `DELETE /api/account/sessions/[id]` |
+
+---
+
+## GET /api/account/sessions
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | No session cookie / unauthenticated | `401 Unauthorized` |
+| 2 | Session exists but `user.id` is absent | `401 Unauthorized` |
+| 3 | Authenticated — returns only the caller's sessions | `200` with scoped session list |
+| 4 | `listStoredSessions` called with the correct `userId` | Verified via mock assertion |
+| 5 | Current session is flagged `current: true` | Session whose `id === session.user.id` is marked |
+| 6 | `touchStoredSession` is called for the current session | Verified via mock assertion |
+| 7 | User has no stored sessions | `200` with `sessions: []` |
+| 8 | Sessions of other users are never returned | `listStoredSessions` never called with another user's id |
+| 9 | Response shape is correct | `id`, `current`, `device.userAgent`, `device.ipAddress`, `createdAt`, `lastSeenAt` |
+
+---
+
+## DELETE /api/account/sessions/[id]
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Unauthenticated request | `401 Unauthorized` |
+| 2 | Session with missing `user.id` | `401 Unauthorized` |
+| 3 | Target session does not exist | `404 Session not found` |
+| 4 | Target session belongs to a different user (foreign id) | `404 Session not found`, no revocation |
+| 5 | Revoking the current session without `?confirm=true` | `400` with error referencing `confirm` |
+| 6 | Revoking the current session with `?confirm=true` | `200 { revoked: true }`, session revoked |
+| 7 | Revoking a non-current session | `200 { revoked: true }`, `revokeStoredSession` called |
+| 8 | Revocation does not affect other users' sessions | `revokeStoredSession` not called for foreign session |
+| 9 | Audit event emitted on successful revoke | `console.info('audit.session.revoked', { sessionId, userId, revokedAt })` |
+| 10 | No audit event on `401` | `console.info` not called |
+| 11 | No audit event on `404` | `console.info` not called |
+| 12 | Already-revoked session (idempotent) | Route returns `200` both times (store behaviour unchanged) |
+
+---
+
+## Running the Tests
+
+```bash
+# Run just the sessions tests
+npx vitest run app/api/account/sessions
+
+# Or via npm script pattern
+npm test -- sessions
+```
+
+---
+
+## Mocking Strategy
+
+Both suites mock at the module boundary:
+
+- `@/lib/auth` → `getSession` — controls authentication state without touching cookies or JWTs.
+- `@/lib/auth/session-store` → `listStoredSessions`, `touchStoredSession`, `getStoredSession`, `revokeStoredSession` — controls the in-memory session store without side-effects across tests.
+
+`console.info` is spied on to assert the audit log line emitted by the DELETE handler.

--- a/app/api/account/sessions/[id]/route.test.ts
+++ b/app/api/account/sessions/[id]/route.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { DELETE } from './route';
+
+// ── mocks ──────────────────────────────────────────────────────────────────
+
+const mockGetSession = vi.fn();
+const mockGetStoredSession = vi.fn();
+const mockRevokeStoredSession = vi.fn();
+
+vi.mock('@/lib/auth', () => ({ getSession: mockGetSession }));
+vi.mock('@/lib/auth/session-store', () => ({
+  getStoredSession: mockGetStoredSession,
+  revokeStoredSession: mockRevokeStoredSession,
+}));
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(sessionId: string, confirm?: string): NextRequest {
+  const url = confirm
+    ? `http://localhost/api/account/sessions/${sessionId}?confirm=${confirm}`
+    : `http://localhost/api/account/sessions/${sessionId}`;
+  return new NextRequest(url, { method: 'DELETE' });
+}
+
+function makeContext(id: string) {
+  return { params: { id } };
+}
+
+function makeStoredSession(id: string, userId: string) {
+  return { id, userId, userAgent: 'Chrome', ipAddress: '127.0.0.1', createdAt: '2025-01-01T00:00:00Z', lastSeenAt: '2025-01-02T00:00:00Z' };
+}
+
+const SESSION_USER_A = { user: { id: 'user-a' } };
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/account/sessions/[id]', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  // ── unauthorized ──────────────────────────────────────────────────────
+
+  it('returns 401 when no session exists', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const res = await DELETE(makeRequest('sess-1'), makeContext('sess-1'));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when session has no user id', async () => {
+    mockGetSession.mockResolvedValue({ user: {} });
+
+    const res = await DELETE(makeRequest('sess-1'), makeContext('sess-1'));
+
+    expect(res.status).toBe(401);
+  });
+
+  // ── not found / foreign session ───────────────────────────────────────
+
+  it('returns 404 when target session does not exist', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockGetStoredSession.mockReturnValue(null);
+
+    const res = await DELETE(makeRequest('non-existent'), makeContext('non-existent'));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: 'Session not found' });
+  });
+
+  it('returns 404 when the session belongs to a different user (foreign session)', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockGetStoredSession.mockReturnValue(makeStoredSession('sess-foreign', 'user-b'));
+
+    const res = await DELETE(makeRequest('sess-foreign'), makeContext('sess-foreign'));
+
+    expect(res.status).toBe(404);
+    expect(mockRevokeStoredSession).not.toHaveBeenCalled();
+  });
+
+  // ── current-session guard ─────────────────────────────────────────────
+
+  it('returns 400 when revoking the current session without confirm=true', async () => {
+    // The route considers it "current" when target.id === session.user.id
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockGetStoredSession.mockReturnValue(makeStoredSession('user-a', 'user-a'));
+
+    const res = await DELETE(makeRequest('user-a'), makeContext('user-a'));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining('confirm') });
+    expect(mockRevokeStoredSession).not.toHaveBeenCalled();
+  });
+
+  it('revokes the current session when confirm=true is provided', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockGetStoredSession.mockReturnValue(makeStoredSession('user-a', 'user-a'));
+
+    const res = await DELETE(makeRequest('user-a', 'true'), makeContext('user-a'));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ revoked: true });
+    expect(mockRevokeStoredSession).toHaveBeenCalledWith('user-a');
+  });
+
+  // ── successful revoke ─────────────────────────────────────────────────
+
+  it('revokes a non-current session and returns { revoked: true }', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockGetStoredSession.mockReturnValue(makeStoredSession('sess-other', 'user-a'));
+
+    const res = await DELETE(makeRequest('sess-other'), makeContext('sess-other'));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ revoked: true });
+    expect(mockRevokeStoredSession).toHaveBeenCalledWith('sess-other');
+  });
+
+  it('does not revoke sessions belonging to other users', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockGetStoredSession.mockReturnValue(makeStoredSession('sess-b', 'user-b'));
+
+    await DELETE(makeRequest('sess-b'), makeContext('sess-b'));
+
+    expect(mockRevokeStoredSession).not.toHaveBeenCalled();
+  });
+
+  // ── audit event ───────────────────────────────────────────────────────
+
+  it('emits an audit event on successful revoke', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockGetStoredSession.mockReturnValue(makeStoredSession('sess-other', 'user-a'));
+
+    await DELETE(makeRequest('sess-other'), makeContext('sess-other'));
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'audit.session.revoked',
+      expect.objectContaining({
+        sessionId: 'sess-other',
+        userId: 'user-a',
+        revokedAt: expect.any(String),
+      })
+    );
+  });
+
+  it('does not emit an audit event when revoke is rejected (unauthorized)', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    await DELETE(makeRequest('sess-1'), makeContext('sess-1'));
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not emit an audit event when target session is not found', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockGetStoredSession.mockReturnValue(null);
+
+    await DELETE(makeRequest('sess-ghost'), makeContext('sess-ghost'));
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  // ── already-revoked (idempotent) ──────────────────────────────────────
+
+  it('calling revoke a second time still succeeds (idempotent behaviour from route perspective)', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    // Simulate the session still being findable after first revoke (store doesn't remove it)
+    mockGetStoredSession.mockReturnValue(makeStoredSession('sess-other', 'user-a'));
+
+    const res1 = await DELETE(makeRequest('sess-other'), makeContext('sess-other'));
+    const res2 = await DELETE(makeRequest('sess-other'), makeContext('sess-other'));
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(mockRevokeStoredSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/api/account/sessions/route.test.ts
+++ b/app/api/account/sessions/route.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+
+// ── mocks ──────────────────────────────────────────────────────────────────
+
+const mockGetSession = vi.fn();
+const mockListStoredSessions = vi.fn();
+const mockTouchStoredSession = vi.fn();
+
+vi.mock('@/lib/auth', () => ({ getSession: mockGetSession }));
+vi.mock('@/lib/auth/session-store', () => ({
+  listStoredSessions: mockListStoredSessions,
+  touchStoredSession: mockTouchStoredSession,
+}));
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+const SESSION_USER_A = { user: { id: 'user-a' } };
+const SESSION_USER_B = { user: { id: 'user-b' } };
+
+function makeStoredSession(id: string, userId: string, overrides: object = {}) {
+  return {
+    id,
+    userId,
+    userAgent: 'Mozilla/5.0',
+    ipAddress: '127.0.0.1',
+    createdAt: '2025-01-01T00:00:00Z',
+    lastSeenAt: '2025-01-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('GET /api/account/sessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when no session exists', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when session has no user id', async () => {
+    mockGetSession.mockResolvedValue({ user: {} });
+
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns only the authenticated user\'s sessions', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockListStoredSessions.mockReturnValue([
+      makeStoredSession('sess-1', 'user-a'),
+      makeStoredSession('sess-2', 'user-a'),
+    ]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const { sessions } = await res.json();
+    expect(sessions).toHaveLength(2);
+    expect(sessions.every((s: { id: string }) => ['sess-1', 'sess-2'].includes(s.id))).toBe(true);
+  });
+
+  it('calls listStoredSessions with the authenticated user id', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockListStoredSessions.mockReturnValue([]);
+
+    await GET();
+
+    expect(mockListStoredSessions).toHaveBeenCalledWith('user-a');
+  });
+
+  it('marks the current session with current: true', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockListStoredSessions.mockReturnValue([
+      makeStoredSession('user-a', 'user-a'),   // id matches session.user.id → current
+      makeStoredSession('sess-2', 'user-a'),
+    ]);
+
+    const res = await GET();
+    const { sessions } = await res.json();
+
+    const current = sessions.find((s: { current: boolean }) => s.current);
+    expect(current).toBeDefined();
+    expect(current.id).toBe('user-a');
+
+    const other = sessions.find((s: { id: string }) => s.id === 'sess-2');
+    expect(other.current).toBe(false);
+  });
+
+  it('touches the current session on list', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockListStoredSessions.mockReturnValue([]);
+
+    await GET();
+
+    expect(mockTouchStoredSession).toHaveBeenCalledWith('user-a');
+  });
+
+  it('returns an empty sessions array when the user has no stored sessions', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockListStoredSessions.mockReturnValue([]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const { sessions } = await res.json();
+    expect(sessions).toEqual([]);
+  });
+
+  it('does not leak sessions belonging to another user', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    // listStoredSessions is expected to filter server-side; we return only user-a sessions
+    mockListStoredSessions.mockReturnValue([makeStoredSession('sess-1', 'user-a')]);
+
+    const res = await GET();
+    const { sessions } = await res.json();
+
+    expect(sessions.every((s: { id: string }) => s.id !== 'sess-user-b-data')).toBe(true);
+    // Verify the call was scoped to the authenticated user
+    expect(mockListStoredSessions).toHaveBeenCalledWith('user-a');
+    expect(mockListStoredSessions).not.toHaveBeenCalledWith('user-b');
+  });
+
+  it('shapes each session entry correctly', async () => {
+    mockGetSession.mockResolvedValue(SESSION_USER_A);
+    mockListStoredSessions.mockReturnValue([makeStoredSession('sess-1', 'user-a')]);
+
+    const res = await GET();
+    const { sessions } = await res.json();
+    const s = sessions[0];
+
+    expect(s).toHaveProperty('id');
+    expect(s).toHaveProperty('current');
+    expect(s).toHaveProperty('device');
+    expect(s.device).toHaveProperty('userAgent');
+    expect(s.device).toHaveProperty('ipAddress');
+    expect(s).toHaveProperty('createdAt');
+    expect(s).toHaveProperty('lastSeenAt');
+  });
+});


### PR DESCRIPTION
## Summary

Adds integration tests for the `GET /api/account/sessions` and `DELETE /api/account/sessions/[id]` routes.

### Changes
- `app/api/account/sessions/route.test.ts` - 9 tests for the session list endpoint
- `app/api/account/sessions/[id]/route.test.ts` - 12 tests for the session revoke endpoint
- `app/api/account/sessions/SESSIONS_TESTS.md` - test plan, scenario table, and run instructions

### Coverage
**GET** - unauthenticated, missing user id, returns only caller's sessions, current-session flag, empty list, response shape.

**DELETE** - unauthenticated, foreign session (404), non-existent session (404), current-session guard (400 without `confirm=true`, 200 with it), successful revoke, audit event emitted, no audit on rejected requests, idempotent revoke.

### Testing
```bash
npx vitest run app/api/account/sessions
# or
npm test -- sessions
```

Closes #637