### PR TITLE
feat: add CSV export button wired to transactions export

### DIFF
--- a/app/api/transactions/export/route.ts
+++ b/app/api/transactions/export/route.ts
@@ -6,19 +6,25 @@ import {
   serializeTransactionsToCSV,
 } from '@/lib/transactions';
 import type { TransactionFilters, TransactionStatus } from '@/lib/transactions';
+import { parseTransactionFilter } from '@/lib/transactions/filters';
 import { withRequestLogging } from '@/lib/api/handler';
 
 export const runtime = 'nodejs';
 
-const VALID_STATUSES = new Set<string>(['All', 'Completed', 'Processing', 'Failed']);
-
 function parseFilters(searchParams: URLSearchParams): TransactionFilters {
-  const status = searchParams.get('status') ?? 'All';
+  const parsed = parseTransactionFilter(searchParams);
+  if (!parsed.valid) {
+    return {};
+  }
+
+  const status = parsed.filter.status ?? (searchParams.get('status') ?? 'All');
+  const normalizedStatus = status && status !== 'All' ? (status as TransactionStatus) : 'All';
+
   return {
-    search:   searchParams.get('search')   ?? undefined,
-    status:   VALID_STATUSES.has(status) ? (status as TransactionStatus | 'All') : 'All',
-    dateFrom: searchParams.get('dateFrom') ?? undefined,
-    dateTo:   searchParams.get('dateTo')   ?? undefined,
+    search: searchParams.get('search') ?? undefined,
+    status: normalizedStatus,
+    dateFrom: parsed.filter.fromDate,
+    dateTo: parsed.filter.toDate,
   };
 }
 
@@ -30,7 +36,18 @@ async function handleExportTransactions(request: NextRequest) {
 
   const filters = parseFilters(request.nextUrl.searchParams);
   const all = await fetchTransactions();
-  const filtered = filterTransactions(all, filters);
+  let filtered = filterTransactions(all, filters);
+
+  const asset = request.nextUrl.searchParams.get('asset');
+  const type = request.nextUrl.searchParams.get('type');
+
+  if (asset) {
+    filtered = filtered.filter((transaction) => transaction.asset.toLowerCase() === asset.toLowerCase());
+  }
+
+  if (type) {
+    filtered = filtered.filter((transaction) => transaction.type.toLowerCase().includes(type.toLowerCase()));
+  }
 
   const csv = serializeTransactionsToCSV(filtered);
   const filename = `transactions-${new Date().toISOString().slice(0, 10)}.csv`;

--- a/app/dashboard/transactions/page.tsx
+++ b/app/dashboard/transactions/page.tsx
@@ -1,24 +1,27 @@
 "use client";
 
-import React, { useState } from "react";
-import dynamic from "next/dynamic";
+import React, { useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { DashboardLayout } from "@/components";
 import { Transactions } from "@/components/shared/common/Transaction";
-import { IconPlaceholder } from "@/components/shared/ui/icons/IconPlaceholder";
 import { PageHeader } from "@/components/shared/common";
 import TransactionFilters from "@/components/features/dashboard/components/TransactionFilters";
-import { TransactionsSummaryHeader } from "@/components/features/dashboard/components";
+import { TransactionExportButton, TransactionsSummaryHeader } from "@/components/features/dashboard/components";
 import { useTransactionSummary } from "@/hooks/useTransactionSummary";
-
-// Lazy load Bank icon to reduce initial bundle size
-const Bank = dynamic(() => import("@/components/shared/ui/icons/Bank").then(mod => ({ default: mod.Bank })), {
-  loading: () => <IconPlaceholder />,
-  ssr: true,
-});
 
 export default function TransactionsPage() {
   const [totalCount, setTotalCount] = useState(0);
   const { inflow, outflow, net, isLoading } = useTransactionSummary();
+  const searchParams = useSearchParams();
+
+  const filters = useMemo(() => ({
+    asset: searchParams.get("asset") ?? undefined,
+    type: searchParams.get("type") ?? undefined,
+    status: searchParams.get("status") ?? undefined,
+    search: searchParams.get("search") ?? undefined,
+    dateFrom: searchParams.get("fromDate") ?? undefined,
+    dateTo: searchParams.get("toDate") ?? undefined,
+  }), [searchParams]);
 
   return (
     <DashboardLayout>
@@ -26,12 +29,7 @@ export default function TransactionsPage() {
         <PageHeader
           title="Transactions"
           description="Review every lend, borrow, repay, and withdrawal tied to your account."
-          actions={
-            <button className="bg-[#15A350] hover:bg-[#0A3D1E] text-white border border-[#71B48D] rounded-lg flex items-center justify-center gap-2 py-3 px-6 font-semibold transition-colors">
-              <Bank />
-              <span>Export CSV</span>
-            </button>
-          }
+          actions={<TransactionExportButton filters={filters} />}
         />
       </div>
       <div className="px-6 md:px-12 mt-4">

--- a/components/features/dashboard/components/TransactionExportButton.test.tsx
+++ b/components/features/dashboard/components/TransactionExportButton.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "@/components/shared/common/Toast";
+import { TransactionExportButton } from "./TransactionExportButton";
+
+const fetchMock = vi.fn();
+const createObjectURLMock = vi.fn(() => "blob:test-export");
+const revokeObjectURLMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock.mockReset();
+  createObjectURLMock.mockClear();
+  revokeObjectURLMock.mockClear();
+  Object.defineProperty(global, "fetch", {
+    configurable: true,
+    writable: true,
+    value: fetchMock,
+  });
+  Object.defineProperty(window.URL, "createObjectURL", {
+    configurable: true,
+    writable: true,
+    value: createObjectURLMock,
+  });
+  Object.defineProperty(window.URL, "revokeObjectURL", {
+    configurable: true,
+    writable: true,
+    value: revokeObjectURLMock,
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function renderExportButton(filters: Record<string, string | undefined> = {}) {
+  return render(
+    <ToastProvider>
+      <TransactionExportButton filters={filters as any} />
+    </ToastProvider>,
+  );
+}
+
+describe("TransactionExportButton", () => {
+  it("serializes active filters into the export request and downloads the CSV", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "Content-Disposition": 'attachment; filename="transactions.csv"' }),
+      blob: vi.fn().mockResolvedValue(new Blob(["id,type\n1,test"], { type: "text/csv" })),
+    });
+
+    renderExportButton({
+      asset: "XLM",
+      type: "lend",
+      status: "Completed",
+      search: "hello",
+      dateFrom: "2025-01-01",
+      dateTo: "2025-02-01",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toContain("asset=XLM");
+    expect(url).toContain("type=lend");
+    expect(url).toContain("status=Completed");
+    expect(url).toContain("search=hello");
+    expect(url).toContain("fromDate=2025-01-01");
+    expect(url).toContain("toDate=2025-02-01");
+    expect(options).toEqual({ method: "GET" });
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still downloads an empty CSV export when the response body is empty", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      blob: vi.fn().mockResolvedValue(new Blob([], { type: "text/csv" })),
+    });
+
+    renderExportButton({});
+
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    await waitFor(() => {
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:test-export");
+  });
+
+  it("shows an error toast when the export request fails", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    renderExportButton({});
+
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Export failed")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/features/dashboard/components/TransactionExportButton.tsx
+++ b/components/features/dashboard/components/TransactionExportButton.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, { useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { useToast } from "@/components/shared/common/Toast";
+import { serializeTransactionFilters } from "@/lib/transactions/filters";
+import type { TransactionFilters } from "@/lib/transactions/types";
+
+interface TransactionExportButtonProps {
+  filters: TransactionFilters;
+  className?: string;
+}
+
+function buildExportUrl(filters: TransactionFilters): string {
+  const params = serializeTransactionFilters({
+    asset: filters.asset,
+    type: filters.type,
+    status: filters.status && filters.status !== "All" ? filters.status : undefined,
+    fromDate: filters.dateFrom,
+    toDate: filters.dateTo,
+  });
+
+  if (filters.search) params.set("search", filters.search);
+
+  const query = params.toString();
+  return query ? `/api/transactions/export?${query}` : "/api/transactions/export";
+}
+
+export function TransactionExportButton({ filters, className = "" }: TransactionExportButtonProps) {
+  const [isExporting, setIsExporting] = useState(false);
+  const { showToast } = useToast();
+
+  const handleExport = async () => {
+    if (isExporting) return;
+
+    setIsExporting(true);
+
+    try {
+      const response = await fetch(buildExportUrl(filters), { method: "GET" });
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => null);
+        showToast({
+          title: "Export failed",
+          description: errorPayload?.error ?? "Unable to prepare your CSV export.",
+          variant: "error",
+        });
+        return;
+      }
+
+      const blob = await response.blob();
+      const contentDisposition = response.headers.get("Content-Disposition") ?? "";
+      const filenameMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
+      const filename = filenameMatch?.[1] ?? "transactions.csv";
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+
+      showToast({
+        title: "Export ready",
+        description: "Your transaction history CSV has been downloaded.",
+        variant: "success",
+      });
+    } catch (error) {
+      showToast({
+        title: "Export failed",
+        description: error instanceof Error ? error.message : "Unable to prepare your CSV export.",
+        variant: "error",
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      disabled={isExporting}
+      aria-busy={isExporting}
+      className={`bg-[#15A350] hover:bg-[#0A3D1E] text-white border border-[#71B48D] rounded-lg flex items-center justify-center gap-2 py-3 px-6 font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-70 ${className}`}
+    >
+      {isExporting ? (
+        <>
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>Preparing…</span>
+        </>
+      ) : (
+        <>
+          <Download className="h-4 w-4" />
+          <span>Export CSV</span>
+        </>
+      )}
+    </button>
+  );
+}
+
+export default TransactionExportButton;

--- a/components/features/dashboard/components/index.ts
+++ b/components/features/dashboard/components/index.ts
@@ -6,3 +6,4 @@ export { default as PositionSummary } from './PositionSummary';
 export { default as NextPaymentDue } from './NextPaymentDue';
 export { default as TransactionDetail } from './TransactionDetail';
 export { default as TransactionReceipt } from './TransactionReceipt';
+export { default as TransactionExportButton } from './TransactionExportButton';

--- a/lib/transactions/filters.ts
+++ b/lib/transactions/filters.ts
@@ -9,13 +9,25 @@ export interface TransactionFilter {
 }
 
 const ALLOWED_TYPES   = new Set(['lend', 'borrow', 'repay', 'withdraw']);
-const ALLOWED_STATUSES = new Set(['completed', 'pending', 'failed']);
+const ALLOWED_STATUSES = new Set(['completed', 'processing', 'failed', 'all']);
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}Z)?$/;
 
 export interface FilterValidationResult {
   valid: boolean;
   filter: TransactionFilter;
   error?: string;
+}
+
+export function serializeTransactionFilters(filters: TransactionFilter): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (filters.type) params.set('type', filters.type);
+  if (filters.status) params.set('status', filters.status);
+  if (filters.asset) params.set('asset', filters.asset);
+  if (filters.fromDate) params.set('fromDate', filters.fromDate);
+  if (filters.toDate) params.set('toDate', filters.toDate);
+
+  return params;
 }
 
 /**
@@ -35,10 +47,20 @@ export function parseTransactionFilter(params: URLSearchParams): FilterValidatio
 
   const status = params.get('status');
   if (status) {
-    if (!ALLOWED_STATUSES.has(status)) {
+    const normalizedStatus = status.toLowerCase();
+    if (!ALLOWED_STATUSES.has(normalizedStatus)) {
       return { valid: false, filter, error: `Invalid status: ${status}` };
     }
-    filter.status = status as TransactionFilter['status'];
+
+    if (normalizedStatus === 'all') {
+      filter.status = 'All';
+    } else if (normalizedStatus === 'completed') {
+      filter.status = 'Completed';
+    } else if (normalizedStatus === 'processing') {
+      filter.status = 'Processing';
+    } else {
+      filter.status = 'Failed';
+    }
   }
 
   const asset = params.get('asset');


### PR DESCRIPTION
# Transactions CSV Export Summary

## Summary
Adds an Export CSV action to the transactions page so users can download filtered transaction history directly from the UI.

## Why
Users could generate a CSV from the export route, but there was no UI control on the transactions page to trigger the download. This change makes the export discoverable and uses the currently active filters.

## Changes
- Added an Export CSV button to the transactions page header
- Wired the button to the current transaction filter state for asset, type, status, search, and date range
- Added a loading/disabled state while the CSV is being prepared
- Added toast-based error handling for export failures
- Added regression tests for success, empty export, and error scenarios

## Files updated
- app/dashboard/transactions/page.tsx
- app/api/transactions/export/route.ts
- components/features/dashboard/components/TransactionExportButton.tsx
- components/features/dashboard/components/TransactionExportButton.test.tsx
- lib/transactions/filters.ts
- components/features/dashboard/components/index.ts

## Testing
Verified with:
- npx vitest run components/features/dashboard/components/TransactionExportButton.test.tsx --coverage.enabled false

Result: 3/3 tests passed.

closes #487 