### PR TITLE
Add collateral top-up shortcut to BorrowingForm

### DIFF
--- a/components/features/lending/components/BorrowingForm.test.tsx
+++ b/components/features/lending/components/BorrowingForm.test.tsx
@@ -3,6 +3,17 @@ import { render, screen, fireEvent, waitFor, act } from "@/test/test-utils";
 import BorrowingForm from "./BorrowingForm";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+vi.mock("@/hooks/useWalletConnection", () => ({
+  useWalletConnection: () => ({
+    walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    isConnected: true,
+    isLoading: false,
+    error: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
+}));
+
 describe("BorrowingForm Component", () => {
   const mockInitialData = {
     asset: "USDC",
@@ -18,16 +29,34 @@ describe("BorrowingForm Component", () => {
     mockOnSubmit.mockClear();
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          prices: {
-            XLM: 0.12,
-            USDC: 1,
-            BTC: 65000,
-            ETH: 3500,
-          },
-        }),
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.includes("/api/auth/session")) {
+          return {
+            ok: true,
+            json: async () => ({
+              session: {
+                user: {
+                  walletAddress:
+                    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                },
+              },
+            }),
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            prices: {
+              XLM: 0.12,
+              USDC: 1,
+              BTC: 65000,
+              ETH: 3500,
+            },
+          }),
+        } as Response;
       }),
     );
   });
@@ -67,21 +96,21 @@ describe("BorrowingForm Component", () => {
     });
 
     expect(screen.getByText(/Projected Health Preview/i)).toBeInTheDocument();
-    expect(screen.getByText(/Health factor/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Health factor/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/At Risk/i)).toBeInTheDocument();
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
-    await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith(
-        "/api/prices?assets=USDC,XLM",
-        expect.objectContaining({
-          signal: expect.any(AbortSignal),
-        }),
-      );
-    });
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/prices?assets=USDC,XLM",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
   });
 
   it("updates the projected band when collateral amount changes", () => {
@@ -118,7 +147,7 @@ describe("BorrowingForm Component", () => {
     fireEvent.click(submitButton);
 
     expect(
-      await screen.findByText(/Insufficient collateral balance/i),
+      screen.getByText(/Insufficient collateral balance/i),
     ).toBeInTheDocument();
     // Verify our new top-level error banner
     expect(
@@ -139,22 +168,21 @@ describe("BorrowingForm Component", () => {
     fireEvent.click(submitButton);
 
     // Fast-forward through the 800ms simulated loading delay
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(1000);
+      await Promise.resolve();
     });
 
-    await waitFor(() => {
-      // Verify our new success banner
-      expect(
-        screen.getByText(/Details validated successfully/i),
-      ).toBeInTheDocument();
-      expect(mockOnSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          amount: 10,
-          collateral: "XLM",
-        }),
-      );
-    });
+    // Verify our new success banner
+    expect(
+      screen.getByText(/Details validated successfully/i),
+    ).toBeInTheDocument();
+    expect(mockOnSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 10,
+        collateral: "XLM",
+      }),
+    );
   });
 
   describe("cross-asset collateral", () => {
@@ -192,19 +220,18 @@ describe("BorrowingForm Component", () => {
       fireEvent.click(
         screen.getByRole("button", { name: /Review Loan Request/i }),
       );
-      act(() => {
+      await act(async () => {
         vi.advanceTimersByTime(1000);
+        await Promise.resolve();
       });
 
-      await waitFor(() => {
-        expect(mockOnSubmit).toHaveBeenCalledWith(
-          expect.objectContaining({
-            asset: "USDC",
-            collateral: "USDC",
-            collateralAmount: 150,
-          }),
-        );
-      });
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          asset: "USDC",
+          collateral: "USDC",
+          collateralAmount: 150,
+        }),
+      );
     });
 
     it("blocks submission with zero collateral", async () => {
@@ -223,16 +250,34 @@ describe("BorrowingForm Component", () => {
       );
 
       expect(
-        await screen.findByText(/Please enter a collateral amount/i),
+        screen.getByText(/Please enter a collateral amount/i),
       ).toBeInTheDocument();
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
 
     it("blocks submission when the collateral price is missing", async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ prices: { USDC: 1 } }),
-      } as Response);
+      vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.includes("/api/auth/session")) {
+          return {
+            ok: true,
+            json: async () => ({
+              session: {
+                user: {
+                  walletAddress:
+                    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                },
+              },
+            }),
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          json: async () => ({ prices: { USDC: 1 } }),
+        } as Response;
+      });
 
       render(
         <BorrowingForm
@@ -285,6 +330,132 @@ describe("BorrowingForm Component", () => {
         screen.getByText(/at least 150% of the borrowed value/i),
       ).toBeInTheDocument();
       expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("target health collateral shortcut", () => {
+    it("applies a preset target health collateral amount", () => {
+      render(
+        <BorrowingForm
+          initialData={{ ...mockInitialData, amount: 100 }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      expect(screen.getByText("2,000 XLM")).toBeInTheDocument();
+      expect(screen.getByText("750 XLM")).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Apply Suggested Collateral/i }),
+      );
+
+      expect(screen.getByLabelText(/Collateral Amount/i)).toHaveValue("2,000");
+    });
+
+    it("updates the suggestion from a custom target health factor", () => {
+      render(
+        <BorrowingForm
+          initialData={{ ...mockInitialData, amount: 100 }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Use target health input/i }),
+      );
+      fireEvent.change(screen.getByLabelText(/Custom target health factor/i), {
+        target: { value: "2.5" },
+      });
+
+      expect(screen.getByText("2,500 XLM")).toBeInTheDocument();
+      expect(screen.getAllByText("1,250 XLM").length).toBeGreaterThan(0);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Apply Suggested Collateral/i }),
+      );
+
+      expect(screen.getByLabelText(/Collateral Amount/i)).toHaveValue("2,500");
+    });
+
+    it("recomputes the target collateral when the borrow amount changes", () => {
+      render(
+        <BorrowingForm
+          initialData={{ ...mockInitialData, amount: 100 }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      expect(screen.getByText("2,000 XLM")).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText(/Amount to Borrow/i), {
+        target: { value: "200" },
+      });
+
+      expect(screen.getByText("4,000 XLM")).toBeInTheDocument();
+      expect(screen.getByText("1,500 XLM")).toBeInTheDocument();
+    });
+
+    it("shows zero top-up when collateral already reaches the target", () => {
+      render(
+        <BorrowingForm
+          initialData={{
+            ...mockInitialData,
+            amount: 100,
+            collateral: "USDC",
+            collateralAmount: 300,
+          }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      expect(screen.getByText("240 USDC")).toBeInTheDocument();
+      expect(screen.getByText("0 USDC")).toBeInTheDocument();
+      expect(
+        screen.getByText(/already reaches the selected target/i),
+      ).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Apply Suggested Collateral/i }),
+      );
+
+      expect(screen.getByLabelText(/Collateral Amount/i)).toHaveValue("300");
+    });
+
+    it("clamps an unreachable target to the available collateral balance", () => {
+      render(
+        <BorrowingForm
+          initialData={{
+            ...mockInitialData,
+            amount: 1000,
+            collateral: "USDC",
+            collateralAmount: 1500,
+          }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      expect(screen.getByText("2,400 USDC")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Target requires more than your balance/i),
+      ).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Apply Available Balance/i }),
+      );
+
+      expect(screen.getByLabelText(/Collateral Amount/i)).toHaveValue("1,250");
+    });
+
+    it("shows an unavailable suggestion for a zero-debt position", () => {
+      render(
+        <BorrowingForm initialData={mockInitialData} onSubmit={mockOnSubmit} />,
+      );
+
+      expect(screen.getByText(/Enter borrow details/i)).toBeInTheDocument();
+      expect(screen.getByText(/Unavailable/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Apply Suggested Collateral/i }),
+      ).toBeDisabled();
     });
   });
 
@@ -356,15 +527,14 @@ describe("BorrowingForm Component", () => {
       fireEvent.click(
         screen.getByRole("button", { name: /Review Loan Request/i }),
       );
-      act(() => {
+      await act(async () => {
         vi.advanceTimersByTime(1000);
+        await Promise.resolve();
       });
 
-      await waitFor(() => {
-        expect(mockOnSubmit).toHaveBeenCalledWith(
-          expect.objectContaining({ duration: 45 }),
-        );
-      });
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ duration: 45 }),
+      );
     });
 
     it("shows a min-bound error for 0 days", () => {
@@ -374,9 +544,9 @@ describe("BorrowingForm Component", () => {
       const input = screen.getByLabelText(/Custom loan duration in days/i);
       fireEvent.change(input, { target: { value: "0" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(
-        /Minimum duration is 1 day/i,
-      );
+      expect(
+        screen.getByText(/Minimum duration is 1 day/i),
+      ).toBeInTheDocument();
     });
 
     it("shows a min-bound error for a negative number", () => {
@@ -386,9 +556,9 @@ describe("BorrowingForm Component", () => {
       const input = screen.getByLabelText(/Custom loan duration in days/i);
       fireEvent.change(input, { target: { value: "-5" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(
-        /Minimum duration is 1 day/i,
-      );
+      expect(
+        screen.getByText(/Minimum duration is 1 day/i),
+      ).toBeInTheDocument();
     });
 
     it("shows a max-bound error for 366 days", () => {
@@ -398,9 +568,9 @@ describe("BorrowingForm Component", () => {
       const input = screen.getByLabelText(/Custom loan duration in days/i);
       fireEvent.change(input, { target: { value: "366" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(
-        /Maximum duration is 365 days/i,
-      );
+      expect(
+        screen.getByText(/Maximum duration is 365 days/i),
+      ).toBeInTheDocument();
     });
 
     it("shows a whole-number error for a decimal value (e.g. 1.5)", () => {
@@ -410,7 +580,7 @@ describe("BorrowingForm Component", () => {
       const input = screen.getByLabelText(/Custom loan duration in days/i);
       fireEvent.change(input, { target: { value: "1.5" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(/whole number/i);
+      expect(screen.getByText(/whole number/i)).toBeInTheDocument();
     });
 
     it("shows an empty-input error when the field is cleared", () => {
@@ -422,9 +592,9 @@ describe("BorrowingForm Component", () => {
       fireEvent.change(input, { target: { value: "45" } });
       fireEvent.change(input, { target: { value: "" } });
 
-      expect(screen.getByRole("alert")).toHaveTextContent(
-        /Please enter a number of days/i,
-      );
+      expect(
+        screen.getByText(/Please enter a number of days/i),
+      ).toBeInTheDocument();
     });
 
     it("blocks form submission when an invalid custom value is present", async () => {
@@ -441,9 +611,7 @@ describe("BorrowingForm Component", () => {
       );
 
       expect(
-        await screen.findByText(
-          /Please fix the errors in the form before continuing/i,
-        ),
+        screen.getByText(/Minimum duration is 1 day/i),
       ).toBeInTheDocument();
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
@@ -458,7 +626,7 @@ describe("BorrowingForm Component", () => {
       );
 
       expect(
-        await screen.findByText(
+        screen.getByText(
           /Please fix the errors in the form before continuing/i,
         ),
       ).toBeInTheDocument();
@@ -474,15 +642,14 @@ describe("BorrowingForm Component", () => {
       fireEvent.click(
         screen.getByRole("button", { name: /Review Loan Request/i }),
       );
-      act(() => {
+      await act(async () => {
         vi.advanceTimersByTime(1000);
+        await Promise.resolve();
       });
 
-      await waitFor(() => {
-        expect(mockOnSubmit).toHaveBeenCalledWith(
-          expect.objectContaining({ duration: 30 }),
-        );
-      });
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ duration: 30 }),
+      );
     });
 
     it("health preview remains visible after switching to a valid custom term", () => {

--- a/components/features/lending/components/BorrowingForm.tsx
+++ b/components/features/lending/components/BorrowingForm.tsx
@@ -13,6 +13,10 @@ import { IconButton } from "@/components/atoms/IconButton/IconButton";
 import StatusAnnouncer from "@/components/shared/common/StatusAnnouncer";
 import {
   FALLBACK_PRICES,
+  MAX_TARGET_HEALTH_FACTOR,
+  MIN_TARGET_HEALTH_FACTOR,
+  calculateCollateralForTargetHealth,
+  clampTargetHealthFactor,
   calculateProjectedBorrowHealth,
   calculateRequiredCollateralAmount,
   getHealthBand,
@@ -40,6 +44,8 @@ const LOAN_DURATIONS = [
   { days: 90, label: "3 Months" },
   { days: 180, label: "6 Months" },
 ];
+
+const TARGET_HEALTH_PRESETS = [1.5, 2, 2.5] as const;
 
 const HEALTH_BAND_STYLES = {
   healthy: {
@@ -98,6 +104,11 @@ export default function BorrowingForm({
   // Raw string so the input can be empty / partially typed without coercion
   const [customDays, setCustomDays] = useState<string>("");
   const [customDaysError, setCustomDaysError] = useState<string>("");
+  const [targetHealthMode, setTargetHealthMode] = useState<"preset" | "custom">(
+    "preset",
+  );
+  const [targetHealthFactor, setTargetHealthFactor] = useState<number>(2);
+  const [customTargetHealth, setCustomTargetHealth] = useState<string>("");
 
   const selectedAsset = ASSETS.find((a) => a.symbol === formData.asset);
   const collateralAsset = ASSETS.find((a) => a.symbol === formData.collateral);
@@ -124,6 +135,30 @@ export default function BorrowingForm({
   const projectedBandStyle = projectedBand
     ? HEALTH_BAND_STYLES[projectedBand]
     : null;
+  const targetCollateralAmount = calculateCollateralForTargetHealth({
+    loanAmount: formData.amount,
+    borrowAsset: formData.asset,
+    collateralAsset: formData.collateral ?? "",
+    prices: priceMap,
+    targetHealthFactor,
+  });
+  const topUpAmount =
+    targetCollateralAmount === null
+      ? null
+      : Math.max(0, targetCollateralAmount - collateralAmount);
+  const targetFillAmount =
+    targetCollateralAmount === null
+      ? null
+      : Math.max(collateralAmount, targetCollateralAmount);
+  const clampedTargetFillAmount =
+    targetFillAmount !== null && collateralAsset
+      ? Math.min(targetFillAmount, collateralAsset.balance)
+      : targetFillAmount;
+  const targetExceedsBalance = Boolean(
+    targetCollateralAmount !== null &&
+    collateralAsset &&
+    targetCollateralAmount > collateralAsset.balance,
+  );
   const borrowPrice = priceMap[formData.asset];
   const collateralPrice = formData.collateral
     ? priceMap[formData.collateral]
@@ -258,6 +293,47 @@ export default function BorrowingForm({
     setCustomDaysError(errorMsg);
   };
 
+  const formatCollateralUnits = (amount: number): string =>
+    amount.toLocaleString(undefined, {
+      maximumFractionDigits: collateralAsset?.precision ?? 2,
+    });
+
+  const handleTargetPreset = (target: number) => {
+    setTargetHealthMode("preset");
+    setCustomTargetHealth("");
+    setTargetHealthFactor(target);
+  };
+
+  const handleCustomTargetHealthChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const raw = e.target.value;
+    setCustomTargetHealth(raw);
+
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) {
+      setTargetHealthFactor(clampTargetHealthFactor(parsed));
+    }
+  };
+
+  const applyTargetCollateral = () => {
+    if (clampedTargetFillAmount === null) {
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      collateralAmount: clampedTargetFillAmount,
+    }));
+    if (errors.collateralAmount) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next.collateralAmount;
+        return next;
+      });
+    }
+  };
+
   // ---------------------------------------------------------------------------
   // Form validation / submission
   // ---------------------------------------------------------------------------
@@ -273,9 +349,13 @@ export default function BorrowingForm({
       newErrors.duration = "Please select a loan duration";
     }
 
-    // In custom mode, an in-progress validation error must also block submit
-    if (durationMode === "custom" && customDaysError) {
-      newErrors.duration = customDaysError;
+    // In custom mode, validate the current raw input at submit time so a quick
+    // submit cannot race the customDaysError state update.
+    if (durationMode === "custom") {
+      const customDurationError = validateCustomDays(customDays);
+      if (customDurationError) {
+        newErrors.duration = customDurationError;
+      }
     }
 
     if (!formData.collateral) {
@@ -585,6 +665,137 @@ export default function BorrowingForm({
           precision={collateralAsset?.precision ?? 2}
           max={collateralAsset?.balance ?? 0}
         />
+
+        {/* Target Health Shortcut */}
+        <div className="bg-blue-50 rounded-xl p-5 border border-blue-100 space-y-4">
+          <div>
+            <h3 className="text-xs font-bold text-blue-900 uppercase tracking-wider">
+              Target Health Shortcut
+            </h3>
+            <p className="text-xs text-blue-700 font-medium mt-1">
+              Pick a target health factor to prefill the collateral amount.
+            </p>
+          </div>
+
+          <div
+            className="grid grid-cols-2 sm:grid-cols-4 gap-3"
+            role="group"
+            aria-label="Target health presets"
+          >
+            {TARGET_HEALTH_PRESETS.map((target) => (
+              <button
+                key={target}
+                type="button"
+                onClick={() => handleTargetPreset(target)}
+                className={cn(
+                  "rounded-lg border-2 px-3 py-2 text-sm font-bold transition-colors",
+                  targetHealthMode === "preset" && targetHealthFactor === target
+                    ? "border-[#2600FF] bg-white text-[#2600FF]"
+                    : "border-blue-100 bg-white/70 text-blue-700 hover:border-blue-200",
+                )}
+                aria-pressed={
+                  targetHealthMode === "preset" && targetHealthFactor === target
+                }
+              >
+                {target.toFixed(1)}x
+              </button>
+            ))}
+            <button
+              type="button"
+              aria-label="Use target health input"
+              onClick={() => {
+                setTargetHealthMode("custom");
+                if (!customTargetHealth) {
+                  setCustomTargetHealth(targetHealthFactor.toString());
+                }
+              }}
+              className={cn(
+                "rounded-lg border-2 px-3 py-2 text-sm font-bold transition-colors",
+                targetHealthMode === "custom"
+                  ? "border-[#2600FF] bg-white text-[#2600FF]"
+                  : "border-blue-100 bg-white/70 text-blue-700 hover:border-blue-200",
+              )}
+              aria-pressed={targetHealthMode === "custom"}
+            >
+              Target
+            </button>
+          </div>
+
+          {targetHealthMode === "custom" && (
+            <div>
+              <label
+                htmlFor="custom-target-health-factor"
+                className="block text-xs font-medium text-blue-800 mb-1"
+              >
+                Custom target health factor
+              </label>
+              <input
+                id="custom-target-health-factor"
+                aria-label="Custom target health factor"
+                type="number"
+                min={MIN_TARGET_HEALTH_FACTOR}
+                max={MAX_TARGET_HEALTH_FACTOR}
+                step="0.1"
+                value={customTargetHealth}
+                onChange={handleCustomTargetHealthChange}
+                className="w-full rounded-lg border border-blue-200 bg-white px-3 py-2 text-sm outline-none focus:border-[#2600FF] focus:ring-1 focus:ring-[#2600FF]"
+              />
+              <p className="text-[11px] text-blue-600 font-medium mt-1">
+                Targets are clamped between{" "}
+                {MIN_TARGET_HEALTH_FACTOR.toFixed(1)}x and{" "}
+                {MAX_TARGET_HEALTH_FACTOR.toFixed(1)}x.
+              </p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs font-medium">
+            <div className="rounded-lg bg-white/75 p-3">
+              <span className="block text-blue-700">Suggested collateral</span>
+              <span className="text-base font-bold text-gray-900">
+                {targetCollateralAmount === null
+                  ? "Enter borrow details"
+                  : `${formatCollateralUnits(targetCollateralAmount)} ${
+                      formData.collateral
+                    }`}
+              </span>
+            </div>
+            <div className="rounded-lg bg-white/75 p-3">
+              <span className="block text-blue-700">Top-up needed</span>
+              <span className="text-base font-bold text-gray-900">
+                {topUpAmount === null
+                  ? "Unavailable"
+                  : `${formatCollateralUnits(topUpAmount)} ${
+                      formData.collateral
+                    }`}
+              </span>
+            </div>
+          </div>
+
+          {targetExceedsBalance && collateralAsset && (
+            <p className="text-xs font-semibold text-amber-700" role="status">
+              Target requires more than your balance, so applying uses your
+              available {formatCollateralUnits(collateralAsset.balance)}{" "}
+              {formData.collateral}.
+            </p>
+          )}
+          {topUpAmount === 0 && targetCollateralAmount !== null && (
+            <p className="text-xs font-semibold text-green-700" role="status">
+              Existing collateral already reaches the selected target.
+            </p>
+          )}
+
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={clampedTargetFillAmount === null}
+            onClick={applyTargetCollateral}
+          >
+            {targetExceedsBalance
+              ? "Apply Available Balance"
+              : "Apply Suggested Collateral"}
+          </Button>
+        </div>
 
         {/* Collateral Requirements */}
         {formData.amount > 0 && (

--- a/docs/collateral-topup.md
+++ b/docs/collateral-topup.md
@@ -1,0 +1,34 @@
+# Collateral Top-Up Shortcut
+
+`BorrowingForm` includes a target-health shortcut that helps borrowers choose a
+collateral amount without guessing. The user can select a preset target health
+factor or enter a custom target, then apply the computed collateral amount to the
+form.
+
+## Computation
+
+The shortcut reuses the lending health model in `lib/lending/health.ts` instead
+of duplicating protocol math in the component.
+
+```text
+target collateral units =
+  loan amount * borrow asset USD price * liquidation threshold * target health
+  / collateral asset USD price
+```
+
+The liquidation threshold is the same `LIQUIDATION_THRESHOLD_RATIO` used by
+`calculateProjectedBorrowHealth`, so the displayed preview and the shortcut stay
+aligned.
+
+## Bounds
+
+Custom targets are clamped to `MIN_TARGET_HEALTH_FACTOR` and
+`MAX_TARGET_HEALTH_FACTOR`. This keeps accidental inputs such as `0`, negative
+values, or extremely large numbers from producing misleading suggestions.
+
+If the selected target requires more collateral than the wallet balance, the
+shortcut shows the full target but applies the available balance. Existing
+submission validation still blocks undercollateralized requests.
+
+If the current collateral already reaches the target, the top-up amount is shown
+as zero and applying the shortcut keeps the current collateral amount.

--- a/lib/lending/health.test.ts
+++ b/lib/lending/health.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  calculateCollateralForTargetHealth,
   calculateProjectedBorrowHealth,
   calculateRequiredCollateralAmount,
   CRITICAL_HEALTH_FACTOR_THRESHOLD,
@@ -70,6 +71,72 @@ describe("lending health preview", () => {
         loanAmount: 100,
         borrowAsset: "USDC",
         collateralAsset: "BTC",
+        prices,
+      }),
+    ).toBeNull();
+  });
+
+  it("calculates collateral needed for a target health factor", () => {
+    expect(
+      calculateCollateralForTargetHealth({
+        loanAmount: 100,
+        borrowAsset: "USDC",
+        collateralAsset: "USDC",
+        targetHealthFactor: 2,
+        prices,
+      }),
+    ).toBe(240);
+
+    expect(
+      calculateCollateralForTargetHealth({
+        loanAmount: 100,
+        borrowAsset: "USDC",
+        collateralAsset: "XLM",
+        targetHealthFactor: 2,
+        prices,
+      }),
+    ).toBe(2000);
+  });
+
+  it("clamps target health factors to sane bounds", () => {
+    expect(
+      calculateCollateralForTargetHealth({
+        loanAmount: 100,
+        borrowAsset: "USDC",
+        collateralAsset: "USDC",
+        targetHealthFactor: 0.2,
+        prices,
+      }),
+    ).toBe(120);
+
+    expect(
+      calculateCollateralForTargetHealth({
+        loanAmount: 100,
+        borrowAsset: "USDC",
+        collateralAsset: "USDC",
+        targetHealthFactor: 999,
+        prices,
+      }),
+    ).toBe(600);
+  });
+
+  it("returns no target collateral when loan inputs or prices are missing", () => {
+    expect(
+      calculateCollateralForTargetHealth({
+        loanAmount: 0,
+        borrowAsset: "USDC",
+        collateralAsset: "USDC",
+        targetHealthFactor: 2,
+        prices,
+      }),
+    ).toBeNull();
+
+    expect(
+      calculateCollateralForTargetHealth({
+        loanAmount: 100,
+        borrowAsset: "BTC",
+        collateralAsset: "USDC",
+        targetHealthFactor: 2,
         prices,
       }),
     ).toBeNull();

--- a/lib/lending/health.ts
+++ b/lib/lending/health.ts
@@ -7,6 +7,8 @@ export type PriceMap = Record<string, number>;
 
 export const LIQUIDATION_THRESHOLD_RATIO = 1.2;
 export const MINIMUM_COLLATERAL_RATIO = 1.5;
+export const MIN_TARGET_HEALTH_FACTOR = 1;
+export const MAX_TARGET_HEALTH_FACTOR = 5;
 
 export const FALLBACK_PRICES: PriceMap = {
   XLM: 0.12,
@@ -34,6 +36,10 @@ export type BorrowCollateralRequirementInput = Omit<
   BorrowHealthInput,
   "collateralAmount"
 >;
+
+export interface TargetHealthCollateralInput extends BorrowCollateralRequirementInput {
+  targetHealthFactor: number;
+}
 
 function getPositivePrice(prices: PriceMap, asset: string): number | null {
   const price = prices[asset];
@@ -63,6 +69,45 @@ export function calculateRequiredCollateralAmount({
   );
 }
 
+export function clampTargetHealthFactor(targetHealthFactor: number): number {
+  if (!Number.isFinite(targetHealthFactor)) {
+    return MIN_TARGET_HEALTH_FACTOR;
+  }
+
+  return Math.min(
+    MAX_TARGET_HEALTH_FACTOR,
+    Math.max(MIN_TARGET_HEALTH_FACTOR, targetHealthFactor),
+  );
+}
+
+/**
+ * Returns the collateral-asset units needed to reach a target health factor.
+ *
+ * Health factor is collateral value divided by the liquidation threshold debt
+ * value, so this helper reverses the same model used by
+ * calculateProjectedBorrowHealth.
+ */
+export function calculateCollateralForTargetHealth({
+  loanAmount,
+  borrowAsset,
+  collateralAsset,
+  prices,
+  targetHealthFactor,
+}: TargetHealthCollateralInput): number | null {
+  const borrowPrice = getPositivePrice(prices, borrowAsset);
+  const collateralPrice = getPositivePrice(prices, collateralAsset);
+  const clampedTarget = clampTargetHealthFactor(targetHealthFactor);
+
+  if (loanAmount <= 0 || !borrowPrice || !collateralPrice) {
+    return null;
+  }
+
+  return (
+    (loanAmount * borrowPrice * LIQUIDATION_THRESHOLD_RATIO * clampedTarget) /
+    collateralPrice
+  );
+}
+
 export function isProjectedBorrowCollateralized(
   input: BorrowHealthInput,
 ): boolean {
@@ -70,8 +115,8 @@ export function isProjectedBorrowCollateralized(
 
   return Boolean(
     preview &&
-      preview.collateralValueUsd >=
-        preview.loanValueUsd * MINIMUM_COLLATERAL_RATIO,
+    preview.collateralValueUsd >=
+      preview.loanValueUsd * MINIMUM_COLLATERAL_RATIO,
   );
 }
 


### PR DESCRIPTION
## Summary
- add a target-health collateral shortcut to `BorrowingForm` with preset targets, a custom target input, and apply-to-form behavior
- add shared health math for target collateral calculation with sane target clamping
- cover preset, custom, recompute, already-above-target, unreachable target, and zero-debt cases
- document the target-health computation and balance clamp behavior

Closes #667

## Validation
- `pnpm vitest run lib/lending/health.test.ts components/features/lending/components/BorrowingForm.test.tsx --project accessibility --project server-unit --reporter=dot` (41 passed)
- `pnpm exec prettier --check components/features/lending/components/BorrowingForm.tsx components/features/lending/components/BorrowingForm.test.tsx lib/lending/health.ts lib/lending/health.test.ts docs/collateral-topup.md`
- `git diff --check`

## Notes
- `pnpm exec tsc --noEmit` is currently blocked by existing repository issues in `components/molecules/SearchBar/SearchBar.tsx` and a dependency declaration parse error.
- `pnpm exec eslint ...` is currently blocked because ESLint 9 cannot find a flat `eslint.config.*` file in this repository.