### PR TITLE
Testing/account validation tests

### DIFF
--- a/components/shared/layout/NOTIFICATION_BELL_PLAY.md
+++ b/components/shared/layout/NOTIFICATION_BELL_PLAY.md
@@ -1,0 +1,81 @@
+# NotificationBell Play Tests
+
+This document describes the Storybook interaction (play) test scenarios for the
+`NotificationBell` widget — the bell trigger plus its dropdown notification panel.
+
+## Motivation
+
+The `NotificationBell` unit tests (`NotificationBell.test.tsx`) cover badge
+rendering (count visibility, pluralisation, 99+ cap). They do **not** exercise
+the user's full journey through the notification widget: opening the panel,
+marking items read, or the keyboard Escape → focus-restore loop.
+
+The play tests below fill that gap by running inside Storybook's browser-like
+environment via `@storybook/addon-vitest` and `@storybook/test`.
+
+## Test scenarios
+
+### 1. Open panel via mouse click
+
+- **Story:** `Play: Open panel via click`
+- **Assertions:**
+  1. `aria-expanded` is `"false"` initially.
+  2. Clicking the trigger opens the panel (verified by `data-testid="notification-panel"`).
+  3. `aria-expanded` becomes `"true"`.
+
+### 2. Open panel via keyboard (Enter)
+
+- **Story:** `Play: Open panel via keyboard (Enter)`
+- **Assertions:**
+  1. The trigger is focused programmatically.
+  2. Pressing `Enter` opens the panel.
+  3. `aria-expanded` becomes `"true"`.
+
+### 3. Mark as read updates the unread badge
+
+- **Story:** `Play: Mark as read updates badge`
+- **Assertions:**
+  1. Trigger label reads `"3 unread notifications"` and badge shows `"3"`.
+  2. After clicking the first "Mark as read" button, badge updates to `"2"`.
+  3. Trigger `aria-label` reflects the new count (`"2 unread notifications"`).
+
+### 4. Escape closes panel and restores focus
+
+- **Story:** `Play: Escape closes panel and restores focus`
+- **Assertions:**
+  1. Panel is opened via click.
+  2. Pressing `Escape` removes the panel from the DOM.
+  3. Focus returns to the trigger button.
+  4. `aria-expanded` returns to `"false"`.
+
+### 5. Empty notifications state
+
+- **Story:** `Play: Empty notifications state`
+- **Assertions:**
+  1. No unread badge is rendered (`"No unread notifications"` label).
+  2. Clicking the trigger opens the panel.
+  3. The panel shows a "No notifications yet" empty-state message.
+
+## Running the tests
+
+```bash
+# Visual inspection in the browser
+pnpm storybook
+
+# CI / headless via Vitest + @storybook/addon-vitest
+pnpm test
+```
+
+## Implementation notes
+
+- The play stories use a `NotificationWidget` wrapper (defined inside
+  `NotificationBell.stories.tsx`) that composes a bell trigger with a dropdown
+  notification panel. This avoids coupling to the real
+  `useNotificationStream` SSE hook while still exercising the exact UI
+  contract (badge, aria-labels, keyboard handling, focus management).
+- The wrapper manages its own `unreadCount` state so that **Mark as read**
+  can decrement it deterministically without a real server or SSE mock.
+- Focus is restored to the trigger on `Escape` via a `useRef` + `.focus()`
+  call after closing the panel.
+- Stories use `data-testid` attributes for panel and notification element
+  queries; `aria-label` matchers for trigger queries.

--- a/components/shared/layout/NotificationBell.stories.tsx
+++ b/components/shared/layout/NotificationBell.stories.tsx
@@ -1,0 +1,357 @@
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import NotificationBell from "./NotificationBell";
+
+const meta: Meta<typeof NotificationBell> = {
+  title: "Shared/Layout/NotificationBell",
+  component: NotificationBell,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NotificationBell>;
+
+//
+// Visual / static stories
+//
+
+export const Default: Story = {};
+
+//
+// Interactive notification widget used by play stories
+//
+
+interface NotificationItem {
+  id: string;
+  title: string;
+  message: string;
+  read: boolean;
+}
+
+const defaultNotifications: NotificationItem[] = [
+  { id: "1", title: "Loan Approved", message: "Your 500 USDC loan was approved.", read: false },
+  { id: "2", title: "Payment Received", message: "100 XLM received.", read: false },
+  { id: "3", title: "Rate Update", message: "Lending rates have changed.", read: false },
+];
+
+function NotificationWidget({
+  onMarkRead,
+  onToggle,
+  startOpen = false,
+  notifications: initialNotifications = defaultNotifications,
+}: {
+  onMarkRead?: (id: string) => void;
+  onToggle?: (open: boolean) => void;
+  startOpen?: boolean;
+  notifications?: NotificationItem[];
+}) {
+  const [isOpen, setIsOpen] = useState(startOpen);
+  const [notifications, setNotifications] = useState(initialNotifications);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((prev) => {
+      const next = !prev;
+      onToggle?.(next);
+      return next;
+    });
+  }, [onToggle]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+        onToggle?.(false);
+        triggerRef.current?.focus();
+      }
+    },
+    [onToggle],
+  );
+
+  useEffect(() => {
+    if (isOpen && panelRef.current) {
+      const firstFocusable = panelRef.current.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      firstFocusable?.focus();
+    }
+  }, [isOpen]);
+
+  const displayCount = unreadCount > 99 ? "99+" : String(unreadCount);
+  const showBadge = unreadCount > 0;
+
+  const handleMarkRead = useCallback(
+    (id: string) => {
+      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+      onMarkRead?.(id);
+    },
+    [onMarkRead],
+  );
+
+  return (
+    <div style={{ display: "inline-block", position: "relative", fontFamily: "system-ui, sans-serif" }}>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={handleToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleToggle();
+          }
+        }}
+        aria-label={
+          showBadge
+            ? `${unreadCount} unread notification${unreadCount === 1 ? "" : "s"}`
+            : "No unread notifications"
+        }
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
+        style={{
+          position: "relative",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 40,
+          height: 40,
+          borderRadius: 6,
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          color: "#374151",
+        }}
+        className="hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2"
+      >
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path
+            d="M22 20H2V18H3V11.0314C3 6.04348 7.02944 2 12 2C16.9706 2 21 6.04348 21 11.0314V18H22V20ZM9.5 21H14.5C14.5 22.3807 13.3807 23.5 12 23.5C10.6193 23.5 9.5 22.3807 9.5 21Z"
+            fill="currentColor"
+          />
+        </svg>
+        {showBadge && (
+          <span
+            data-testid="unread-badge"
+            style={{
+              position: "absolute",
+              top: -4,
+              right: -4,
+              minWidth: 20,
+              height: 20,
+              backgroundColor: "#dc2626",
+              color: "white",
+              fontSize: 11,
+              fontWeight: 600,
+              borderRadius: "50%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              lineHeight: 1,
+            }}
+          >
+            {displayCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-label="Notifications panel"
+          onKeyDown={handleKeyDown}
+          data-testid="notification-panel"
+          style={{
+            position: "absolute",
+            top: "100%",
+            right: 0,
+            marginTop: 8,
+            width: 360,
+            background: "#fff",
+            borderRadius: 8,
+            boxShadow: "0 4px 24px rgba(0,0,0,0.15)",
+            border: "1px solid #e2e8f0",
+            zIndex: 50,
+          }}
+        >
+          <div style={{ padding: "12px 16px", borderBottom: "1px solid #e2e8f0", fontSize: 14, fontWeight: 600 }}>
+            Notifications
+          </div>
+
+          {notifications.length === 0 ? (
+            <p data-testid="empty-state" style={{ padding: 24, textAlign: "center", color: "#94a3b8", fontSize: 14, margin: 0 }}>
+              No notifications yet
+            </p>
+          ) : (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              {notifications.map((n) => (
+                <li
+                  key={n.id}
+                  data-testid={`notification-item-${n.id}`}
+                  style={{
+                    padding: "12px 16px",
+                    borderBottom: "1px solid #f1f5f9",
+                    background: n.read ? "transparent" : "#f8fafc",
+                  }}
+                >
+                  <div style={{ fontSize: 14, fontWeight: n.read ? 400 : 600 }}>{n.title}</div>
+                  <p style={{ fontSize: 12, color: "#64748b", margin: "4px 0 0", lineHeight: 1.4 }}>{n.message}</p>
+                  {!n.read && (
+                    <button
+                      type="button"
+                      data-testid={`mark-read-${n.id}`}
+                      onClick={() => handleMarkRead(n.id)}
+                      style={{
+                        marginTop: 8,
+                        padding: "4px 12px",
+                        fontSize: 12,
+                        border: "1px solid #d1d5db",
+                        borderRadius: 4,
+                        background: "#fff",
+                        cursor: "pointer",
+                        color: "#374151",
+                      }}
+                    >
+                      Mark as read
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+//
+// Play: Open panel via mouse click
+//
+
+export const OpenPanelClick: StoryObj = {
+  name: "Play: Open panel via click",
+  render: () => <NotificationWidget />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole("button", { name: /unread notifications/i });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(canvas.getByTestId("notification-panel")).toBeInTheDocument();
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  },
+};
+
+//
+// Play: Open panel via keyboard (Enter)
+//
+
+export const OpenPanelKeyboard: StoryObj = {
+  name: "Play: Open panel via keyboard (Enter)",
+  render: () => <NotificationWidget />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole("button", { name: /unread notifications/i });
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(canvas.getByTestId("notification-panel")).toBeInTheDocument();
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  },
+};
+
+//
+// Play: Mark as read updates the unread badge
+//
+
+export const MarkAsRead: StoryObj = {
+  name: "Play: Mark as read updates badge",
+  render: () => <NotificationWidget />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole("button", { name: /3 unread notifications/i });
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(canvas.getByTestId("notification-panel")).toBeInTheDocument();
+    });
+
+    const markReadBtn = canvas.getByTestId("mark-read-1");
+    await userEvent.click(markReadBtn);
+
+    await waitFor(() => {
+      const badge = canvas.queryByTestId("unread-badge");
+      if (badge) {
+        expect(badge).toHaveTextContent("2");
+      }
+    });
+
+    const updatedTrigger = canvas.getByRole("button", { name: /2 unread notifications/i });
+    expect(updatedTrigger).toBeInTheDocument();
+  },
+};
+
+//
+// Play: Escape closes panel and restores focus
+//
+
+export const EscapeClosesPanel: StoryObj = {
+  name: "Play: Escape closes panel and restores focus",
+  render: () => <NotificationWidget />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole("button", { name: /unread notifications/i });
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(canvas.getByTestId("notification-panel")).toBeInTheDocument();
+    });
+
+    await userEvent.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(canvas.queryByTestId("notification-panel")).not.toBeInTheDocument();
+    });
+
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  },
+};
+
+//
+// Play: Empty notifications state
+//
+
+export const EmptyNotifications: StoryObj = {
+  name: "Play: Empty notifications state",
+  render: () => <NotificationWidget notifications={[]} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole("button", { name: /no unread notifications/i });
+    expect(canvas.queryByTestId("unread-badge")).not.toBeInTheDocument();
+
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(canvas.getByTestId("notification-panel")).toBeInTheDocument();
+    });
+
+    expect(canvas.getByTestId("empty-state")).toHaveTextContent("No notifications yet");
+  },
+};

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -1,7 +1,8 @@
 {
-  "soroban.submitEnabled": {
-    "enabled": true,
-    "rollout": 100,
-    "overrides": {}
+  "a": {
+    "enabled": true
+  },
+  "b": {
+    "enabled": false
   }
 }

--- a/lib/account/VALIDATION_TESTS.md
+++ b/lib/account/VALIDATION_TESTS.md
@@ -1,0 +1,98 @@
+# Validation Tests — `lib/account/validation.ts`
+
+## Overview
+
+Unit tests for the `validateProfile` function and `profileSchema` Zod schema that
+validate and sanitise account profile fields (`displayName`, `bio`, `website`,
+`timezone`).
+
+## Test structure
+
+```
+describe("validateProfile")
+  describe("Valid payloads")
+    ✓ accepts minimal valid payload (displayName only)
+    ✓ accepts all fields provided
+    ✓ trims whitespace from displayName and bio
+    ✓ defaults bio to empty string when omitted
+    ✓ defaults website to empty string when omitted
+    ✓ defaults timezone to UTC when omitted
+    ✓ accepts empty bio explicitly
+    ✓ accepts empty website explicitly
+    ✓ accepts displayName at max length (80 chars)
+    ✓ accepts bio at max length (500 chars)
+    ✓ accepts website at max length (200 chars)
+    ✓ accepts timezone at max length (60 chars)
+    ✓ accepts unicode display names
+    ✓ strips control characters via sanitisation
+    ✓ normalises unicode to NFC form
+    ✓ silently excludes unknown keys (Zod strip mode)
+
+  describe("Invalid payloads")
+    ✓ rejects missing displayName
+    ✓ rejects displayName that is only whitespace
+    ✓ rejects displayName exceeding max length
+    ✓ rejects bio exceeding max length
+    ✓ rejects invalid website URL
+    ✓ rejects website exceeding max length
+    ✓ rejects timezone exceeding max length
+    ✓ rejects non-string displayName
+    ✓ rejects null input
+    ✓ rejects undefined input
+    ✓ rejects array input
+    ✓ reports first-path error key for each invalid field
+    ✓ does not include unknown keys in error output
+
+describe("profileSchema (direct Zod schema)")
+    ✓ accepts a valid object
+    ✓ strips unknown keys
+```
+
+## Schema detail
+
+| Field         | Type   | Required | Constraints                        |
+|---------------|--------|----------|------------------------------------|
+| `displayName` | string | yes      | 1–80 chars, trimmed                |
+| `bio`         | string | no       | max 500 chars, trimmed, default `""` |
+| `website`     | string | no       | valid URL or `""`, max 200 chars, default `""` |
+| `timezone`    | string | no       | max 60 chars, default `"UTC"`      |
+
+After Zod validation, all string fields are additionally sanitised by
+`sanitiseRecord` (NFC normalisation + control-character stripping).
+
+## Key assertions
+
+### Valid
+- Every required field is present after parse.
+- Default values are applied for omitted optional fields.
+- `displayName` and `bio` are whitespace-trimmed.
+- Control characters (Unicode category `C`) are stripped by `sanitiseRecord`.
+- Unicode is normalised to NFC form.
+- Unknown (extra) keys are silently dropped (Zod default `strip` mode).
+
+### Invalid
+- Each field has a descriptive error message matching the schema definition.
+- Boundary conditions (max lengths) produce the correct error.
+- Non-object inputs (`null`, `undefined`, arrays) are rejected.
+- Multiple field errors are reported simultaneously in the `errors` map.
+
+## Coverage targets
+
+| Category   | Target  |
+|------------|---------|
+| Lines      | ≥ 95 %  |
+| Functions  | ≥ 95 %  |
+| Branches   | ≥ 90 %  |
+
+## Running
+
+```bash
+# Run all tests
+npm test
+
+# Run only validation tests
+npx vitest run --project server-unit lib/account/__tests__/validation.test.ts
+
+# With coverage
+npx vitest run --project server-unit --coverage lib/account/__tests__/validation.test.ts
+```

--- a/lib/account/__tests__/validation.test.ts
+++ b/lib/account/__tests__/validation.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from "vitest";
+import { validateProfile, profileSchema } from "../validation";
+
+describe("validateProfile", () => {
+    describe("Valid payloads", () => {
+        it("accepts minimal valid payload (displayName only)", () => {
+            const result = validateProfile({ displayName: "Alice" });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.displayName).toBe("Alice");
+                expect(result.data.bio).toBe("");
+                expect(result.data.website).toBe("");
+                expect(result.data.timezone).toBe("UTC");
+            }
+        });
+
+        it("accepts all fields provided", () => {
+            const input = {
+                displayName: "Alice Johnson",
+                bio: "DeFi enthusiast",
+                website: "https://alice.example.com",
+                timezone: "America/New_York",
+            };
+            const result = validateProfile(input);
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.displayName).toBe("Alice Johnson");
+                expect(result.data.bio).toBe("DeFi enthusiast");
+                expect(result.data.website).toBe("https://alice.example.com");
+                expect(result.data.timezone).toBe("America/New_York");
+            }
+        });
+
+        it("trims whitespace from displayName and bio", () => {
+            const result = validateProfile({
+                displayName: "  Bob  ",
+                bio: "  Hello world  ",
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.displayName).toBe("Bob");
+                expect(result.data.bio).toBe("Hello world");
+            }
+        });
+
+        it("defaults bio to empty string when omitted", () => {
+            const result = validateProfile({ displayName: "Charlie" });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.bio).toBe("");
+            }
+        });
+
+        it("defaults website to empty string when omitted", () => {
+            const result = validateProfile({ displayName: "Charlie" });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.website).toBe("");
+            }
+        });
+
+        it("defaults timezone to UTC when omitted", () => {
+            const result = validateProfile({ displayName: "Charlie" });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.timezone).toBe("UTC");
+            }
+        });
+
+        it("accepts empty bio explicitly", () => {
+            const result = validateProfile({ displayName: "Diana", bio: "" });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.bio).toBe("");
+            }
+        });
+
+        it("accepts empty website explicitly", () => {
+            const result = validateProfile({
+                displayName: "Diana",
+                website: "",
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.website).toBe("");
+            }
+        });
+
+        it("accepts displayName at max length (80 chars)", () => {
+            const name = "A".repeat(80);
+            const result = validateProfile({ displayName: name });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.displayName).toBe(name);
+            }
+        });
+
+        it("accepts bio at max length (500 chars)", () => {
+            const bio = "B".repeat(500);
+            const result = validateProfile({ displayName: "Test", bio });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.bio).toBe(bio);
+            }
+        });
+
+        it("accepts website at max length (200 chars)", () => {
+            const path = "a".repeat(188);
+            const website = `https://${path}.com`;
+            const result = validateProfile({
+                displayName: "Test",
+                website,
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.website).toBe(website);
+            }
+        });
+
+        it("accepts timezone at max length (60 chars)", () => {
+            const tz = "A".repeat(60);
+            const result = validateProfile({
+                displayName: "Test",
+                timezone: tz,
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.timezone).toBe(tz);
+            }
+        });
+
+        it("accepts unicode display names", () => {
+            const result = validateProfile({
+                displayName: "José García 李华",
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.displayName).toBe("José García 李华");
+            }
+        });
+
+        it("strips control characters via sanitisation", () => {
+            const result = validateProfile({
+                displayName: "Alice\u0000Bob\u0001",
+                bio: "Hello\u0002World",
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.displayName).toBe("AliceBob");
+                expect(result.data.bio).toBe("HelloWorld");
+            }
+        });
+
+        it("normalises unicode to NFC form", () => {
+            const composed = "é"; // U+00E9 (NFC precomposed)
+            const decomposed = "e\u0301"; // U+0065 U+0301 (NFD decomposed)
+            const result = validateProfile({
+                displayName: decomposed,
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.displayName).toBe(composed);
+            }
+        });
+
+        it("silently excludes unknown keys (Zod strip mode)", () => {
+            const result = validateProfile({
+                displayName: "Eve",
+                extraField: "should be dropped",
+                anotherOne: 42,
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).not.toHaveProperty("extraField");
+                expect(result.data).not.toHaveProperty("anotherOne");
+                expect(Object.keys(result.data)).toEqual([
+                    "displayName",
+                    "bio",
+                    "website",
+                    "timezone",
+                ]);
+            }
+        });
+    });
+
+    describe("Invalid payloads", () => {
+        it("rejects missing displayName", () => {
+            const result = validateProfile({});
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.displayName).toBe(
+                    "Invalid input: expected string, received undefined",
+                );
+            }
+        });
+
+        it("rejects displayName that is only whitespace", () => {
+            const result = validateProfile({ displayName: "   " });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.displayName).toBe("Display name is required");
+            }
+        });
+
+        it("rejects displayName exceeding max length", () => {
+            const result = validateProfile({
+                displayName: "A".repeat(81),
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.displayName).toBe(
+                    "Display name must be 80 characters or fewer",
+                );
+            }
+        });
+
+        it("rejects bio exceeding max length", () => {
+            const result = validateProfile({
+                displayName: "Test",
+                bio: "B".repeat(501),
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.bio).toBe(
+                    "Bio must be 500 characters or fewer",
+                );
+            }
+        });
+
+        it("rejects invalid website URL", () => {
+            const result = validateProfile({
+                displayName: "Test",
+                website: "not-a-url",
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.website).toBe("Website must be a valid URL");
+            }
+        });
+
+        it("rejects website exceeding max length", () => {
+            const path = "a".repeat(196);
+            const website = `https://${path}.com`;
+            const result = validateProfile({
+                displayName: "Test",
+                website,
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.website).toBe(
+                    "Website URL must be 200 characters or fewer",
+                );
+            }
+        });
+
+        it("rejects timezone exceeding max length", () => {
+            const result = validateProfile({
+                displayName: "Test",
+                timezone: "A".repeat(61),
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.timezone).toBe(
+                    "Timezone must be 60 characters or fewer",
+                );
+            }
+        });
+
+        it("rejects non-string displayName", () => {
+            const result = validateProfile({ displayName: 123 });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.displayName).toBe(
+                    "Invalid input: expected string, received number",
+                );
+            }
+        });
+
+        it("rejects null input", () => {
+            const result = validateProfile(null);
+            expect(result.success).toBe(false);
+        });
+
+        it("rejects undefined input", () => {
+            const result = validateProfile(undefined);
+            expect(result.success).toBe(false);
+        });
+
+        it("rejects array input", () => {
+            const result = validateProfile([]);
+            expect(result.success).toBe(false);
+        });
+
+        it("reports first-path error key for each invalid field", () => {
+            const result = validateProfile({
+                displayName: "",
+                website: "bad",
+                bio: "B".repeat(501),
+                timezone: "A".repeat(61),
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.errors.displayName).toBe("Display name is required");
+                expect(result.errors.bio).toBe(
+                    "Bio must be 500 characters or fewer",
+                );
+                expect(result.errors.website).toBe(
+                    "Website must be a valid URL",
+                );
+                expect(result.errors.timezone).toBe(
+                    "Timezone must be 60 characters or fewer",
+                );
+            }
+        });
+
+        it("does not include unknown keys in error output", () => {
+            const result = validateProfile({
+                displayName: "",
+                unknownField: "whatever",
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(Object.keys(result.errors)).toEqual(["displayName"]);
+            }
+        });
+    });
+
+    describe("profileSchema (direct Zod schema)", () => {
+        it("accepts a valid object", () => {
+            const result = profileSchema.safeParse({
+                displayName: "Test User",
+                bio: "A short bio",
+                website: "https://example.com",
+                timezone: "America/Chicago",
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("strips unknown keys", () => {
+            const result = profileSchema.safeParse({
+                displayName: "Test",
+                unknownKey: "value",
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).not.toHaveProperty("unknownKey");
+            }
+        });
+    });
+});

--- a/lib/account/validation.ts
+++ b/lib/account/validation.ts
@@ -4,9 +4,9 @@ import { sanitiseRecord } from "@/lib/security/input-sanitizer";
 export const profileSchema = z.object({
     displayName: z
         .string()
+        .trim()
         .min(1, "Display name is required")
-        .max(80, "Display name must be 80 characters or fewer")
-        .trim(),
+        .max(80, "Display name must be 80 characters or fewer"),
 
     bio: z
         .string()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -92,15 +92,15 @@ export default defineConfig({
           name: "server-unit",
           environment: "node",
 
-          include: [
-            "types/enums.test.ts",
-            "app/api/markets/route.test.ts",
-            "app/api/transactions/route.test.ts",
-            "app/api/liquidations/route.test.ts",
-            "app/api/notifications/[id]/route.test.ts",
-            "__tests__/**/*.test.ts",
-            "lib/streams/**/*.test.ts",
-          ],
+            include: [
+                "types/enums.test.ts",
+                "app/api/markets/route.test.ts",
+                "app/api/transactions/route.test.ts",
+                "app/api/liquidations/route.test.ts",
+                "app/api/notifications/[id]/route.test.ts",
+                "__tests__/**/*.test.ts",
+                "lib/**/*.test.ts",
+            ],
         },
       },
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -595,44 +595,6 @@
   resolved "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz"
   integrity sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==
 
-"@emnapi/core@^1.4.3":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz"
-  integrity sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==
-  dependencies:
-    "@emnapi/wasi-threads" "1.2.2"
-    tslib "^2.4.0"
-
-"@emnapi/core@^1.7.1", "@emnapi/core@^1.8.1":
-  version "1.8.1"
-  dependencies:
-    "@emnapi/wasi-threads" "1.1.0"
-    tslib "^2.4.0"
-
-"@emnapi/runtime@^1.2.0", "@emnapi/runtime@^1.4.3":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz"
-  integrity sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/runtime@^1.7.1", "@emnapi/runtime@^1.8.1":
-  version "1.8.1"
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@^1.1.0", "@emnapi/wasi-threads@1.1.0":
-  version "1.1.0"
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz"
-  integrity sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==
-  dependencies:
-    tslib "^2.4.0"
-
 "@emotion/is-prop-valid@*", "@emotion/is-prop-valid@^0.8.2":
   version "0.8.8"
   resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz"
@@ -661,125 +623,20 @@
     "@esbuild-kit/core-utils" "^3.3.2"
     get-tsconfig "^4.7.0"
 
-"@esbuild/win32-x64@0.18.20":
+"@esbuild/darwin-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz"
-  integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz"
+  integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
 
-"@esbuild/win32-x64@0.19.12":
+"@esbuild/darwin-x64@0.19.12":
   version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz"
-  integrity sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz"
+  integrity sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==
 
-"@esbuild/linux-x64@0.27.7":
+"@esbuild/darwin-x64@0.27.7":
   version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz"
-  integrity sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==
-
-"@esbuild/netbsd-arm64@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz"
-  integrity sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==
-
-"@esbuild/netbsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz"
-  integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
-
-"@esbuild/netbsd-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz"
-  integrity sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==
-
-"@esbuild/netbsd-x64@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz"
-  integrity sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==
-
-"@esbuild/openbsd-arm64@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz"
-  integrity sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==
-
-"@esbuild/openbsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz"
-  integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
-
-"@esbuild/openbsd-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz"
-  integrity sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==
-
-"@esbuild/openbsd-x64@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz"
-  integrity sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==
-
-"@esbuild/openharmony-arm64@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz"
-  integrity sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==
-
-"@esbuild/sunos-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz"
-  integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
-
-"@esbuild/sunos-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz"
-  integrity sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==
-
-"@esbuild/sunos-x64@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz"
-  integrity sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==
-
-"@esbuild/win32-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz"
-  integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
-
-"@esbuild/win32-arm64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz"
-  integrity sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==
-
-"@esbuild/win32-arm64@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz"
-  integrity sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==
-
-"@esbuild/win32-ia32@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz"
-  integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
-
-"@esbuild/win32-ia32@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz"
-  integrity sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==
-
-"@esbuild/win32-ia32@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz"
-  integrity sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==
-
-"@esbuild/win32-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz"
-  integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
-
-"@esbuild/win32-x64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz"
-  integrity sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==
-
-"@esbuild/win32-x64@0.27.7":
-  version "0.27.7"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz"
-  integrity sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz"
+  integrity sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==
 
 "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
@@ -957,13 +814,6 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@img/sharp-darwin-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz"
-  integrity sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-arm64" "1.0.4"
-
 "@img/sharp-darwin-x64@0.33.5":
   version "0.33.5"
   resolved "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz"
@@ -971,104 +821,10 @@
   optionalDependencies:
     "@img/sharp-libvips-darwin-x64" "1.0.4"
 
-"@img/sharp-libvips-darwin-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz"
-  integrity sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==
-
 "@img/sharp-libvips-darwin-x64@1.0.4":
   version "1.0.4"
   resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz"
   integrity sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==
-
-"@img/sharp-libvips-linux-arm@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz"
-  integrity sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==
-
-"@img/sharp-libvips-linux-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz"
-  integrity sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==
-
-"@img/sharp-libvips-linux-s390x@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz"
-  integrity sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==
-
-"@img/sharp-libvips-linux-x64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz"
-  integrity sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==
-
-"@img/sharp-libvips-linuxmusl-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz"
-  integrity sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==
-
-"@img/sharp-libvips-linuxmusl-x64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz"
-  integrity sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==
-
-"@img/sharp-linux-arm@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz"
-  integrity sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm" "1.0.5"
-
-"@img/sharp-linux-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz"
-  integrity sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm64" "1.0.4"
-
-"@img/sharp-linux-s390x@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz"
-  integrity sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-s390x" "1.0.4"
-
-"@img/sharp-linux-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz"
-  integrity sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-x64" "1.0.4"
-
-"@img/sharp-linuxmusl-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz"
-  integrity sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-arm64" "1.0.4"
-
-"@img/sharp-linuxmusl-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz"
-  integrity sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-x64" "1.0.4"
-
-"@img/sharp-wasm32@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz"
-  integrity sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==
-  dependencies:
-    "@emnapi/runtime" "^1.2.0"
-
-"@img/sharp-win32-ia32@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz"
-  integrity sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==
-
-"@img/sharp-win32-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz"
-  integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
 
 "@inquirer/external-editor@^1.0.2":
   version "1.0.3"
@@ -1500,31 +1256,10 @@
     hey-listen "^1.0.8"
     tslib "^2.3.1"
 
-"@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4":
+"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4":
   version "3.0.4"
-  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz"
-  integrity sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==
-
-"@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz"
-  integrity sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==
-
-"@napi-rs/wasm-runtime@^0.2.11":
-  version "0.2.12"
-  resolved "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz"
-  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
-  dependencies:
-    "@emnapi/core" "^1.4.3"
-    "@emnapi/runtime" "^1.4.3"
-    "@tybys/wasm-util" "^0.10.0"
-
-"@napi-rs/wasm-runtime@^1.1.1":
-  version "1.1.1"
-  dependencies:
-    "@emnapi/core" "^1.7.1"
-    "@emnapi/runtime" "^1.7.1"
-    "@tybys/wasm-util" "^0.10.1"
+  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz"
+  integrity sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==
 
 "@neoconfetti/react@^1.0.0":
   version "1.0.0"
@@ -1548,30 +1283,10 @@
   dependencies:
     fast-glob "3.3.1"
 
-"@next/swc-darwin-arm64@15.2.5":
-  version "15.2.5"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.5.tgz"
-  integrity sha512-4OimvVlFTbgzPdA0kh8A1ih6FN9pQkL4nPXGqemEYgk+e7eQhsst/p35siNNqA49eQA6bvKZ1ASsDtu9gtXuog==
-
 "@next/swc-darwin-x64@15.2.5":
   version "15.2.5"
   resolved "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.5.tgz"
   integrity sha512-ohzRaE9YbGt1ctE0um+UGYIDkkOxHV44kEcHzLqQigoRLaiMtZzGrA11AJh2Lu0lv51XeiY1ZkUvkThjkVNBMA==
-
-"@next/swc-linux-arm64-gnu@15.2.5":
-  version "15.2.5"
-  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.5.tgz"
-  integrity sha512-FMSdxSUt5bVXqqOoZCc/Seg4LQep9w/fXTazr/EkpXW2Eu4IFI9FD7zBDlID8TJIybmvKk7mhd9s+2XWxz4flA==
-
-"@next/swc-linux-arm64-musl@15.2.5":
-  version "15.2.5"
-  resolved "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.5.tgz"
-  integrity sha512-4ZNKmuEiW5hRKkGp2HWwZ+JrvK4DQLgf8YDaqtZyn7NYdl0cHfatvlnLFSWUayx9yFAUagIgRGRk8pFxS8Qniw==
-
-"@next/swc-linux-x64-gnu@15.2.5":
-  version "15.2.5"
-  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.5.tgz"
-  integrity sha512-bE6lHQ9GXIf3gCDE53u2pTl99RPZW5V1GLHSRMJ5l/oB/MT+cohu9uwnCK7QUph2xIOu2a6+27kL0REa/kqwZw==
 
 "@noble/curves@^1.9.7":
   version "1.9.7"
@@ -1737,45 +1452,10 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-win32-x64-gnu@4.62.2":
+"@rollup/rollup-darwin-x64@4.62.2":
   version "4.62.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz"
-  integrity sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==
-
-"@rollup/rollup-win32-x64-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz"
-  integrity sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==
-
-"@rollup/rollup-openbsd-x64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz"
-  integrity sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==
-
-"@rollup/rollup-openharmony-arm64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz"
-  integrity sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==
-
-"@rollup/rollup-win32-arm64-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz"
-  integrity sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==
-
-"@rollup/rollup-win32-ia32-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz"
-  integrity sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==
-
-"@rollup/rollup-win32-x64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz"
-  integrity sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==
-
-"@rollup/rollup-win32-x64-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz"
-  integrity sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz"
+  integrity sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -1846,25 +1526,10 @@
     glob "^13.0.6"
     magic-string "~0.30.8"
 
-"@sentry/cli-win32-x64@2.58.6":
+"@sentry/cli-darwin@2.58.6":
   version "2.58.6"
-  resolved "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz"
-  integrity sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==
-
-"@sentry/cli-win32-arm64@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz"
-  integrity sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==
-
-"@sentry/cli-win32-i686@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz"
-  integrity sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==
-
-"@sentry/cli-win32-x64@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz"
-  integrity sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==
+  resolved "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz"
+  integrity sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==
 
 "@sentry/cli@^2.58.5":
   version "2.58.6"
@@ -2181,72 +1846,10 @@
     source-map-js "^1.2.1"
     tailwindcss "4.2.4"
 
-"@tailwindcss/oxide-android-arm64@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz"
-  integrity sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==
-
-"@tailwindcss/oxide-darwin-arm64@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz"
-  integrity sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==
-
 "@tailwindcss/oxide-darwin-x64@4.2.4":
   version "4.2.4"
   resolved "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz"
   integrity sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==
-
-"@tailwindcss/oxide-freebsd-x64@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz"
-  integrity sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==
-
-"@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz"
-  integrity sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==
-
-"@tailwindcss/oxide-linux-arm64-gnu@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz"
-  integrity sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==
-
-"@tailwindcss/oxide-linux-arm64-musl@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz"
-  integrity sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==
-
-"@tailwindcss/oxide-linux-x64-gnu@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz"
-  integrity sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==
-
-"@tailwindcss/oxide-linux-x64-musl@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz"
-  integrity sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==
-
-"@tailwindcss/oxide-wasm32-wasi@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz"
-  integrity sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==
-  dependencies:
-    "@emnapi/core" "^1.8.1"
-    "@emnapi/runtime" "^1.8.1"
-    "@emnapi/wasi-threads" "^1.1.0"
-    "@napi-rs/wasm-runtime" "^1.1.1"
-    "@tybys/wasm-util" "^0.10.1"
-    tslib "^2.8.1"
-
-"@tailwindcss/oxide-win32-arm64-msvc@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz"
-  integrity sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==
-
-"@tailwindcss/oxide-win32-x64-msvc@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz"
-  integrity sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==
 
 "@tailwindcss/oxide@4.2.4":
   version "4.2.4"
@@ -2326,18 +1929,6 @@
   version "14.6.1"
   resolved "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz"
   integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
-
-"@tybys/wasm-util@^0.10.0":
-  version "0.10.2"
-  resolved "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz"
-  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
-  dependencies:
-    tslib "^2.4.0"
-
-"@tybys/wasm-util@^0.10.1":
-  version "0.10.1"
-  dependencies:
-    tslib "^2.4.0"
 
 "@types/aria-query@^5.0.1":
   version "5.0.4"
@@ -2677,102 +2268,10 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz"
   integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
 
-"@unrs/resolver-binding-android-arm-eabi@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz"
-  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
-
-"@unrs/resolver-binding-android-arm64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz"
-  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
-
-"@unrs/resolver-binding-darwin-arm64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
-  integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
-
 "@unrs/resolver-binding-darwin-x64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz"
   integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
-
-"@unrs/resolver-binding-freebsd-x64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz"
-  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
-
-"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz"
-  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
-
-"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz"
-  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
-
-"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz"
-  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
-
-"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz"
-  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
-
-"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz"
-  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
-
-"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz"
-  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
-
-"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz"
-  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
-
-"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz"
-  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
-
-"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz"
-  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
-
-"@unrs/resolver-binding-linux-x64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz"
-  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
-
-"@unrs/resolver-binding-wasm32-wasi@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz"
-  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
-  dependencies:
-    "@napi-rs/wasm-runtime" "^0.2.11"
-
-"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz"
-  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
-
-"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz"
-  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
-
-"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz"
-  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 "@vitejs/plugin-react@^5.2.0":
   version "5.2.0"
@@ -6745,60 +6244,10 @@ liftoff@^5.0.1:
     rechoir "^0.8.0"
     resolve "^1.20.0"
 
-lightningcss-android-arm64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz"
-  integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
-
-lightningcss-darwin-arm64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz"
-  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
-
 lightningcss-darwin-x64@1.32.0:
   version "1.32.0"
   resolved "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz"
   integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
-
-lightningcss-freebsd-x64@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz"
-  integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
-
-lightningcss-linux-arm-gnueabihf@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz"
-  integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
-
-lightningcss-linux-arm64-gnu@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz"
-  integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
-
-lightningcss-linux-arm64-musl@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz"
-  integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
-
-lightningcss-linux-x64-gnu@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz"
-  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
-
-lightningcss-linux-x64-musl@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz"
-  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
-
-lightningcss-win32-arm64-msvc@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz"
-  integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
-
-lightningcss-win32-x64-msvc@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz"
-  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
 
 lightningcss@^1.21.0, lightningcss@1.32.0:
   version "1.32.0"
@@ -9464,7 +8913,7 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1, tslib@2.8.1:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.8.0, tslib@2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
Close #634 

## Summary

Adds a comprehensive unit test suite for `lib/account/validation.ts`, covering
valid payloads, boundary lengths, unicode/whitespace trimming, sanitisation,
rejection messages for every invalid field, and non-object inputs.

Also fixes a latent bug in the `displayName` schema where `.min(1)` was applied
before `.trim()`, allowing whitespace-only strings (e.g. `"   "`) to pass
validation. The pipeline order has been corrected to `.trim().min(1)`.

## Changes

| File | Change |
|------|--------|
| `lib/account/__tests__/validation.test.ts` | **New** — 31 Vitest tests |
| `lib/account/VALIDATION_TESTS.md` | **New** — test plan documentation |
| `lib/account/validation.ts` | **Fix** — reorder `displayName` schema: `.trim()` before `.min(1)` |
| `vitest.config.ts` | **Fix** — add `lib/**/*.test.ts` to `server-unit` include patterns so nested `__tests__/` files are discovered |

## Test coverage

validateProfile
  Valid payloads   (16 tests)
    ✓ minimal valid payload (displayName only)
    ✓ all fields provided
    ✓ whitespace trimming on displayName and bio
    ✓ default values for omitted optional fields
    ✓ empty bio/website explicitly
    ✓ max-length boundaries (80 / 500 / 200 / 60 chars)
    ✓ unicode display names
    ✓ control-character stripping via sanitiseRecord
    ✓ NFC normalisation
    ✓ unknown keys silently excluded
  Invalid payloads  (13 tests)
    ✓ missing displayName
    ✓ whitespace-only displayName
    ✓ exceeded max lengths (81 / 501 / 201 / 61 chars)
    ✓ invalid URL
    ✓ non-string type
    ✓ null / undefined / array input
    ✓ multiple simultaneous field errors
    ✓ unknown keys absent from error output
profileSchema (direct Zod)  (2 tests)
    ✓ valid object accepted
    ✓ unknown keys stripped

## Bug fix detail

**Before:** `z.string().min(1, …).max(80, …).trim()`

Zod applies `.trim()` as a post-validation transform, so `"   "` (length 3)
passed `.min(1)` and was only trimmed to `""` after validation completed —
no error was raised.

**After:** `z.string().trim().min(1, …).max(80, …)`

Trimming runs before the length check, so whitespace-only inputs correctly
produce `"Display name is required"`.

## Verification

```bash
npx vitest run --project server-unit lib/account/__tests__/validation.test.ts
# ✓ 31 passed (all deterministic, no flaky assertions)