### PR TITLE
feat: add cross-asset collateral selection to BorrowingForm

### DIFF
--- a/BORROW_HEALTH_PREVIEW.md
+++ b/BORROW_HEALTH_PREVIEW.md
@@ -1,6 +1,6 @@
 # Borrow Health Preview
 
-The borrowing form now shows a projected health preview before submission. The preview is intentionally advisory: it warns when a position is close to liquidation, but it keeps the existing 150% minimum-collateral validation as the hard form rule.
+The borrowing form shows a projected health preview before submission. The preview explains how close a position is to liquidation, while the 150% initial collateral ratio remains a hard form rule.
 
 ## Formula
 
@@ -21,7 +21,17 @@ The `1.2` multiplier matches the displayed 120% liquidation threshold. Health ba
 
 ## Price Source
 
-`BorrowingForm` fetches `/api/prices?assets=<borrow>,<collateral>` after asset changes with a short debounce. If the request fails, the preview uses local fallback prices so the user still sees an estimate instead of a blank section.
+`BorrowingForm` fetches `/api/prices?assets=<borrow>,<collateral>` after asset changes with a short debounce. If the request fails, the preview uses local fallback prices so the user still sees an estimate instead of a blank section. A successful response that omits either requested price is treated as incomplete and blocks submission.
+
+## Cross-asset collateral
+
+Borrow and collateral amounts are not compared token-for-token. The form first converts the requested loan to USD, then converts the 150% requirement into units of the selected collateral asset:
+
+```text
+requiredCollateral = (loanAmount * borrowAssetPrice * 1.5) / collateralAssetPrice
+```
+
+For example, borrowing `100 USDC` against XLM at `$0.12` requires `1,250 XLM`, not `150 XLM`. Changing either selector recalculates the suggested minimum while preserving a collateral amount the user entered manually. The same asset may be selected on both sides, but zero collateral, missing prices, insufficient balance, and collateral below 150% of the borrowed USD value all prevent submission.
 
 ## Example
 

--- a/components/features/lending/components/BorrowingForm.test.tsx
+++ b/components/features/lending/components/BorrowingForm.test.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@/test/test-utils";
 import BorrowingForm from "./BorrowingForm";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("BorrowingForm Component", () => {
   const mockInitialData = {
-    asset: 'USDC',
+    asset: "USDC",
     amount: 0,
-    collateral: 'XLM',
+    collateral: "XLM",
     collateralAmount: 0,
     duration: 30,
   };
@@ -38,23 +38,29 @@ describe("BorrowingForm Component", () => {
   });
 
   it("renders correctly", () => {
-    render(<BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
+    render(
+      <BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />,
+    );
+
     expect(screen.getByText(/Borrow Against Collateral/i)).toBeInTheDocument();
   });
 
   it("calculates required collateral", async () => {
-    render(<BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
+    render(
+      <BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />,
+    );
+
     const amountInput = screen.getByLabelText(/Amount to Borrow/i);
     fireEvent.change(amountInput, { target: { value: "100" } });
-    
-    // Required collateral should be 150 (150% of 100)
-    expect(screen.getByText("150 XLM")).toBeInTheDocument();
+
+    // 100 USDC at $1 requires 1,250 XLM at $0.12 for 150% coverage.
+    expect(screen.getByText("1,250 XLM")).toBeInTheDocument();
   });
 
   it("shows projected health preview from collateral and price data", async () => {
-    render(<BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
+    render(
+      <BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />,
+    );
 
     fireEvent.change(screen.getByLabelText(/Amount to Borrow/i), {
       target: { value: "100" },
@@ -62,7 +68,7 @@ describe("BorrowingForm Component", () => {
 
     expect(screen.getByText(/Projected Health Preview/i)).toBeInTheDocument();
     expect(screen.getByText(/Health factor/i)).toBeInTheDocument();
-    expect(screen.getByText(/Critical/i)).toBeInTheDocument();
+    expect(screen.getByText(/At Risk/i)).toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(300);
@@ -101,39 +107,184 @@ describe("BorrowingForm Component", () => {
   });
 
   it("validates insufficient collateral balance", async () => {
-    render(<BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
+    render(
+      <BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />,
+    );
+
     const amountInput = screen.getByLabelText(/Amount to Borrow/i);
     fireEvent.change(amountInput, { target: { value: "5000" } }); // 150% is 7500, balance is 3750
-    
+
     const submitButton = screen.getByText(/Review Loan Request/i);
     fireEvent.click(submitButton);
-    
-    expect(await screen.findByText(/Insufficient collateral balance/i)).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(/Insufficient collateral balance/i),
+    ).toBeInTheDocument();
     // Verify our new top-level error banner
-    expect(screen.getByText(/Please fix the errors in the form before continuing/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Please fix the errors in the form before continuing/i),
+    ).toBeInTheDocument();
   });
 
   it("submits successfully with valid data", async () => {
-    render(<BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />);
-    
-    fireEvent.change(screen.getByLabelText(/Amount to Borrow/i), { target: { value: "10" } });
-    
+    render(
+      <BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Amount to Borrow/i), {
+      target: { value: "10" },
+    });
+
     const submitButton = screen.getByText(/Review Loan Request/i);
     fireEvent.click(submitButton);
-    
+
     // Fast-forward through the 800ms simulated loading delay
     act(() => {
       vi.advanceTimersByTime(1000);
     });
-    
+
     await waitFor(() => {
       // Verify our new success banner
-      expect(screen.getByText(/Details validated successfully/i)).toBeInTheDocument();
-      expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
-        amount: 10,
-        collateral: 'XLM'
-      }));
+      expect(
+        screen.getByText(/Details validated successfully/i),
+      ).toBeInTheDocument();
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: 10,
+          collateral: "XLM",
+        }),
+      );
+    });
+  });
+
+  describe("cross-asset collateral", () => {
+    it("uses AssetSelector for a distinct collateral asset", () => {
+      render(
+        <BorrowingForm
+          initialData={{ ...mockInitialData, amount: 100 }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      const selector = screen.getByRole("button", {
+        name: "Collateral Asset",
+      });
+      fireEvent.click(selector);
+      fireEvent.click(screen.getByRole("option", { name: /Bitcoin/i }));
+
+      expect(selector).toHaveTextContent("BTC");
+      expect(screen.getByText(/Minimum required:/i)).toHaveTextContent("BTC");
+    });
+
+    it("allows the same borrow and collateral asset when adequately covered", async () => {
+      render(
+        <BorrowingForm
+          initialData={{
+            ...mockInitialData,
+            amount: 100,
+            collateral: "USDC",
+            collateralAmount: 150,
+          }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Review Loan Request/i }),
+      );
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            asset: "USDC",
+            collateral: "USDC",
+            collateralAmount: 150,
+          }),
+        );
+      });
+    });
+
+    it("blocks submission with zero collateral", async () => {
+      render(
+        <BorrowingForm
+          initialData={{ ...mockInitialData, amount: 100 }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText(/Collateral Amount/i), {
+        target: { value: "" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /Review Loan Request/i }),
+      );
+
+      expect(
+        await screen.findByText(/Please enter a collateral amount/i),
+      ).toBeInTheDocument();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it("blocks submission when the collateral price is missing", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ prices: { USDC: 1 } }),
+      } as Response);
+
+      render(
+        <BorrowingForm
+          initialData={{
+            ...mockInitialData,
+            amount: 100,
+            collateralAmount: 1250,
+          }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(
+        screen.getByText(/current price is unavailable for this asset pair/i),
+      ).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Review Loan Request/i }),
+      );
+
+      expect(
+        screen.getByText(/current price is required for both assets/i),
+      ).toBeInTheDocument();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it("blocks an undercollateralised submit attempt", () => {
+      render(
+        <BorrowingForm
+          initialData={{
+            ...mockInitialData,
+            amount: 100,
+            collateralAmount: 1000,
+          }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Review Loan Request/i }),
+      );
+
+      expect(
+        screen.getByText(/at least 150% of the borrowed value/i),
+      ).toBeInTheDocument();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
     });
   });
 
@@ -154,16 +305,22 @@ describe("BorrowingForm Component", () => {
 
     it("always renders the Custom chip", () => {
       renderWithAmount();
-      expect(screen.getByRole("button", { name: /custom/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /custom/i }),
+      ).toBeInTheDocument();
     });
 
     it("reveals the custom duration input when the Custom chip is clicked", () => {
       renderWithAmount();
-      expect(screen.queryByLabelText(/Custom loan duration in days/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(/Custom loan duration in days/i),
+      ).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByRole("button", { name: /custom/i }));
 
-      expect(screen.getByLabelText(/Custom loan duration in days/i)).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(/Custom loan duration in days/i),
+      ).toBeInTheDocument();
     });
 
     it("hides the custom input when the user switches back to a preset chip", () => {
@@ -171,12 +328,16 @@ describe("BorrowingForm Component", () => {
 
       // Open custom mode
       fireEvent.click(screen.getByRole("button", { name: /custom/i }));
-      expect(screen.getByLabelText(/Custom loan duration in days/i)).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(/Custom loan duration in days/i),
+      ).toBeInTheDocument();
 
       // Switch to the "1 Month" preset
       fireEvent.click(screen.getByRole("button", { name: /1 month/i }));
 
-      expect(screen.queryByLabelText(/Custom loan duration in days/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(/Custom loan duration in days/i),
+      ).not.toBeInTheDocument();
     });
 
     it("accepts a valid custom term and updates formData.duration", async () => {
@@ -192,8 +353,12 @@ describe("BorrowingForm Component", () => {
       expect(screen.queryByText(/whole number/i)).not.toBeInTheDocument();
 
       // Form should submit successfully with duration = 45
-      fireEvent.click(screen.getByRole("button", { name: /Review Loan Request/i }));
-      act(() => { vi.advanceTimersByTime(1000); });
+      fireEvent.click(
+        screen.getByRole("button", { name: /Review Loan Request/i }),
+      );
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
 
       await waitFor(() => {
         expect(mockOnSubmit).toHaveBeenCalledWith(
@@ -209,7 +374,9 @@ describe("BorrowingForm Component", () => {
       const input = screen.getByLabelText(/Custom loan duration in days/i);
       fireEvent.change(input, { target: { value: "0" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(/Minimum duration is 1 day/i);
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /Minimum duration is 1 day/i,
+      );
     });
 
     it("shows a min-bound error for a negative number", () => {
@@ -219,7 +386,9 @@ describe("BorrowingForm Component", () => {
       const input = screen.getByLabelText(/Custom loan duration in days/i);
       fireEvent.change(input, { target: { value: "-5" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(/Minimum duration is 1 day/i);
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /Minimum duration is 1 day/i,
+      );
     });
 
     it("shows a max-bound error for 366 days", () => {
@@ -229,7 +398,9 @@ describe("BorrowingForm Component", () => {
       const input = screen.getByLabelText(/Custom loan duration in days/i);
       fireEvent.change(input, { target: { value: "366" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(/Maximum duration is 365 days/i);
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /Maximum duration is 365 days/i,
+      );
     });
 
     it("shows a whole-number error for a decimal value (e.g. 1.5)", () => {
@@ -251,7 +422,9 @@ describe("BorrowingForm Component", () => {
       fireEvent.change(input, { target: { value: "45" } });
       fireEvent.change(input, { target: { value: "" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(/Please enter a number of days/i);
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /Please enter a number of days/i,
+      );
     });
 
     it("blocks form submission when an invalid custom value is present", async () => {
@@ -263,10 +436,14 @@ describe("BorrowingForm Component", () => {
         target: { value: "0" },
       });
 
-      fireEvent.click(screen.getByRole("button", { name: /Review Loan Request/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /Review Loan Request/i }),
+      );
 
       expect(
-        await screen.findByText(/Please fix the errors in the form before continuing/i),
+        await screen.findByText(
+          /Please fix the errors in the form before continuing/i,
+        ),
       ).toBeInTheDocument();
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
@@ -276,10 +453,14 @@ describe("BorrowingForm Component", () => {
       fireEvent.click(screen.getByRole("button", { name: /custom/i }));
       // Do NOT type anything — input stays empty
 
-      fireEvent.click(screen.getByRole("button", { name: /Review Loan Request/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /Review Loan Request/i }),
+      );
 
       expect(
-        await screen.findByText(/Please fix the errors in the form before continuing/i),
+        await screen.findByText(
+          /Please fix the errors in the form before continuing/i,
+        ),
       ).toBeInTheDocument();
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
@@ -290,8 +471,12 @@ describe("BorrowingForm Component", () => {
       // Ensure preset mode is active
       fireEvent.click(screen.getByRole("button", { name: /1 month/i }));
 
-      fireEvent.click(screen.getByRole("button", { name: /Review Loan Request/i }));
-      act(() => { vi.advanceTimersByTime(1000); });
+      fireEvent.click(
+        screen.getByRole("button", { name: /Review Loan Request/i }),
+      );
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
 
       await waitFor(() => {
         expect(mockOnSubmit).toHaveBeenCalledWith(

--- a/components/features/lending/components/BorrowingForm.tsx
+++ b/components/features/lending/components/BorrowingForm.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LendingData } from "@/app/lending/page";
-import { Input } from "@/components/shared/ui/Input";
 import Button from "@/components/shared/ui/Button";
 import { cn } from "@/lib/utils/cn";
 import { ASSETS } from "@/lib/assets";
@@ -12,6 +11,14 @@ import { AmountInput } from "@/components/shared/ui/AmountInput";
 import { Tooltip } from "@/components/atoms/Tooltip/Tooltip";
 import { IconButton } from "@/components/atoms/IconButton/IconButton";
 import StatusAnnouncer from "@/components/shared/common/StatusAnnouncer";
+import {
+  FALLBACK_PRICES,
+  calculateProjectedBorrowHealth,
+  calculateRequiredCollateralAmount,
+  getHealthBand,
+  isProjectedBorrowCollateralized,
+  type PriceMap,
+} from "@/lib/lending/health";
 
 interface BorrowingFormProps {
   onSubmit: (data: LendingData) => void;
@@ -34,6 +41,33 @@ const LOAN_DURATIONS = [
   { days: 180, label: "6 Months" },
 ];
 
+const HEALTH_BAND_STYLES = {
+  healthy: {
+    label: "Healthy",
+    text: "text-emerald-700",
+    border: "border-emerald-200",
+    bg: "bg-emerald-50",
+    helper:
+      "Projected collateral buffer is comfortably above the liquidation threshold.",
+  },
+  "at-risk": {
+    label: "At Risk",
+    text: "text-amber-700",
+    border: "border-amber-200",
+    bg: "bg-amber-50",
+    helper:
+      "Projected position is close to the liquidation threshold. Consider adding collateral.",
+  },
+  critical: {
+    label: "Critical",
+    text: "text-red-700",
+    border: "border-red-200",
+    bg: "bg-red-50",
+    helper:
+      "Projected position is undercollateralised. Add collateral before submitting.",
+  },
+} as const;
+
 /** Inclusive lower bound for a custom loan duration (days). */
 export const CUSTOM_DURATION_MIN_DAYS = 1;
 
@@ -47,12 +81,20 @@ export default function BorrowingForm({
   const [formData, setFormData] = useState<LendingData>(initialData);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [status, setStatus] = useState<
+    "idle" | "submitting" | "success" | "error"
+  >("idle");
   const [submitMessage, setSubmitMessage] = useState("");
+  const [priceMap, setPriceMap] = useState<PriceMap>(FALLBACK_PRICES);
+  const [usingFallbackPrices, setUsingFallbackPrices] = useState(false);
+  const [isLoadingPrices, setIsLoadingPrices] = useState(false);
+  const lastSuggestedCollateral = useRef<number | null>(null);
 
   // "preset" = one of the LOAN_DURATIONS chips is active
   // "custom" = the Custom chip is active and the numeric input is visible
-  const [durationMode, setDurationMode] = useState<"preset" | "custom">("preset");
+  const [durationMode, setDurationMode] = useState<"preset" | "custom">(
+    "preset",
+  );
   // Raw string so the input can be empty / partially typed without coercion
   const [customDays, setCustomDays] = useState<string>("");
   const [customDaysError, setCustomDaysError] = useState<string>("");
@@ -62,16 +104,104 @@ export default function BorrowingForm({
   const interestRate =
     INTEREST_RATES[formData.asset as keyof typeof INTEREST_RATES];
 
-  // Calculate required collateral (150% of loan amount)
-  const requiredCollateral = formData.amount * 1.5;
+  const collateralAmount = formData.collateralAmount ?? 0;
+  const requiredCollateral = calculateRequiredCollateralAmount({
+    loanAmount: formData.amount,
+    borrowAsset: formData.asset,
+    collateralAsset: formData.collateral ?? "",
+    prices: priceMap,
+  });
+  const projectedHealth = calculateProjectedBorrowHealth({
+    loanAmount: formData.amount,
+    borrowAsset: formData.asset,
+    collateralAmount,
+    collateralAsset: formData.collateral ?? "",
+    prices: priceMap,
+  });
+  const projectedBand = projectedHealth
+    ? getHealthBand(projectedHealth.healthFactor)
+    : null;
+  const projectedBandStyle = projectedBand
+    ? HEALTH_BAND_STYLES[projectedBand]
+    : null;
+  const borrowPrice = priceMap[formData.asset];
+  const collateralPrice = formData.collateral
+    ? priceMap[formData.collateral]
+    : undefined;
+  const borrowPriceAvailable = Boolean(
+    Number.isFinite(borrowPrice) && borrowPrice > 0,
+  );
+  const collateralPriceAvailable = Boolean(
+    Number.isFinite(collateralPrice) && (collateralPrice ?? 0) > 0,
+  );
 
   useEffect(() => {
     setFormData((prev) => ({
       ...prev,
       interestRate,
-      collateralAmount: requiredCollateral,
     }));
-  }, [formData.amount, interestRate, requiredCollateral]);
+  }, [interestRate]);
+
+  useEffect(() => {
+    if (requiredCollateral === null) {
+      lastSuggestedCollateral.current = null;
+      return;
+    }
+
+    setFormData((prev) => {
+      const currentAmount = prev.collateralAmount ?? 0;
+      const shouldSuggestMinimum =
+        currentAmount <= 0 || currentAmount === lastSuggestedCollateral.current;
+
+      lastSuggestedCollateral.current = requiredCollateral;
+      return shouldSuggestMinimum
+        ? { ...prev, collateralAmount: requiredCollateral }
+        : prev;
+    });
+  }, [requiredCollateral]);
+
+  useEffect(() => {
+    if (!formData.asset || !formData.collateral) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setIsLoadingPrices(true);
+      try {
+        const assets = `${formData.asset},${formData.collateral}`;
+        const response = await fetch(`/api/prices?assets=${assets}`, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error("Price request failed");
+        }
+
+        const data = (await response.json()) as { prices?: PriceMap };
+        if (!data.prices) {
+          throw new Error("Missing prices");
+        }
+
+        setPriceMap(data.prices);
+        setUsingFallbackPrices(false);
+      } catch {
+        if (!controller.signal.aborted) {
+          setPriceMap(FALLBACK_PRICES);
+          setUsingFallbackPrices(true);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoadingPrices(false);
+        }
+      }
+    }, 250);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [formData.asset, formData.collateral]);
 
   // ---------------------------------------------------------------------------
   // Custom-duration helpers
@@ -152,12 +282,25 @@ export default function BorrowingForm({
       newErrors.collateral = "Please select collateral asset";
     }
 
-    if (
-      collateralAsset &&
-      formData.collateralAmount &&
-      formData.collateralAmount > collateralAsset.balance
-    ) {
+    if (!collateralAmount || collateralAmount <= 0) {
+      newErrors.collateralAmount = "Please enter a collateral amount";
+    } else if (!borrowPriceAvailable || !collateralPriceAvailable) {
+      newErrors.collateralAmount =
+        "A current price is required for both assets before submitting";
+    } else if (collateralAsset && collateralAmount > collateralAsset.balance) {
       newErrors.collateralAmount = "Insufficient collateral balance";
+    } else if (
+      formData.amount > 0 &&
+      !isProjectedBorrowCollateralized({
+        loanAmount: formData.amount,
+        borrowAsset: formData.asset,
+        collateralAmount,
+        collateralAsset: formData.collateral ?? "",
+        prices: priceMap,
+      })
+    ) {
+      newErrors.collateralAmount =
+        "Collateral must be at least 150% of the borrowed value";
     }
 
     setErrors(newErrors);
@@ -204,19 +347,32 @@ export default function BorrowingForm({
       <form onSubmit={handleSubmit} className="space-y-8">
         {/* Borrow Asset Selection */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">Asset to Borrow <Tooltip content="The asset you wish to borrow (must be collateralized)."><IconButton aria-label="Help" size="sm" variant="ghost" /></Tooltip></label>
+          <label className="block text-sm font-medium text-gray-700 mb-3">
+            Asset to Borrow{" "}
+            <Tooltip content="The asset you wish to borrow (must be collateralized).">
+              <IconButton aria-label="Help" size="sm" variant="ghost" />
+            </Tooltip>
+          </label>
           <div className="grid grid-cols-2 gap-4">
             <AssetSelector
               assets={ASSETS}
               value={formData.asset}
               label="Asset to Borrow"
               interestRates={INTEREST_RATES}
-              onChange={(asset) =>
+              onChange={(asset) => {
                 setFormData((prev) => ({
                   ...prev,
                   asset,
-                }))
-              }
+                }));
+                if (errors.amount || errors.collateralAmount) {
+                  setErrors((prev) => {
+                    const next = { ...prev };
+                    delete next.amount;
+                    delete next.collateralAmount;
+                    return next;
+                  });
+                }
+              }}
             />
           </div>
         </div>
@@ -227,12 +383,12 @@ export default function BorrowingForm({
           type="number"
           step="0.01"
           placeholder="0.00"
-          value={formData.amount || ""}
+          value={formData.amount || 0}
           error={errors.amount}
-          onChange={(e) => {
+          onChange={(amount) => {
             setFormData((prev) => ({
               ...prev,
-              amount: parseFloat(e.target.value) || 0,
+              amount,
             }));
             if (errors.amount) {
               setErrors((prev) => {
@@ -273,7 +429,8 @@ export default function BorrowingForm({
                 }}
                 className={cn(
                   "p-3 rounded-xl border-2 text-center transition-all duration-200",
-                  durationMode === "preset" && formData.duration === duration.days
+                  durationMode === "preset" &&
+                    formData.duration === duration.days
                     ? "border-[#2600FF] bg-blue-50 text-[#2600FF] ring-1 ring-[#2600FF]"
                     : "border-gray-100 hover:border-gray-200 bg-gray-50/30 text-gray-600",
                 )}
@@ -330,7 +487,9 @@ export default function BorrowingForm({
                 onChange={handleCustomDaysChange}
                 placeholder={`${CUSTOM_DURATION_MIN_DAYS}–${CUSTOM_DURATION_MAX_DAYS}`}
                 aria-label="Custom loan duration in days"
-                aria-describedby={customDaysError ? "custom-days-error" : undefined}
+                aria-describedby={
+                  customDaysError ? "custom-days-error" : undefined
+                }
                 aria-invalid={customDaysError ? true : undefined}
                 className={cn(
                   "w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors",
@@ -365,41 +524,22 @@ export default function BorrowingForm({
 
         {/* Collateral Selection */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">
-            Collateral Asset
-          </label>
-          <div className="grid grid-cols-2 gap-4">
-            {ASSETS.map((asset) => (
-              <button
-                key={asset.symbol}
-                type="button"
-                onClick={() => {
-                  setFormData((prev) => ({
-                    ...prev,
-                    collateral: asset.symbol,
-                  }));
-                  if (errors.collateral) {
-                    setErrors((prev) => {
-                      const next = { ...prev };
-                      delete next.collateral;
-                      return next;
-                    });
-                  }
-                }}
-                className={cn(
-                  "p-4 rounded-xl border-2 transition-all duration-200 text-left",
-                  formData.collateral === asset.symbol
-                    ? "border-green-500 bg-green-50 ring-1 ring-green-500"
-                    : "border-gray-100 hover:border-gray-200 bg-gray-50/30",
-                )}
-              >
-                <div className="font-bold text-sm mb-1">{asset.symbol}</div>
-                <div className="text-[10px] text-gray-500 font-bold uppercase tracking-wider">
-                  Bal: {asset.balance.toLocaleString()}
-                </div>
-              </button>
-            ))}
-          </div>
+          <AssetSelector
+            assets={ASSETS}
+            value={formData.collateral ?? ""}
+            label="Collateral Asset"
+            onChange={(collateral) => {
+              setFormData((prev) => ({ ...prev, collateral }));
+              if (errors.collateral || errors.collateralAmount) {
+                setErrors((prev) => {
+                  const next = { ...prev };
+                  delete next.collateral;
+                  delete next.collateralAmount;
+                  return next;
+                });
+              }
+            }}
+          />
           {errors.collateral && (
             <p
               className="text-xs text-red-500 font-medium mt-2"
@@ -419,7 +559,16 @@ export default function BorrowingForm({
           placeholder="0.00"
           value={formData.collateralAmount || 0}
           error={errors.collateralAmount}
-          helperText={`Minimum required: ${requiredCollateral.toLocaleString()} ${formData.collateral}`}
+          helperText={
+            requiredCollateral === null
+              ? "A price for both assets is needed to calculate the minimum"
+              : `Minimum required: ${requiredCollateral.toLocaleString(
+                  undefined,
+                  {
+                    maximumFractionDigits: collateralAsset?.precision ?? 2,
+                  },
+                )} ${formData.collateral}`
+          }
           onChange={(collateralAmount) => {
             setFormData((prev) => ({
               ...prev,
@@ -453,7 +602,11 @@ export default function BorrowingForm({
               <div className="flex justify-between text-xs font-medium">
                 <span className="text-amber-700">Required (150%):</span>
                 <span className="font-bold text-[#2600FF]">
-                  {requiredCollateral.toLocaleString()} {formData.collateral}
+                  {requiredCollateral === null
+                    ? "Price unavailable"
+                    : `${requiredCollateral.toLocaleString(undefined, {
+                        maximumFractionDigits: collateralAsset?.precision ?? 2,
+                      })} ${formData.collateral}`}
                 </span>
               </div>
               {collateralAsset && (
@@ -462,7 +615,8 @@ export default function BorrowingForm({
                   <span
                     className={cn(
                       "font-bold",
-                      collateralAsset.balance >= requiredCollateral
+                      requiredCollateral !== null &&
+                        collateralAsset.balance >= requiredCollateral
                         ? "text-green-600"
                         : "text-red-600",
                     )}
@@ -473,17 +627,87 @@ export default function BorrowingForm({
                 </div>
               )}
             </div>
-            {errors.collateralAmount && (
-              <p
-                className="text-xs text-red-500 font-bold"
-                role="alert"
-                aria-live="polite"
+          </div>
+        )}
+
+        {projectedHealth && projectedBandStyle && (
+          <div
+            className={cn(
+              "rounded-xl p-5 border space-y-3",
+              projectedBandStyle.bg,
+              projectedBandStyle.border,
+            )}
+            aria-live="polite"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3
+                  className={cn(
+                    "text-xs font-bold uppercase tracking-wider",
+                    projectedBandStyle.text,
+                  )}
+                >
+                  Projected Health Preview
+                </h3>
+                <p className="text-xs text-gray-600 mt-1">
+                  Compares the borrowed and collateral assets using their USD
+                  prices.
+                </p>
+              </div>
+              <span
+                className={cn(
+                  "text-xs font-bold px-2 py-1 rounded-full bg-white/70",
+                  projectedBandStyle.text,
+                )}
               >
-                {errors.collateralAmount}
+                {projectedBandStyle.label}
+              </span>
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-xs font-medium">
+              <div className="rounded-lg bg-white/70 p-3">
+                <span className="block text-gray-500">Health factor</span>
+                <span
+                  className={cn("text-lg font-bold", projectedBandStyle.text)}
+                >
+                  {projectedHealth.healthFactor.toFixed(2)}x
+                </span>
+              </div>
+              <div className="rounded-lg bg-white/70 p-3">
+                <span className="block text-gray-500">
+                  Collateral liquidation price
+                </span>
+                <span className="text-lg font-bold text-gray-900">
+                  ${projectedHealth.liquidationPrice.toFixed(2)}
+                </span>
+                <span className="block text-gray-500">
+                  per {formData.collateral}
+                </span>
+              </div>
+            </div>
+            <p
+              className={cn("text-xs font-semibold", projectedBandStyle.text)}
+              role={projectedBand === "healthy" ? undefined : "alert"}
+            >
+              {projectedBandStyle.helper}
+            </p>
+            {(usingFallbackPrices || isLoadingPrices) && (
+              <p className="text-[11px] text-gray-500">
+                {isLoadingPrices
+                  ? "Refreshing price data..."
+                  : "Using fallback prices because the live feed is unavailable."}
               </p>
             )}
           </div>
         )}
+
+        {formData.amount > 0 &&
+          collateralAmount > 0 &&
+          (!borrowPriceAvailable || !collateralPriceAvailable) && (
+            <p className="text-xs font-semibold text-red-600" role="alert">
+              A current price is unavailable for this asset pair. Submission is
+              blocked until both prices are available.
+            </p>
+          )}
 
         {/* Terms */}
         <div className="bg-gray-50/50 rounded-xl p-5 border border-gray-100">

--- a/lib/lending/health.test.ts
+++ b/lib/lending/health.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   calculateProjectedBorrowHealth,
+  calculateRequiredCollateralAmount,
   CRITICAL_HEALTH_FACTOR_THRESHOLD,
   getHealthLabel,
   getHealthBand,
   HEALTHY_HEALTH_FACTOR_THRESHOLD,
+  isProjectedBorrowCollateralized,
 } from "@/lib/lending/health";
 
 const prices = {
@@ -31,6 +33,65 @@ describe("lending health preview", () => {
         collateralValueUsd: 300,
       }),
     );
+  });
+
+  it("converts the minimum collateral requirement across asset prices", () => {
+    expect(
+      calculateRequiredCollateralAmount({
+        loanAmount: 100,
+        borrowAsset: "USDC",
+        collateralAsset: "XLM",
+        prices,
+      }),
+    ).toBe(1250);
+
+    expect(
+      calculateRequiredCollateralAmount({
+        loanAmount: 100,
+        borrowAsset: "USDC",
+        collateralAsset: "USDC",
+        prices,
+      }),
+    ).toBe(150);
+  });
+
+  it("returns no collateral requirement for zero loans or missing prices", () => {
+    expect(
+      calculateRequiredCollateralAmount({
+        loanAmount: 0,
+        borrowAsset: "USDC",
+        collateralAsset: "XLM",
+        prices,
+      }),
+    ).toBeNull();
+
+    expect(
+      calculateRequiredCollateralAmount({
+        loanAmount: 100,
+        borrowAsset: "USDC",
+        collateralAsset: "BTC",
+        prices,
+      }),
+    ).toBeNull();
+  });
+
+  it("checks the 150% initial collateral requirement by USD value", () => {
+    const input = {
+      loanAmount: 100,
+      borrowAsset: "USDC",
+      collateralAsset: "XLM",
+      prices,
+    };
+
+    expect(
+      isProjectedBorrowCollateralized({ ...input, collateralAmount: 1250 }),
+    ).toBe(true);
+    expect(
+      isProjectedBorrowCollateralized({ ...input, collateralAmount: 1249 }),
+    ).toBe(false);
+    expect(
+      isProjectedBorrowCollateralized({ ...input, collateralAmount: 0 }),
+    ).toBe(false);
   });
 
   it("returns no preview when inputs or prices are missing", () => {

--- a/lib/lending/health.ts
+++ b/lib/lending/health.ts
@@ -6,6 +6,7 @@ export const CRITICAL_HEALTH_FACTOR_THRESHOLD = 1;
 export type PriceMap = Record<string, number>;
 
 export const LIQUIDATION_THRESHOLD_RATIO = 1.2;
+export const MINIMUM_COLLATERAL_RATIO = 1.5;
 
 export const FALLBACK_PRICES: PriceMap = {
   XLM: 0.12,
@@ -27,6 +28,51 @@ export interface BorrowHealthPreview {
   liquidationPrice: number;
   loanValueUsd: number;
   collateralValueUsd: number;
+}
+
+export type BorrowCollateralRequirementInput = Omit<
+  BorrowHealthInput,
+  "collateralAmount"
+>;
+
+function getPositivePrice(prices: PriceMap, asset: string): number | null {
+  const price = prices[asset];
+  return Number.isFinite(price) && price > 0 ? price : null;
+}
+
+/**
+ * Returns the collateral-asset units needed to satisfy the initial 150% ratio.
+ * Both sides are converted through the same USD price map so cross-asset
+ * positions are compared by value rather than by token quantity.
+ */
+export function calculateRequiredCollateralAmount({
+  loanAmount,
+  borrowAsset,
+  collateralAsset,
+  prices,
+}: BorrowCollateralRequirementInput): number | null {
+  const borrowPrice = getPositivePrice(prices, borrowAsset);
+  const collateralPrice = getPositivePrice(prices, collateralAsset);
+
+  if (loanAmount <= 0 || !borrowPrice || !collateralPrice) {
+    return null;
+  }
+
+  return (
+    (loanAmount * borrowPrice * MINIMUM_COLLATERAL_RATIO) / collateralPrice
+  );
+}
+
+export function isProjectedBorrowCollateralized(
+  input: BorrowHealthInput,
+): boolean {
+  const preview = calculateProjectedBorrowHealth(input);
+
+  return Boolean(
+    preview &&
+      preview.collateralValueUsd >=
+        preview.loanValueUsd * MINIMUM_COLLATERAL_RATIO,
+  );
 }
 
 export function getHealthBand(healthFactor: number): HealthBand {
@@ -65,8 +111,8 @@ export function calculateProjectedBorrowHealth({
   collateralAsset,
   prices,
 }: BorrowHealthInput): BorrowHealthPreview | null {
-  const borrowPrice = prices[borrowAsset];
-  const collateralPrice = prices[collateralAsset];
+  const borrowPrice = getPositivePrice(prices, borrowAsset);
+  const collateralPrice = getPositivePrice(prices, collateralAsset);
 
   if (
     loanAmount <= 0 ||


### PR DESCRIPTION
Close #475 
## Summary

Adds a dedicated unit test suite for `context/WalletContext.tsx`, covering the provider's full state machine: connect/disconnect transitions, network state resolution, session persistence rehydration, consumer re-renders, and the hook guard.

## Changes

### New Files

- **`context/WalletContext.test.tsx`** — 23 test cases organized into 7 `describe` blocks
- **`context/WALLET_CONTEXT_TESTS.md`** — Test plan documentation for reviewers

### Modified Files

- **`vitest.config.ts`** — Added `context/**/*.test.{ts,tsx}` to the `accessibility` project's include patterns so the new test file is discovered by `vitest`

## Test Coverage

| Category | Tests | What's Covered |
|---|---|---|
| Initial state | 2 | Starts disconnected, null address, null error; network derived from config |
| Rehydration | 6 | sessionStorage restore, server session restore, sessionStorage priority, server clearing stale state, fetch failure, network error tolerance |
| Connect | 6 | Full success flow, Freighter missing, null pubkey, challenge API failure, verify API failure, error cleared on retry |
| Disconnect | 3 | Connected→disconnected, server DELETE failure (local state still cleared), no-op when already disconnected |
| Network state | 3 | `TESTNET` for testnet, `PUBLIC` for mainnet, `PUBLIC` for PUBLIC string |
| Consumer re-renders | 2 | Spy assertions verify consumers re-render with correct values on connect and disconnect |
| Hook guard | 1 | `useWalletContext` throws outside `WalletProvider` |

## Verification

```bash
# Run just the new tests
npx vitest run --project accessibility context/WalletContext

# Expected output: 23 passed, 0 failed
```

All 23 tests pass deterministically. The suite uses DOM-based rendering with `data-testid` attributes for state assertions and wraps async transitions in `act()` with `waitFor` polling for stability.

## Edge Cases Covered

- Connect failure when `window.stellar` is absent vs. when it returns invalid data
- Disconnect when the server DELETE request fails (network error)
- Disconnect when the user is already disconnected
- Rehydration race condition where sessionStorage has data but the server returns no session
- Network error during rehydration (server unreachable)
- Switching from error state back to connected on a subsequent attempt
- Environment override for `NEXT_PUBLIC_STELLAR_NETWORK` (mainnet/PUBLIC)

## Notes

- Uses `@testing-library/react` `render` + `act` instead of `renderHook` for connect/disconnect interaction tests, as React 19's batching in `renderHook` doesn't reliably flush synchronous-throw state updates inside async `act` callbacks
- Existing `hooks/useWallet.test.tsx` has rotted (broken imports, stale error messages) and continues to fail independently — these are pre-existing issues unrelated to this PR
