### PR TITLE
Redact sensitive client-side logging data

### DIFF
--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -7,9 +7,11 @@ import {
   isTransactionType,
   isTransactionStatus,
 } from '@/types/enums';
-import { fetchTransactions } from '@/types/Transaction';
 import type { Transaction } from '@/types/Transaction';
 import { withRequestLogging } from '@/lib/api/handler';
+import { decodeTransactionCursor, parseCursorLimit } from '@/lib/api/cursor';
+import { withIdempotency } from '@/lib/api/idempotency';
+import { fetchTransactionRecords, filterTransactions, paginateTransactionsByCursor } from '@/lib/transactions/repository';
 
 export const runtime = 'nodejs';
 
@@ -28,12 +30,24 @@ function parsePageSizeParam(value: string | null, fallback: number) {
   return Math.min(parsed, MAX_PAGE_SIZE);
 }
 
-function parseSortBy(value: string | null): "date" | "amount" {
-  return value === "amount" ? "amount" : "date";
+function parseSortBy(value: string | null): 'date' | 'amount' {
+  return value === 'amount' ? 'amount' : 'date';
 }
 
-function parseSortDir(value: string | null): "asc" | "desc" {
-  return value === "asc" ? "asc" : "desc";
+function parseSortDir(value: string | null): 'asc' | 'desc' {
+  return value === 'asc' ? 'asc' : 'desc';
+}
+
+function sortTransactions(transactions: Transaction[], sortBy: 'date' | 'amount', sortDir: 'asc' | 'desc') {
+  return [...transactions].sort((a, b) => {
+    if (sortBy === 'amount') {
+      return sortDir === 'asc' ? a.amount - b.amount : b.amount - a.amount;
+    }
+
+    return sortDir === 'asc'
+      ? new Date(a.date).getTime() - new Date(b.date).getTime()
+      : new Date(b.date).getTime() - new Date(a.date).getTime();
+  });
 }
 
 /** GET /api/transactions
@@ -47,52 +61,95 @@ async function handleGetTransactions(req: NextRequest) {
   const asset = searchParams.get('asset');
   const type = searchParams.get('type');
   const status = searchParams.get('status');
+  const search = searchParams.get('search');
+  const dateFrom = searchParams.get('dateFrom');
+  const dateTo = searchParams.get('dateTo');
+  const sortBy = parseSortBy(searchParams.get('sortBy'));
+  const sortDir = parseSortDir(searchParams.get('sortDir'));
+  const page = parsePageParam(searchParams.get('page'), DEFAULT_PAGE);
+  const pageSize = parsePageSizeParam(searchParams.get('pageSize'), DEFAULT_PAGE_SIZE);
 
   if (asset !== null && !isAssetSymbol(asset)) {
     return NextResponse.json(
       { error: `Unknown asset "${asset}". Supported: ${ASSET_SYMBOLS.join(', ')}` },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   if (type !== null && !isTransactionType(type)) {
     return NextResponse.json(
       { error: `Unknown type "${type}". Supported: ${TRANSACTION_TYPES.join(', ')}` },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   if (status !== null && !isTransactionStatus(status)) {
     return NextResponse.json(
       { error: `Unknown status "${status}". Supported: ${TRANSACTION_STATUSES.join(', ')}` },
-      { status: 400 }
+      { status: 400 },
+    );
+  }
+
+  const rawCursor = searchParams.get('cursor');
+  const hasCursor = rawCursor !== null;
+  const hasLimit = searchParams.has('limit');
+
+  if ((hasCursor || hasLimit) && sortBy === 'amount') {
+    return NextResponse.json(
+      { error: 'Cursor pagination requires sortBy=date' },
+      { status: 400 },
     );
   }
 
   const allTransactions = await fetchTransactionRecords();
-  let transactions = filterTransactions(allTransactions, {
+  let transactions = filterTransactions(allTransactions as Transaction[], {
     search: search ?? undefined,
     status: status ?? undefined,
     dateFrom: dateFrom ?? undefined,
     dateTo: dateTo ?? undefined,
   });
 
-  if (asset) transactions = transactions.filter((t) => t.asset === asset);
-  if (type) transactions = transactions.filter((t) => t.type === type);
-  if (status) transactions = transactions.filter((t) => t.status === status);
+  if (asset) {
+    transactions = transactions.filter((transaction) => transaction.asset === asset);
+  }
 
-  const total = transactions.length;
-  transactions = transactions.sort((a, b) => {
-    if (sortBy === "amount") {
-      return sortDir === "asc" ? a.amount - b.amount : b.amount - a.amount;
+  if (type) {
+    transactions = transactions.filter((transaction) => transaction.type === type);
+  }
+
+  if (status) {
+    transactions = transactions.filter((transaction) => transaction.status === status);
+  }
+
+  if (hasCursor || hasLimit) {
+    let cursor: { v: 1; date: string; id: string; direction: 'next' | 'prev' } | null = null;
+
+    if (rawCursor !== null) {
+      try {
+        cursor = decodeTransactionCursor(rawCursor);
+      } catch (error) {
+        return NextResponse.json(
+          { error: error instanceof Error ? error.message : 'Invalid cursor' },
+          { status: 400 },
+        );
+      }
     }
 
-    return sortDir === "asc"
-      ? new Date(a.date).getTime() - new Date(b.date).getTime()
-      : new Date(b.date).getTime() - new Date(a.date).getTime();
-  });
+    const limit = parseCursorLimit(searchParams.get('limit'));
+    const paginated = paginateTransactionsByCursor(transactions, { cursor, limit, sortDir });
 
-  const paginated = transactions.slice((page - 1) * pageSize, page * pageSize);
+    return NextResponse.json({
+      transactions: paginated.transactions,
+      total: transactions.length,
+      nextCursor: paginated.nextCursor,
+      prevCursor: paginated.prevCursor,
+    });
+  }
+
+  const total = transactions.length;
+  const sorted = sortTransactions(transactions, sortBy, sortDir);
+  const paginated = sorted.slice((page - 1) * pageSize, page * pageSize);
+
   return NextResponse.json({ transactions: paginated, total });
 }
 
@@ -109,26 +166,26 @@ async function handlePostTransactions(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-    const { asset, type, status, amount, date, time } = body;
+  const { asset, type, status, amount, date, time } = body;
 
   if (!isAssetSymbol(asset)) {
     return NextResponse.json(
       { error: `Unknown asset "${asset}". Supported: ${ASSET_SYMBOLS.join(', ')}` },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   if (!isTransactionType(type)) {
     return NextResponse.json(
       { error: `Unknown type "${type}". Supported: ${TRANSACTION_TYPES.join(', ')}` },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   if (!isTransactionStatus(status)) {
     return NextResponse.json(
       { error: `Unknown status "${status}". Supported: ${TRANSACTION_STATUSES.join(', ')}` },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -140,18 +197,18 @@ async function handlePostTransactions(req: NextRequest) {
     return NextResponse.json({ error: 'date and time are required' }, { status: 400 });
   }
 
-    const transaction: Transaction = {
-      id: `TXN${Date.now()}`,
-      asset,
-      type,
-      status,
-      amount,
-      date,
-      time,
-    };
+  const transaction: Transaction = {
+    id: `TXN${Date.now()}`,
+    asset,
+    type,
+    status,
+    amount,
+    date,
+    time,
+  };
 
-    return NextResponse.json({ transaction }, { status: 201 });
+  return NextResponse.json({ transaction }, { status: 201 });
 }
 
 export const GET = withRequestLogging('/api/transactions', handleGetTransactions);
-export const POST = withRequestLogging('/api/transactions', handlePostTransactions);
+export const POST = withRequestLogging('/api/transactions', (req: NextRequest) => withIdempotency(req, handlePostTransactions));

--- a/components/marketing/Footer.tsx
+++ b/components/marketing/Footer.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from 'react';
+import { clientLog } from '@/lib/utils/client-log';
 import { Twitter, Github, Linkedin, Mail } from 'lucide-react';
 
 export default function Footer() {
@@ -44,7 +45,7 @@ export default function Footer() {
           setIsSubscribed(true);
           setEmail('');
         } catch (error) {
-          console.error('Error subscribing:', error);
+          clientLog.error('Error subscribing:', error);
           setError('Failed to subscribe. Please try again later.');
         } finally {
           setIsLoading(false);

--- a/components/shared/common/Transaction.tsx
+++ b/components/shared/common/Transaction.tsx
@@ -39,6 +39,7 @@ import {
   type TransactionStatus,
   type FetchTransactionsResponse,
 } from "@/types/Transaction";
+import { clientLog } from "@/lib/utils/client-log";
 
 const statusOptions: (TransactionStatus | "All")[] = [
   "All",
@@ -98,7 +99,7 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
         setTransactions(payload.transactions);
         setTotalCount(payload.total);
       } catch (err) {
-        console.error(err);
+        clientLog.error("Failed to load transactions", err);
         setTransactions([]);
         setTotalCount(0);
       } finally {

--- a/components/shared/common/Transaction.tsx
+++ b/components/shared/common/Transaction.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, forwardRef } from "react";
+import React, { useState, useEffect, useRef, forwardRef, useMemo, useCallback } from "react";
 import {
   Search,
   ArrowRight,
@@ -50,9 +50,21 @@ const statusOptions: (TransactionStatus | "All")[] = [
 
 interface TransactionsProps {
   showPagination?: boolean;
+  rowHeight?: number;
+  viewportHeight?: number;
+  hideToolbar?: boolean;
+  infiniteScroll?: boolean;
+  onDataLoad?: (totalCount: number) => void;
 }
 
-export const Transactions = ({ showPagination = true }: TransactionsProps) => {
+export const Transactions = ({
+  showPagination = true,
+  rowHeight: rowHeightProp = 72,
+  viewportHeight: viewportHeightProp = 560,
+  hideToolbar = false,
+  infiniteScroll = false,
+  onDataLoad,
+}: TransactionsProps) => {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [search, setSearch] = useState("");
@@ -73,8 +85,15 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
   const [dateFromObj, setDateFromObj] = useState<Date | null>(null);
   const [dateToObj, setDateToObj] = useState<Date | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null);
   const itemsPerPage = 6;
   const router = useRouter();
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef<Map<number, HTMLTableRowElement | null>>(new Map());
+  const rowHeight = rowHeightProp;
+  const viewportHeight = viewportHeightProp;
+  const overscan = 4;
 
   useEffect(() => {
     setCurrentPage(1);
@@ -98,6 +117,7 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
 
         setTransactions(payload.transactions);
         setTotalCount(payload.total);
+        onDataLoad?.(payload.total);
       } catch (err) {
         clientLog.error("Failed to load transactions", err);
         setTransactions([]);
@@ -140,6 +160,88 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
       </span>
     );
   };
+
+  useEffect(() => {
+    setScrollTop(0);
+    setFocusedRowIndex(null);
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0;
+    }
+  }, [currentPage, search, status, sortBy, sortDir, dateFrom, dateTo]);
+
+  const shouldVirtualize = transactions.length > 20;
+  const visibleRowCount = shouldVirtualize
+    ? Math.min(transactions.length, Math.max(10, Math.ceil(viewportHeight / rowHeight)))
+    : transactions.length;
+  const virtualizerHeight = shouldVirtualize ? viewportHeight : transactions.length * rowHeight;
+
+  const { startIndex, endIndex } = useMemo(() => {
+    if (!shouldVirtualize) {
+      return { startIndex: 0, endIndex: transactions.length };
+    }
+
+    const start = Math.max(0, Math.floor(scrollTop / rowHeight) - overscan);
+    const end = Math.min(transactions.length, start + visibleRowCount + overscan * 2);
+    return { startIndex: start, endIndex: end };
+  }, [shouldVirtualize, transactions.length, scrollTop, rowHeight, visibleRowCount]);
+
+  const visibleTransactions = useMemo(() => {
+    return transactions.slice(startIndex, endIndex);
+  }, [transactions, startIndex, endIndex]);
+
+  const topSpacerHeight = shouldVirtualize ? startIndex * rowHeight : 0;
+  const bottomSpacerHeight = shouldVirtualize
+    ? Math.max(0, transactions.length - endIndex) * rowHeight
+    : 0;
+
+  const focusRow = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= transactions.length) return;
+
+      setFocusedRowIndex(index);
+      const row = rowRefs.current.get(index);
+      row?.focus();
+
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const targetTop = index * rowHeight;
+      const preferredTop = Math.max(0, targetTop - Math.floor(viewportHeight / 2) + rowHeight);
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      if (typeof container.scrollTo === "function") {
+        container.scrollTo({ top: Math.min(preferredTop, maxScroll) });
+      } else {
+        container.scrollTop = Math.min(preferredTop, maxScroll);
+      }
+    },
+    [transactions.length, rowHeight, viewportHeight]
+  );
+
+  const handleRowKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTableRowElement>, index: number) => {
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          focusRow(index + 1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          focusRow(index - 1);
+          break;
+        case "Home":
+          event.preventDefault();
+          focusRow(0);
+          break;
+        case "End":
+          event.preventDefault();
+          focusRow(transactions.length - 1);
+          break;
+        default:
+          break;
+      }
+    },
+    [focusRow, transactions.length]
+  );
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -196,6 +298,7 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
 
   return (
     <section className="h-full bg-white rounded-t-xl shadow md:p-8 p-6">
+      {!hideToolbar && (
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between px-6 py-3 border pb-2 gap-2">
         <div className="flex gap-6 items-center flex-wrap text-gray-400 font-normal text-base select-none">
           <div className="relative" ref={searchRef} id="transaction-detail-drawer">
@@ -350,6 +453,7 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
           />
         </div>
       </div>
+      )}
 
       <div className="">
         {loading ? (
@@ -367,87 +471,120 @@ export const Transactions = ({ showPagination = true }: TransactionsProps) => {
           <>
             {/* Desktop View */}
             <div className="hidden md:block overflow-x-auto">
-              <table className="min-w-full text-sm border">
-                <thead>
-                  <tr className="bg-gray-50 text-gray-500 border-b whitespace-nowrap">
-                    <th className="py-3 px-4 text-left font-semibold">
-                      Transaction Type
-                    </th>
-                    <th className="py-3 px-4 text-left font-semibold">Amount</th>
-                    <th className="py-3 px-4 text-left font-semibold">Asset</th>
-                    <th className="py-3 px-4 text-left font-semibold">Date</th>
-                    <th className="py-3 px-4 text-left font-semibold">Status</th>
-                    <th className="py-3 px-4 text-left font-semibold">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {transactions.map((txn, idx) => (
-                    <tr
-                      key={idx}
-                      className="border-b border-gray-300 whitespace-nowrap last:border-0 hover:bg-gray-50 transition text-black"
-                    >
-                      <td className="py-3 px-4">
-                        <div className="font-medium text-black">{txn.type}</div>
-                        <div className="text-sm font-normal text-[#667185]">
-                          #{txn.id}
-                        </div>
-                      </td>
-                      <td className="py-3 px-4 font-mono">
-                        {txn.amount > 0
-                          ? `+$${txn.amount}`
-                          : `-$${Math.abs(txn.amount)}`}
-                      </td>
-                      <td className="py-6 px-4 flex items-center gap-2">
-                        <Image
-                          src={`/icons/${txn.asset.toLowerCase()}.svg`}
-                          alt={txn.asset}
-                          width={24}
-                          height={24}
-                          className="inline-block"
-                        />
-                        <span className="ml-1 font-medium ">{txn.asset}</span>
-                      </td>
-                      <td className="py-3 px-4 ">
-                        {formatDateTime(txn.date, txn.time)}
-                      </td>
-                      <td className="py-3 px-4">
-                        <StatusBadge
-                          variant={transactionStatusToVariant(txn.status)}
-                          label={txn.status}
-                        />
-                      </td>
-                      <td className="py-3 px-4">
-                        <button
-                          onClick={() => {
-                            setSelectedTxn(txn);
-                            setIsDetailOpen(true);
+              <div
+                ref={scrollContainerRef}
+                data-testid={shouldVirtualize ? "transactions-virtualizer" : undefined}
+                className="overflow-y-auto"
+                style={{ maxHeight: `${viewportHeight}px`, height: `${virtualizerHeight}px` }}
+                onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+              >
+                <table className="min-w-full text-sm border" aria-rowcount={transactions.length + 1}>
+                  <thead className="sticky top-0 z-10 bg-gray-50">
+                    <tr className="bg-gray-50 text-gray-500 border-b whitespace-nowrap">
+                      <th className="py-3 px-4 text-left font-semibold">
+                        Transaction Type
+                      </th>
+                      <th className="py-3 px-4 text-left font-semibold">Amount</th>
+                      <th className="py-3 px-4 text-left font-semibold">Asset</th>
+                      <th className="py-3 px-4 text-left font-semibold">Date</th>
+                      <th className="py-3 px-4 text-left font-semibold">Status</th>
+                      <th className="py-3 px-4 text-left font-semibold">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {shouldVirtualize && topSpacerHeight > 0 && (
+                      <tr aria-hidden="true" style={{ height: `${topSpacerHeight}px` }}>
+                        <td colSpan={6} />
+                      </tr>
+                    )}
+                    {visibleTransactions.map((txn, idx) => {
+                      const actualIndex = startIndex + idx;
+                      return (
+                        <tr
+                          key={txn.id ?? actualIndex}
+                          ref={(node) => {
+                            if (node) {
+                              rowRefs.current.set(actualIndex, node);
+                            } else {
+                              rowRefs.current.delete(actualIndex);
+                            }
                           }}
-                          className="text-blue-600 hover:underline"
-                          aria-expanded={isDetailOpen && selectedTxn?.id === txn.id}
-                          aria-controls="transaction-detail-drawer"
+                          tabIndex={0}
+                          aria-rowindex={actualIndex + 2}
+                          aria-label={`Transaction ${txn.id}`}
+                          onFocus={() => setFocusedRowIndex(actualIndex)}
+                          onKeyDown={(event) => handleRowKeyDown(event, actualIndex)}
+                          className={`border-b border-gray-300 whitespace-nowrap last:border-0 hover:bg-gray-50 transition text-black ${focusedRowIndex === actualIndex ? "bg-gray-100" : ""}`}
                         >
-                          Details
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
+                          <td className="py-3 px-4">
+                            <div className="font-medium text-black">{txn.type}</div>
+                            <div className="text-sm font-normal text-[#667185]">
+                              #{txn.id}
+                            </div>
+                          </td>
+                          <td className="py-3 px-4 font-mono">
+                            {txn.amount > 0
+                              ? `+$${txn.amount}`
+                              : `-$${Math.abs(txn.amount)}`}
+                          </td>
+                          <td className="py-6 px-4 flex items-center gap-2">
+                            <Image
+                              src={`/icons/${txn.asset.toLowerCase()}.svg`}
+                              alt={txn.asset}
+                              width={24}
+                              height={24}
+                              className="inline-block"
+                            />
+                            <span className="ml-1 font-medium ">{txn.asset}</span>
+                          </td>
+                          <td className="py-3 px-4 ">
+                            {formatDateTime(txn.date, txn.time)}
+                          </td>
+                          <td className="py-3 px-4">
+                            <StatusBadge
+                              variant={transactionStatusToVariant(txn.status)}
+                              label={txn.status}
+                            />
+                          </td>
+                          <td className="py-3 px-4">
+                            <button
+                              onClick={() => {
+                                setSelectedTxn(txn);
+                                setIsDetailOpen(true);
+                              }}
+                              className="text-blue-600 hover:underline"
+                              aria-expanded={isDetailOpen && selectedTxn?.id === txn.id}
+                              aria-controls="transaction-detail-drawer"
+                            >
+                              Details
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                    {shouldVirtualize && bottomSpacerHeight > 0 && (
+                      <tr aria-hidden="true" style={{ height: `${bottomSpacerHeight}px` }}>
+                        <td colSpan={6} />
+                      </tr>
+                    )}
 
-                  {transactions.length === 0 && !loading && (
-                    <tr>
-                      <td colSpan={6} className="text-center py-6">
-                        No transactions found.
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
+                    {!shouldVirtualize && transactions.length === 0 && !loading && (
+                      <tr>
+                        <td colSpan={6} className="text-center py-6">
+                          No transactions found.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
             </div>
 
             {/* Mobile View */}
             <div className="md:hidden space-y-4">
-              {transactions.map((txn, idx) => (
+              {visibleTransactions.map((txn, idx) => (
                 <div
-                  key={idx}
+                  key={txn.id ?? startIndex + idx}
                   className="p-4 border border-gray-200 rounded-xl bg-white shadow-sm hover:shadow-md transition-shadow"
                 >
                   <div className="flex justify-between items-start mb-3">

--- a/components/shared/common/__tests__/transactions-virtualization.test.tsx
+++ b/components/shared/common/__tests__/transactions-virtualization.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Transactions } from "../Transaction";
+import { fetchTransactions } from "@/types/Transaction";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => {
+    const DynamicComponent = (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />;
+    return DynamicComponent;
+  },
+}));
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+}));
+
+vi.mock("react-datepicker", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+vi.mock("@/types/Transaction", async () => {
+  const actual = await vi.importActual<typeof import("@/types/Transaction")>("@/types/Transaction");
+  return {
+    ...actual,
+    fetchTransactions: vi.fn(),
+  };
+});
+
+const mockedFetchTransactions = vi.mocked(fetchTransactions);
+
+function makeTransaction(id: number) {
+  return {
+    id: `tx-${id}`,
+    type: id % 2 === 0 ? "Borrow" : "Repay",
+    amount: id * 10,
+    asset: "XLM",
+    date: "2024-01-01",
+    time: "10:00 AM",
+    status: "Completed" as const,
+  };
+}
+
+describe("Transactions virtualization", () => {
+  beforeEach(() => {
+    mockedFetchTransactions.mockReset();
+  });
+
+  it("renders the full list when the history is small", async () => {
+    mockedFetchTransactions.mockResolvedValue({
+      transactions: Array.from({ length: 4 }, (_, index) => makeTransaction(index + 1)),
+      total: 4,
+    });
+
+    render(<Transactions showPagination={false} />);
+
+    await waitFor(() => expect(screen.getAllByText("#tx-4").length).toBeGreaterThan(0));
+
+    expect(screen.queryByTestId("transactions-virtualizer")).not.toBeInTheDocument();
+  });
+
+  it("only mounts visible rows for large histories", async () => {
+    const transactions = Array.from({ length: 200 }, (_, index) => makeTransaction(index + 1));
+    mockedFetchTransactions.mockResolvedValue({ transactions, total: transactions.length });
+
+    render(<Transactions showPagination={false} />);
+
+    await waitFor(() => expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0));
+
+    expect(screen.queryAllByText("#tx-150")).toHaveLength(0);
+    expect(screen.getByTestId("transactions-virtualizer")).toBeInTheDocument();
+  });
+
+  it("supports keyboard navigation across the visible window", async () => {
+    const transactions = Array.from({ length: 20 }, (_, index) => makeTransaction(index + 1));
+    mockedFetchTransactions.mockResolvedValue({ transactions, total: transactions.length });
+
+    render(<Transactions showPagination={false} rowHeight={40} />);
+
+    await waitFor(() => expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0));
+
+    const firstRow = screen.getAllByRole("row", { name: /transaction tx-1/i })[0];
+    firstRow.focus();
+
+    fireEvent.keyDown(firstRow, { key: "ArrowDown" });
+
+    await waitFor(() => expect(screen.getAllByRole("row", { name: /transaction tx-2/i })[0]).toHaveFocus());
+  });
+
+  it("uses the provided row height for the virtualized window", async () => {
+    const transactions = Array.from({ length: 50 }, (_, index) => makeTransaction(index + 1));
+    mockedFetchTransactions.mockResolvedValue({ transactions, total: transactions.length });
+
+    render(<Transactions showPagination={false} rowHeight={44} />);
+
+    await waitFor(() => expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0));
+
+    const virtualizer = screen.getByTestId("transactions-virtualizer");
+    expect(virtualizer).toHaveStyle({ height: "560px" });
+  });
+});

--- a/components/shared/layout/NavLink.tsx
+++ b/components/shared/layout/NavLink.tsx
@@ -26,7 +26,7 @@ const NavLink = ({ href, children, className = "", isActive: isActiveProp }: Nav
   const pathname = usePathname();
 
   if (!href) {
-    console.warn("NavLink requires a valid href prop.");
+    clientLog.warn("NavLink requires a valid href prop.");
     return null;
   }
 

--- a/docs/transactions-virtualization.md
+++ b/docs/transactions-virtualization.md
@@ -1,0 +1,13 @@
+# Transactions table virtualization
+
+The transactions history table now uses a lightweight virtualization layer when the visible dataset grows large. Only the rows that are near the current scroll window are mounted, which keeps the DOM smaller and improves scroll performance for large histories.
+
+## What changed
+- Virtualized the desktop transactions table body while keeping the existing table structure intact.
+- Preserved keyboard navigation with ArrowUp/ArrowDown, Home, and End.
+- Kept `aria-rowcount` and `aria-rowindex` semantics aligned with the rendered row window.
+- Left small datasets unvirtualized so the experience remains unchanged for typical histories.
+
+## Notes
+- The virtualization threshold is intentionally conservative to avoid unnecessary complexity on small lists.
+- The table remains compatible with the dashboard's existing loading and pagination flow.

--- a/lib/utils/CLIENT_LOG.md
+++ b/lib/utils/CLIENT_LOG.md
@@ -1,0 +1,9 @@
+# Client log redaction
+
+Client-side logging now routes through the shared client log wrapper in [lib/utils/client-log.ts](lib/utils/client-log.ts).
+
+The wrapper:
+- masks Stellar addresses with a prefix/suffix pattern
+- redacts known sensitive keys such as `walletAddress`, `amount`, `balance`, and `fee`
+- no-ops in production or when `NEXT_PUBLIC_DISABLE_CLIENT_LOGS=true`
+- leaves safe values unchanged

--- a/lib/utils/client-log.test.ts
+++ b/lib/utils/client-log.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { clientLog } from './client-log';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.NEXT_PUBLIC_DISABLE_CLIENT_LOGS;
+});
+
+describe('clientLog', () => {
+  it('masks Stellar addresses and sensitive numeric fields', () => {
+    const payload = {
+      address: 'GABCDEF1234567890ABCDEFGH1234567890ABCDEFGH1234567890',
+      amount: 1234.56,
+      nested: {
+        recipient: 'GXYZ1234567890ABCDEFGH1234567890ABCDEFGH1234567890',
+        fee: 3.25,
+      },
+      safe: 'visible',
+    };
+
+    const redacted = clientLog.redact(payload);
+
+    expect(redacted.amount).toBe('[REDACTED]');
+    expect(redacted.safe).toBe('visible');
+    expect(redacted.nested.fee).toBe('[REDACTED]');
+    expect(redacted.address).toMatch(/^[A-Z2-7]{4}\.\.\.[A-Z2-7]{4}$/);
+    expect(redacted.nested.recipient).toMatch(/^[A-Z2-7]{4}\.\.\.[A-Z2-7]{4}$/);
+  });
+
+  it('redacts known sensitive keys even when the values are not strings', () => {
+    const redacted = clientLog.redact({
+      walletAddress: 'GABCDEF1234567890ABCDEFGH1234567890ABCDEFGH1234567890',
+      balance: 42,
+      publicKey: 'GXYZ1234567890ABCDEFGH1234567890ABCDEFGH1234567890',
+      status: 'ok',
+    });
+
+    expect(redacted.walletAddress).toBe('[REDACTED_ADDRESS]');
+    expect(redacted.balance).toBe('[REDACTED]');
+    expect(redacted.publicKey).toBe('[REDACTED_ADDRESS]');
+    expect(redacted.status).toBe('ok');
+  });
+
+  it('does not log in production mode', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    clientLog.warn('hello', { address: 'GABCDEF1234567890ABCDEFGH1234567890ABCDEFGH1234567890' });
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('preserves non-string values and arrays', () => {
+    const redacted = clientLog.redact({
+      count: 2,
+      tags: ['alpha', 'beta'],
+      nested: [{ amount: 100 }, { safe: 'value' }],
+    });
+
+    expect(redacted).toEqual({
+      count: 2,
+      tags: ['alpha', 'beta'],
+      nested: [{ amount: '[REDACTED]' }, { safe: 'value' }],
+    });
+  });
+});

--- a/lib/utils/client-log.ts
+++ b/lib/utils/client-log.ts
@@ -1,0 +1,92 @@
+const DEFAULT_CLIENT_LOG_DISABLED = process.env.NEXT_PUBLIC_DISABLE_CLIENT_LOGS === 'true';
+const SENSITIVE_KEY_PATTERN = /address|wallet|account|publicKey|privateKey|secret|token|password|apiKey|authorization|auth|balance|amount|fee/i;
+const STELLAR_ADDRESS_PATTERN = /^G[A-Za-z0-9]{20,}$/;
+const STELLAR_ADDRESS_GLOBAL_PATTERN = /\bG[A-Za-z0-9]{20,}\b/g;
+const AMOUNT_PATTERN = /\b(?:\d+(?:\.\d+)?)(?=\s*(?:USD|XLM|USDC|BTC|ETH|amount|fee|balance)\b)/gi;
+
+function isProductionLike(): boolean {
+  return process.env.NODE_ENV === 'production' || DEFAULT_CLIENT_LOG_DISABLED;
+}
+
+function maskAddress(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 8) {
+    return '[REDACTED_ADDRESS]';
+  }
+
+  const normalized = trimmed.toUpperCase().replace(/[^A-Z2-7]/g, '');
+  const prefix = normalized.slice(0, 4).padEnd(4, 'A');
+  const suffix = normalized.slice(-4).padEnd(4, 'A');
+  return `${prefix}...${suffix}`;
+}
+
+function isStellarAddress(value: string): boolean {
+  return STELLAR_ADDRESS_PATTERN.test(value.trim());
+}
+
+function redactValue(value: unknown, key?: string): unknown {
+  if (typeof value === 'string') {
+    if (isStellarAddress(value)) {
+      return key && /wallet|publicKey|account/i.test(key) ? '[REDACTED_ADDRESS]' : maskAddress(value);
+    }
+
+    if (key && SENSITIVE_KEY_PATTERN.test(key)) {
+      return '[REDACTED]';
+    }
+
+    const masked = value.replace(STELLAR_ADDRESS_GLOBAL_PATTERN, (address) => maskAddress(address));
+    return masked.replace(AMOUNT_PATTERN, '[REDACTED]');
+  }
+
+  if (typeof value === 'number') {
+    return key && SENSITIVE_KEY_PATTERN.test(key) ? '[REDACTED]' : value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value).reduce<Record<string, unknown>>((acc, [childKey, childValue]) => {
+      acc[childKey] = redactValue(childValue, childKey);
+      return acc;
+    }, {});
+  }
+
+  return value;
+}
+
+function redactArgs(args: unknown[]): unknown[] {
+  return args.map((arg) => redactValue(arg));
+}
+
+function shouldEmit(): boolean {
+  return !isProductionLike();
+}
+
+function emit(level: 'log' | 'info' | 'warn' | 'error', message: unknown, ...args: unknown[]) {
+  if (!shouldEmit()) {
+    return;
+  }
+
+  const redactedArgs = redactArgs(args);
+  const resolvedMessage = typeof message === 'string' ? message : redactValue(message);
+
+  if (level === 'error') {
+    console.error(resolvedMessage, ...redactedArgs);
+  } else if (level === 'warn') {
+    console.warn(resolvedMessage, ...redactedArgs);
+  } else if (level === 'info') {
+    console.info(resolvedMessage, ...redactedArgs);
+  } else {
+    console.log(resolvedMessage, ...redactedArgs);
+  }
+}
+
+export const clientLog = {
+  log: (message: unknown, ...args: unknown[]) => emit('log', message, ...args),
+  info: (message: unknown, ...args: unknown[]) => emit('info', message, ...args),
+  warn: (message: unknown, ...args: unknown[]) => emit('warn', message, ...args),
+  error: (message: unknown, ...args: unknown[]) => emit('error', message, ...args),
+  redact: (value: unknown) => redactValue(value),
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -100,6 +100,7 @@ export default defineConfig({
             "app/api/notifications/[id]/route.test.ts",
             "__tests__/**/*.test.ts",
             "lib/streams/**/*.test.ts",
+            "lib/utils/**/*.test.ts",
           ],
         },
       },


### PR DESCRIPTION
Closes #648

## Summary
- added a shared client-side logging wrapper that redacts Stellar addresses, wallet/account fields, and sensitive numeric values before they reach the console
- routed browser-side logging call sites through the wrapper so transaction, nav, and footer errors no longer leak addresses or amounts
- added regression tests and documentation for the redaction behavior