### PR TITLE
test: add transaction cursor coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ The server-side API surface is documented in two places:
 | Resource                                                       | Description                                                                               |
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | [`docs/backend-architecture.md`](docs/backend-architecture.md) | Architecture overview - lib/ modules, caching model, security, and how to add a new route |
+| [`docs/api-cursor.md`](docs/api-cursor.md)                     | Opaque transaction cursor format, validation guarantees, and limit handling               |
 | [`openapi.yaml`](openapi.yaml)                                 | OpenAPI 3.1 spec for all `app/api/*` routes, params, and response shapes                  |
 
 ### Available API Routes

--- a/docs/api-cursor.md
+++ b/docs/api-cursor.md
@@ -1,0 +1,45 @@
+# API Cursor Format
+
+`lib/api/cursor.ts` owns the opaque cursor tokens used by transaction list
+routes and CSV-style page walkers. The token is intentionally safe to pass
+through URLs, but callers should treat it as an opaque value and send it back
+unchanged instead of decoding it client-side.
+
+## Payload
+
+The current cursor payload is a versioned JSON object encoded with base64url:
+
+```ts
+{
+  v: 1,
+  date: string,
+  id: string,
+  direction: 'next' | 'prev'
+}
+```
+
+`date` and `id` form the keyset boundary for a transaction row. `direction`
+selects the comparison direction for forward or reverse paging. `v` lets the
+server reject unknown cursor layouts before using the boundary.
+
+## Guarantees
+
+- Tokens are URL-safe base64url strings and do not contain raw JSON.
+- Decoding validates every field before returning a cursor object.
+- Empty, malformed, truncated, and tampered tokens fail with stable cursor
+  validation errors.
+- `id` must be present and no longer than 256 characters.
+- `date` must parse as a valid JavaScript date.
+- `limit` defaults to `DEFAULT_CURSOR_LIMIT`, must be a positive integer, and is
+  capped at `MAX_CURSOR_LIMIT`.
+
+## Operational Notes
+
+When adding a cursor-backed route, keep the cursor as a server-owned contract:
+return `nextCursor` or `prevCursor` from the API, then accept the same token on
+the next request. Do not expose cursor internals in UI copy, local storage
+schemas, or third-party integrations. If the keyset changes, introduce a new
+version and keep the old decoder only as long as live clients can still hold old
+tokens.
+
+Related coverage lives in `lib/api/cursor.test.ts`.

--- a/lib/api/cursor.test.ts
+++ b/lib/api/cursor.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CURSOR_LIMIT,
+  MAX_CURSOR_LIMIT,
+  decodeTransactionCursor,
+  encodeTransactionCursor,
+  parseCursorLimit,
+  parseCursorParams,
+  type TransactionCursor,
+} from "./cursor";
+
+function encodeRawCursor(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+describe("transaction cursor encoding", () => {
+  it("round-trips the cursor payload exactly while keeping the token opaque", () => {
+    const cursor: TransactionCursor = {
+      v: 1,
+      date: "2026-06-28T10:15:30.000Z",
+      id: "txn-001",
+      direction: "next",
+    };
+
+    const encoded = encodeTransactionCursor(cursor);
+
+    expect(encoded).not.toContain("{");
+    expect(encoded).not.toContain("txn-001");
+    expect(decodeTransactionCursor(encoded)).toEqual(cursor);
+  });
+
+  it("round-trips boundary keyset values including unicode ids and prev direction", () => {
+    const cursor: TransactionCursor = {
+      v: 1,
+      date: "9999-12-31T23:59:59.999Z",
+      id: `txn-${"x".repeat(250)}-e`,
+      direction: "prev",
+    };
+
+    expect(cursor.id).toHaveLength(256);
+    expect(decodeTransactionCursor(encodeTransactionCursor(cursor))).toEqual(
+      cursor,
+    );
+  });
+
+  it("round-trips unicode cursor ids without changing their code points", () => {
+    const unicodeId = "txn-cafe-etoile-\u6771\u4eac";
+    const cursor: TransactionCursor = {
+      v: 1,
+      date: "2026-01-01T00:00:00.000Z",
+      id: unicodeId,
+      direction: "next",
+    };
+
+    expect(decodeTransactionCursor(encodeTransactionCursor(cursor))).toEqual(
+      cursor,
+    );
+  });
+
+  it("rejects invalid payloads before encoding", () => {
+    expect(() =>
+      encodeTransactionCursor({
+        v: 1,
+        date: "2026-01-01T00:00:00.000Z",
+        id: "",
+        direction: "next",
+      }),
+    ).toThrow(/cursor id is invalid/);
+  });
+});
+
+describe("transaction cursor decoding", () => {
+  it("rejects an empty cursor token with a stable validation error", () => {
+    expect(() => decodeTransactionCursor("")).toThrow(
+      /cursor must not be empty/,
+    );
+  });
+
+  it("rejects malformed base64url or truncated JSON without leaking parser details", () => {
+    expect(() => decodeTransactionCursor("not-json")).toThrow(
+      /cursor must be a valid base64url-encoded JSON object/,
+    );
+
+    const valid = encodeTransactionCursor({
+      v: 1,
+      date: "2026-01-01T00:00:00.000Z",
+      id: "txn-001",
+      direction: "next",
+    });
+
+    expect(() => decodeTransactionCursor(valid.slice(0, -2))).toThrow(
+      /cursor must be a valid base64url-encoded JSON object/,
+    );
+  });
+
+  it("rejects tampered cursor objects through explicit validation errors", () => {
+    expect(() =>
+      decodeTransactionCursor(
+        encodeRawCursor({
+          v: 1,
+          date: "2026-01-01T00:00:00.000Z",
+          id: "txn-001",
+          direction: "sideways",
+        }),
+      ),
+    ).toThrow(/cursor direction is invalid/);
+
+    expect(() =>
+      decodeTransactionCursor(
+        encodeRawCursor({
+          v: 2,
+          date: "2026-01-01T00:00:00.000Z",
+          id: "txn-001",
+          direction: "next",
+        }),
+      ),
+    ).toThrow(/cursor version is unsupported/);
+
+    expect(() =>
+      decodeTransactionCursor(
+        encodeRawCursor({
+          v: 1,
+          date: "not-a-date",
+          id: "txn-001",
+          direction: "next",
+        }),
+      ),
+    ).toThrow(/cursor date is invalid/);
+
+    expect(() =>
+      decodeTransactionCursor(
+        encodeRawCursor({
+          v: 1,
+          date: "2026-01-01T00:00:00.000Z",
+          id: "x".repeat(257),
+          direction: "next",
+        }),
+      ),
+    ).toThrow(/cursor id is invalid/);
+  });
+
+  it("rejects non-object JSON payloads", () => {
+    expect(() => decodeTransactionCursor(encodeRawCursor(null))).toThrow(
+      /cursor must be an object/,
+    );
+    expect(() => decodeTransactionCursor(encodeRawCursor("cursor"))).toThrow(
+      /cursor must be an object/,
+    );
+  });
+});
+
+describe("cursor query parsing", () => {
+  it("uses null cursor and the default limit when params are absent", () => {
+    expect(parseCursorParams(new URLSearchParams())).toEqual({
+      cursor: null,
+      limit: DEFAULT_CURSOR_LIMIT,
+    });
+  });
+
+  it("decodes cursor and limit from search params", () => {
+    const cursor: TransactionCursor = {
+      v: 1,
+      date: "2026-02-03T04:05:06.000Z",
+      id: "txn-002",
+      direction: "prev",
+    };
+
+    expect(
+      parseCursorParams(
+        new URLSearchParams({
+          cursor: encodeTransactionCursor(cursor),
+          limit: "25",
+        }),
+      ),
+    ).toEqual({
+      cursor,
+      limit: 25,
+    });
+  });
+
+  it("caps large limits and rejects invalid limit values", () => {
+    expect(parseCursorLimit(null)).toBe(DEFAULT_CURSOR_LIMIT);
+    expect(parseCursorLimit("1")).toBe(1);
+    expect(parseCursorLimit(String(MAX_CURSOR_LIMIT + 1))).toBe(
+      MAX_CURSOR_LIMIT,
+    );
+
+    for (const value of ["0", "-1", "1.5", "abc", ""]) {
+      expect(() => parseCursorLimit(value)).toThrow(
+        new RegExp(
+          `limit must be an integer between 1 and ${MAX_CURSOR_LIMIT}`,
+        ),
+      );
+    }
+  });
+});

--- a/lib/api/cursor.ts
+++ b/lib/api/cursor.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_CURSOR_LIMIT = 6;
 export const MAX_CURSOR_LIMIT = 100;
 
-export type CursorDirection = 'next' | 'prev';
+export type CursorDirection = "next" | "prev";
 
 export interface TransactionCursor {
   v: 1;
@@ -15,18 +15,20 @@ export interface ParsedCursorParams {
   limit: number;
 }
 
-const VALID_DIRECTIONS = new Set<CursorDirection>(['next', 'prev']);
-
 function isValidDate(value: string): boolean {
-  return typeof value === 'string' && value.length > 0 && !Number.isNaN(new Date(value).getTime());
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    !Number.isNaN(new Date(value).getTime())
+  );
 }
 
 function encodeBase64Url(value: string): string {
-  return Buffer.from(value, 'utf8').toString('base64url');
+  return Buffer.from(value, "utf8").toString("base64url");
 }
 
 function decodeBase64Url(value: string): string {
-  return Buffer.from(value, 'base64url').toString('utf8');
+  return Buffer.from(value, "base64url").toString("utf8");
 }
 
 export function encodeTransactionCursor(cursor: TransactionCursor): string {
@@ -36,14 +38,14 @@ export function encodeTransactionCursor(cursor: TransactionCursor): string {
 
 export function decodeTransactionCursor(rawCursor: string): TransactionCursor {
   if (!rawCursor) {
-    throw new Error('cursor must not be empty');
+    throw new Error("cursor must not be empty");
   }
 
   let decoded: unknown;
   try {
     decoded = JSON.parse(decodeBase64Url(rawCursor));
   } catch {
-    throw new Error('cursor must be a valid base64url-encoded JSON object');
+    throw new Error("cursor must be a valid base64url-encoded JSON object");
   }
 
   return validateCursor(decoded);
@@ -54,41 +56,49 @@ export function parseCursorLimit(value: string | null): number {
 
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1) {
-    throw new Error(`limit must be an integer between 1 and ${MAX_CURSOR_LIMIT}`);
+    throw new Error(
+      `limit must be an integer between 1 and ${MAX_CURSOR_LIMIT}`,
+    );
   }
 
   return Math.min(parsed, MAX_CURSOR_LIMIT);
 }
 
-export function parseCursorParams(searchParams: URLSearchParams): ParsedCursorParams {
-  const rawCursor = searchParams.get('cursor');
+export function parseCursorParams(
+  searchParams: URLSearchParams,
+): ParsedCursorParams {
+  const rawCursor = searchParams.get("cursor");
   return {
     cursor: rawCursor === null ? null : decodeTransactionCursor(rawCursor),
-    limit: parseCursorLimit(searchParams.get('limit')),
+    limit: parseCursorLimit(searchParams.get("limit")),
   };
 }
 
 function validateCursor(value: unknown): TransactionCursor {
-  if (typeof value !== 'object' || value === null) {
-    throw new Error('cursor must be an object');
+  if (typeof value !== "object" || value === null) {
+    throw new Error("cursor must be an object");
   }
 
   const candidate = value as Partial<TransactionCursor>;
 
   if (candidate.v !== 1) {
-    throw new Error('cursor version is unsupported');
+    throw new Error("cursor version is unsupported");
   }
 
-  if (!isValidDate(candidate.date ?? '')) {
-    throw new Error('cursor date is invalid');
+  if (typeof candidate.date !== "string" || !isValidDate(candidate.date)) {
+    throw new Error("cursor date is invalid");
   }
 
-  if (typeof candidate.id !== 'string' || candidate.id.length === 0 || candidate.id.length > 256) {
-    throw new Error('cursor id is invalid');
+  if (
+    typeof candidate.id !== "string" ||
+    candidate.id.length === 0 ||
+    candidate.id.length > 256
+  ) {
+    throw new Error("cursor id is invalid");
   }
 
-  if (!VALID_DIRECTIONS.has(candidate.direction as CursorDirection)) {
-    throw new Error('cursor direction is invalid');
+  if (candidate.direction !== "next" && candidate.direction !== "prev") {
+    throw new Error("cursor direction is invalid");
   }
 
   return {


### PR DESCRIPTION
## Summary
- add dedicated unit coverage for `lib/api/cursor.ts` round-trips, malformed tokens, tampered payloads, unicode ids, max-length ids, and limit parsing
- document the opaque cursor payload, validation guarantees, and operational guidance in `docs/api-cursor.md`
- tighten `validateCursor` narrowing without changing runtime behavior

Closes #674

## Verification
- `npx vitest run --config vitest.server.config.ts lib/api/cursor.test.ts --coverage --coverage.include=lib/api/cursor.ts --coverage.reporter=text` (100% statements/branches/functions/lines on `lib/api/cursor.ts`)
- `npx vitest run --config vitest.config.ts --project server test/server/cursor.test.ts`
- `npx tsc --noEmit --pretty false --target ES2020 --moduleResolution bundler --module ESNext --types node,vitest/globals --skipLibCheck lib/api/cursor.ts lib/api/cursor.test.ts`

## Notes
- Full-repo `npx tsc --noEmit --pretty false` is currently blocked by unrelated existing type errors across the repository.
- `npx eslint lib/api/cursor.ts lib/api/cursor.test.ts` is blocked because ESLint 9 cannot find an `eslint.config.*` file in this repo.