### PR TITLE
Add sortable and filterable MarketsTable toolbar

### DIFF
--- a/components/features/lending/components/MarketsTable.test.tsx
+++ b/components/features/lending/components/MarketsTable.test.tsx
@@ -1,5 +1,12 @@
 import React from "react";
-import { render, screen, waitFor, within, fireEvent } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  within,
+  fireEvent,
+} from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MarketsTable } from "./MarketsTable";
 import type { MarketsResponse } from "@/lib/markets/types";
@@ -68,6 +75,28 @@ function mockFetchError(message = "Network error") {
   return vi.mocked(fetch).mockRejectedValueOnce(new Error(message));
 }
 
+function getDesktopMarketRows() {
+  const table = screen.getByRole("table");
+  return within(table).getAllByRole("row").slice(1);
+}
+
+function getRowAssetNames() {
+  return getDesktopMarketRows().map(
+    (row) =>
+      within(row).getAllByText(/Stellar Lumens|USD Coin|Bitcoin|Ethereum/)[0]
+        .textContent,
+  );
+}
+
+async function typeFilter(query: string) {
+  fireEvent.change(screen.getByLabelText("Filter markets by asset"), {
+    target: { value: query },
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 275));
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -112,7 +141,7 @@ describe("MarketsTable", () => {
       expect(errorContainer).toBeInTheDocument();
       expect(screen.getByText("Unable to load markets")).toBeInTheDocument();
       expect(
-        screen.getByText(/Failed to fetch market data/)
+        screen.getByText(/Failed to fetch market data/),
       ).toBeInTheDocument();
     });
 
@@ -144,7 +173,7 @@ describe("MarketsTable", () => {
       expect(emptyContainer).toBeInTheDocument();
       expect(screen.getByText("No markets available")).toBeInTheDocument();
       expect(
-        screen.getByText(/no supported assets to display/)
+        screen.getByText(/no supported assets to display/),
       ).toBeInTheDocument();
     });
   });
@@ -212,12 +241,13 @@ describe("MarketsTable", () => {
       render(<MarketsTable />);
       await screen.findByTestId("markets-table");
 
-      // Query within the desktop table only to avoid duplicates from mobile cards
-      const table = document.querySelector("table");
-      const rows = table ? within(table).getAllByText(/Stellar Lumens|USD Coin|Bitcoin|Ethereum/) : screen.getAllByText(/Stellar Lumens|USD Coin|Bitcoin|Ethereum/);
       // Default sort is ascending by asset: BTC, ETH, USDC, XLM
-      expect(rows[0]).toHaveTextContent("Bitcoin");
-      expect(rows[3]).toHaveTextContent("Stellar Lumens");
+      expect(getRowAssetNames()).toEqual([
+        "Bitcoin",
+        "Ethereum",
+        "USD Coin",
+        "Stellar Lumens",
+      ]);
     });
 
     it("toggles asset sort direction on click", async () => {
@@ -229,10 +259,12 @@ describe("MarketsTable", () => {
       fireEvent.click(sortButton);
 
       // Should now be descending: XLM, USDC, ETH, BTC
-      const table = document.querySelector("table");
-      const allNames = table ? within(table).getAllByText(/Stellar Lumens|USD Coin|Bitcoin|Ethereum/) : screen.getAllByText(/Stellar Lumens|USD Coin|Bitcoin|Ethereum/);
-      expect(allNames[0]).toHaveTextContent("Stellar Lumens");
-      expect(allNames[3]).toHaveTextContent("Bitcoin");
+      expect(getRowAssetNames()).toEqual([
+        "Stellar Lumens",
+        "USD Coin",
+        "Ethereum",
+        "Bitcoin",
+      ]);
     });
 
     it("sorts by supply APR when clicking Supply APR header", async () => {
@@ -244,10 +276,15 @@ describe("MarketsTable", () => {
       fireEvent.click(sortButton);
 
       // Ascending: BTC (2.10%), ETH (3.80%), USDC (5.20%), XLM (8.50%)
-      // Verify sorting changed the direction by checking the sort button aria-label
+      expect(getRowAssetNames()).toEqual([
+        "Bitcoin",
+        "Ethereum",
+        "USD Coin",
+        "Stellar Lumens",
+      ]);
       expect(sortButton).toHaveAttribute(
         "aria-label",
-        expect.stringContaining("ascending")
+        expect.stringContaining("ascending"),
       );
     });
 
@@ -260,9 +297,15 @@ describe("MarketsTable", () => {
       fireEvent.click(sortButton);
 
       // Ascending utilization: BTC (47.0%), ETH (58.0%), USDC (65.0%), XLM (71.0%)
+      expect(getRowAssetNames()).toEqual([
+        "Bitcoin",
+        "Ethereum",
+        "USD Coin",
+        "Stellar Lumens",
+      ]);
       expect(sortButton).toHaveAttribute(
         "aria-label",
-        expect.stringContaining("ascending")
+        expect.stringContaining("ascending"),
       );
     });
 
@@ -275,9 +318,15 @@ describe("MarketsTable", () => {
       fireEvent.click(sortButton);
 
       // Ascending: BTC (500K), ETH (1.2M), XLM (2.5M), USDC (10M)
+      expect(getRowAssetNames()).toEqual([
+        "Bitcoin",
+        "Ethereum",
+        "Stellar Lumens",
+        "USD Coin",
+      ]);
       expect(sortButton).toHaveAttribute(
         "aria-label",
-        expect.stringContaining("ascending")
+        expect.stringContaining("ascending"),
       );
     });
 
@@ -290,9 +339,15 @@ describe("MarketsTable", () => {
       fireEvent.click(sortButton);
 
       // Ascending: BTC (235K), ETH (696K), XLM (1.775M), USDC (6.5M)
+      expect(getRowAssetNames()).toEqual([
+        "Bitcoin",
+        "Ethereum",
+        "Stellar Lumens",
+        "USD Coin",
+      ]);
       expect(sortButton).toHaveAttribute(
         "aria-label",
-        expect.stringContaining("ascending")
+        expect.stringContaining("ascending"),
       );
     });
 
@@ -306,15 +361,101 @@ describe("MarketsTable", () => {
       // First click: ascending
       expect(sortButton).toHaveAttribute(
         "aria-label",
-        expect.stringContaining("ascending")
+        expect.stringContaining("ascending"),
       );
 
       fireEvent.click(sortButton);
       // Second click: descending
+      expect(getRowAssetNames()).toEqual([
+        "Stellar Lumens",
+        "USD Coin",
+        "Ethereum",
+        "Bitcoin",
+      ]);
       expect(sortButton).toHaveAttribute(
         "aria-label",
-        expect.stringContaining("descending")
+        expect.stringContaining("descending"),
       );
+    });
+
+    it("exposes aria-sort on active and inactive sortable headers", async () => {
+      mockFetchOnce(mockMarkets);
+      render(<MarketsTable />);
+      await screen.findByTestId("markets-table");
+
+      const table = screen.getByRole("table");
+      expect(
+        within(table).getByRole("columnheader", { name: /Asset/ }),
+      ).toHaveAttribute("aria-sort", "ascending");
+      expect(
+        within(table).getByRole("columnheader", { name: /Borrow APR/ }),
+      ).toHaveAttribute("aria-sort", "none");
+
+      fireEvent.click(screen.getByLabelText(/Sort by Borrow APR/));
+
+      expect(
+        within(table).getByRole("columnheader", { name: /Borrow APR/ }),
+      ).toHaveAttribute("aria-sort", "ascending");
+    });
+  });
+
+  describe("filtering", () => {
+    it("filters by asset symbol after the debounce window", async () => {
+      mockFetchOnce(mockMarkets);
+      render(<MarketsTable />);
+      await screen.findByTestId("markets-table");
+
+      await typeFilter("us");
+
+      expect(screen.getByText("Showing 1 of 4 markets")).toBeInTheDocument();
+      expect(getRowAssetNames()).toEqual(["USD Coin"]);
+    });
+
+    it("filters by asset name case-insensitively", async () => {
+      mockFetchOnce(mockMarkets);
+      render(<MarketsTable />);
+      await screen.findByTestId("markets-table");
+
+      await typeFilter("stellar");
+
+      expect(getRowAssetNames()).toEqual(["Stellar Lumens"]);
+    });
+
+    it("renders a filter-empty state and clears it with the empty-state action", async () => {
+      mockFetchOnce(mockMarkets);
+      render(<MarketsTable />);
+      await screen.findByTestId("markets-table");
+
+      await typeFilter("doge");
+
+      expect(screen.getByTestId("markets-filter-empty")).toBeInTheDocument();
+      expect(screen.getByText("No matching markets")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Clear filter"));
+
+      expect(
+        screen.queryByTestId("markets-filter-empty"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Showing 4 of 4 markets")).toBeInTheDocument();
+    });
+
+    it("clears the filter from the search input clear control", async () => {
+      mockFetchOnce(mockMarkets);
+      render(<MarketsTable />);
+      await screen.findByTestId("markets-table");
+
+      await typeFilter("btc");
+      expect(getRowAssetNames()).toEqual(["Bitcoin"]);
+
+      fireEvent.click(screen.getByLabelText("Clear market filter"));
+
+      expect(screen.getByText("Showing 4 of 4 markets")).toBeInTheDocument();
+      expect(getRowAssetNames()).toEqual([
+        "Bitcoin",
+        "Ethereum",
+        "USD Coin",
+        "Stellar Lumens",
+      ]);
     });
   });
 
@@ -330,23 +471,15 @@ describe("MarketsTable", () => {
       render(<MarketsTable />);
       await screen.findByTestId("markets-table");
 
+      expect(screen.getByLabelText(/Sort by Asset/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Sort by Supply APR/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Sort by Borrow APR/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Sort by Utilization/)).toBeInTheDocument();
       expect(
-        screen.getByLabelText(/Sort by Asset/)
+        screen.getByLabelText(/Sort by Total Supplied/),
       ).toBeInTheDocument();
       expect(
-        screen.getByLabelText(/Sort by Supply APR/)
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(/Sort by Borrow APR/)
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(/Sort by Utilization/)
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(/Sort by Total Supplied/)
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(/Sort by Total Borrowed/)
+        screen.getByLabelText(/Sort by Total Borrowed/),
       ).toBeInTheDocument();
     });
   });

--- a/components/features/lending/components/MarketsTable.tsx
+++ b/components/features/lending/components/MarketsTable.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Search, X } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { formatCurrency } from "@/lib/utils/format";
 import { EmptyState } from "@/components/shared/common/EmptyState";
 import { Skeleton } from "@/components/shared/common/Skeleton";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { ASSETS } from "@/lib/assets";
 import type { AssetMarket, MarketsResponse } from "@/lib/markets/types";
 
@@ -27,7 +28,12 @@ function getAssetName(symbol: string): string {
 
 type SortableField = keyof Pick<
   AssetMarket,
-  "asset" | "supplyApr" | "borrowApr" | "utilization" | "totalSupply" | "totalBorrow"
+  | "asset"
+  | "supplyApr"
+  | "borrowApr"
+  | "utilization"
+  | "totalSupply"
+  | "totalBorrow"
 >;
 
 interface SortConfig {
@@ -49,32 +55,86 @@ interface ColumnDef {
 
 const COLUMNS: ColumnDef[] = [
   { key: "asset", label: "Asset", sortable: true },
-  { key: "supplyApr", label: "Supply APR", align: "right", sortable: true, format: (v) => `${(v as number).toFixed(2)}%` },
-  { key: "borrowApr", label: "Borrow APR", align: "right", sortable: true, format: (v) => `${(v as number).toFixed(2)}%` },
-  { key: "utilization", label: "Utilization", align: "right", sortable: true, format: (v) => `${((v as number) * 100).toFixed(1)}%` },
-  { key: "totalSupply", label: "Total Supplied", align: "right", sortable: true, format: (v) => `$${formatCurrency(v as number)}` },
-  { key: "totalBorrow", label: "Total Borrowed", align: "right", sortable: true, format: (v) => `$${formatCurrency(v as number)}` },
+  {
+    key: "supplyApr",
+    label: "Supply APR",
+    align: "right",
+    sortable: true,
+    format: (v) => `${(v as number).toFixed(2)}%`,
+  },
+  {
+    key: "borrowApr",
+    label: "Borrow APR",
+    align: "right",
+    sortable: true,
+    format: (v) => `${(v as number).toFixed(2)}%`,
+  },
+  {
+    key: "utilization",
+    label: "Utilization",
+    align: "right",
+    sortable: true,
+    format: (v) => `${((v as number) * 100).toFixed(1)}%`,
+  },
+  {
+    key: "totalSupply",
+    label: "Total Supplied",
+    align: "right",
+    sortable: true,
+    format: (v) => `$${formatCurrency(v as number)}`,
+  },
+  {
+    key: "totalBorrow",
+    label: "Total Borrowed",
+    align: "right",
+    sortable: true,
+    format: (v) => `$${formatCurrency(v as number)}`,
+  },
 ];
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function sortMarkets(markets: AssetMarket[], config: SortConfig): AssetMarket[] {
+function sortMarkets(
+  markets: AssetMarket[],
+  config: SortConfig,
+): AssetMarket[] {
   return [...markets].sort((a, b) => {
     const aVal = a[config.field];
     const bVal = b[config.field];
+    const directionMultiplier = config.direction === "asc" ? 1 : -1;
 
     if (typeof aVal === "string" && typeof bVal === "string") {
-      return config.direction === "asc"
-        ? aVal.localeCompare(bVal)
-        : bVal.localeCompare(aVal);
+      const comparison = aVal.localeCompare(bVal);
+      return comparison === 0
+        ? a.asset.localeCompare(b.asset)
+        : comparison * directionMultiplier;
     }
 
     const aNum = aVal as number;
     const bNum = bVal as number;
 
-    return config.direction === "asc" ? aNum - bNum : bNum - aNum;
+    const comparison = aNum - bNum;
+    return comparison === 0
+      ? a.asset.localeCompare(b.asset)
+      : comparison * directionMultiplier;
+  });
+}
+
+function filterMarkets(markets: AssetMarket[], query: string): AssetMarket[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return markets;
+  }
+
+  return markets.filter((market) => {
+    const assetName = getAssetName(market.asset).toLowerCase();
+    return (
+      market.asset.toLowerCase().includes(normalizedQuery) ||
+      assetName.includes(normalizedQuery)
+    );
   });
 }
 
@@ -106,7 +166,7 @@ function SortHeader({
         "group inline-flex items-center gap-1.5 font-semibold transition-colors",
         "focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white rounded",
         column.align === "right" && "ml-auto",
-        isActive ? "text-green-700" : "text-slate-500 hover:text-slate-700"
+        isActive ? "text-green-700" : "text-slate-500 hover:text-slate-700",
       )}
       aria-label={`Sort by ${column.label}${isActive ? ` (${currentSort.direction === "asc" ? "ascending" : "descending"})` : ""}`}
     >
@@ -114,7 +174,7 @@ function SortHeader({
       <Icon
         className={cn(
           "h-3.5 w-3.5 shrink-0 transition-opacity",
-          isActive ? "opacity-100" : "opacity-0 group-hover:opacity-50"
+          isActive ? "opacity-100" : "opacity-0 group-hover:opacity-50",
         )}
         aria-hidden="true"
       />
@@ -126,10 +186,66 @@ function SortHeader({
 // Sub-components
 // ---------------------------------------------------------------------------
 
+function MarketsToolbar({
+  filterValue,
+  resultCount,
+  totalCount,
+  onFilterInputChange,
+  onFilterClear,
+}: {
+  filterValue: string;
+  resultCount: number;
+  totalCount: number;
+  onFilterInputChange: (query: string) => void;
+  onFilterClear: () => void;
+}) {
+  return (
+    <div
+      className="mb-4 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:flex-row md:items-center md:justify-between"
+      data-testid="markets-toolbar"
+    >
+      <div>
+        <h2 className="text-sm font-semibold text-slate-900">Market filters</h2>
+        <p className="mt-1 text-xs text-slate-500" aria-live="polite">
+          Showing {resultCount} of {totalCount} markets
+        </p>
+      </div>
+      <div className="relative w-full md:w-80">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"
+          aria-hidden="true"
+        />
+        <input
+          aria-label="Filter markets by asset"
+          className="w-full rounded-xl border border-slate-300 bg-white py-2.5 pl-10 pr-10 text-sm font-medium text-slate-900 placeholder:text-slate-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-500/30"
+          maxLength={80}
+          onChange={(event) => onFilterInputChange(event.target.value)}
+          placeholder="Filter by asset or symbol"
+          type="search"
+          value={filterValue}
+        />
+        {filterValue ? (
+          <button
+            type="button"
+            aria-label="Clear market filter"
+            className="absolute right-2 top-1/2 rounded p-1 text-slate-400 transition-colors hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+            onClick={onFilterClear}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 /** Desktop skeleton table */
 function MarketsTableSkeleton() {
   return (
-    <div className="hidden md:block overflow-x-auto" aria-label="Loading markets">
+    <div
+      className="hidden md:block overflow-x-auto"
+      aria-label="Loading markets"
+    >
       <table className="min-w-full text-sm" aria-busy="true">
         <thead>
           <tr className="border-b border-slate-200">
@@ -138,7 +254,7 @@ function MarketsTableSkeleton() {
                 key={col.key}
                 className={cn(
                   "py-3 px-4 whitespace-nowrap",
-                  col.align === "right" ? "text-right" : "text-left"
+                  col.align === "right" ? "text-right" : "text-left",
                 )}
               >
                 <Skeleton className="h-4 w-20" />
@@ -196,9 +312,19 @@ function MarketsCardSkeleton() {
           </div>
           <div className="grid grid-cols-2 gap-y-3 gap-x-4">
             {COLUMNS.slice(1).map((col) => (
-              <div key={col.key} className={col.align === "right" ? "text-right" : ""}>
-                <Skeleton className={cn("h-3 w-14 mb-1", col.align === "right" && "ml-auto")} />
-                <Skeleton className={cn("h-4 w-16", col.align === "right" && "ml-auto")} />
+              <div
+                key={col.key}
+                className={col.align === "right" ? "text-right" : ""}
+              >
+                <Skeleton
+                  className={cn(
+                    "h-3 w-14 mb-1",
+                    col.align === "right" && "ml-auto",
+                  )}
+                />
+                <Skeleton
+                  className={cn("h-4 w-16", col.align === "right" && "ml-auto")}
+                />
               </div>
             ))}
           </div>
@@ -216,10 +342,15 @@ function MarketRow({ market }: { market: AssetMarket }) {
     <tr className="border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors">
       <td className="py-4 px-4">
         <div className="flex items-center gap-3">
-          <div className={cn("h-8 w-8 rounded-full shrink-0", colorClass)} aria-hidden="true" />
+          <div
+            className={cn("h-8 w-8 rounded-full shrink-0", colorClass)}
+            aria-hidden="true"
+          />
           <div className="min-w-0">
             <span className="font-semibold text-slate-900">{market.asset}</span>
-            <p className="text-xs text-slate-500 mt-0.5">{getAssetName(market.asset)}</p>
+            <p className="text-xs text-slate-500 mt-0.5">
+              {getAssetName(market.asset)}
+            </p>
           </div>
         </div>
       </td>
@@ -241,7 +372,10 @@ function MarketCard({ market }: { market: AssetMarket }) {
   return (
     <div className="p-4 border border-slate-200 rounded-2xl bg-white shadow-sm hover:shadow-md transition-shadow">
       <div className="flex items-center gap-3 mb-4">
-        <div className={cn("h-10 w-10 rounded-full shrink-0", colorClass)} aria-hidden="true" />
+        <div
+          className={cn("h-10 w-10 rounded-full shrink-0", colorClass)}
+          aria-hidden="true"
+        />
         <div>
           <span className="font-semibold text-slate-900">{market.asset}</span>
           <p className="text-xs text-slate-500">{getAssetName(market.asset)}</p>
@@ -250,12 +384,17 @@ function MarketCard({ market }: { market: AssetMarket }) {
 
       <div className="grid grid-cols-2 gap-y-3 gap-x-4">
         {COLUMNS.slice(1).map((col) => (
-          <div key={col.key} className={col.align === "right" ? "text-right" : ""}>
+          <div
+            key={col.key}
+            className={col.align === "right" ? "text-right" : ""}
+          >
             <span className="text-xs font-medium text-slate-400 uppercase tracking-wider block mb-0.5">
               {col.label}
             </span>
             <span className="text-sm font-semibold text-slate-900">
-              {col.format ? col.format(market[col.key]) : String(market[col.key])}
+              {col.format
+                ? col.format(market[col.key])
+                : String(market[col.key])}
             </span>
           </div>
         ))}
@@ -277,7 +416,13 @@ export function MarketsTable({ apiUrl = "/api/markets" }: MarketsTableProps) {
   const [markets, setMarkets] = useState<AssetMarket[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [sort, setSort] = useState<SortConfig>({ field: "asset", direction: "asc" });
+  const [sort, setSort] = useState<SortConfig>({
+    field: "asset",
+    direction: "asc",
+  });
+  const [filterInput, setFilterInput] = useState("");
+  const [filterQuery, setFilterQuery] = useState("");
+  const debouncedFilterInput = useDebouncedValue(filterInput, 250);
 
   const fetchMarkets = useCallback(async () => {
     setLoading(true);
@@ -291,7 +436,9 @@ export function MarketsTable({ apiUrl = "/api/markets" }: MarketsTableProps) {
       const data: MarketsResponse = await res.json();
       setMarkets(data.markets ?? []);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "An unexpected error occurred");
+      setError(
+        err instanceof Error ? err.message : "An unexpected error occurred",
+      );
       setMarkets([]);
     } finally {
       setLoading(false);
@@ -302,20 +449,30 @@ export function MarketsTable({ apiUrl = "/api/markets" }: MarketsTableProps) {
     fetchMarkets();
   }, [fetchMarkets]);
 
+  useEffect(() => {
+    setFilterQuery(debouncedFilterInput);
+  }, [debouncedFilterInput]);
+
   const sortedMarkets = useMemo(
     () => sortMarkets(markets, sort),
-    [markets, sort]
+    [markets, sort],
+  );
+  const visibleMarkets = useMemo(
+    () => filterMarkets(sortedMarkets, filterQuery),
+    [sortedMarkets, filterQuery],
   );
 
-  const handleSort = useCallback(
-    (field: SortableField) => {
-      setSort((prev) => ({
-        field,
-        direction: prev.field === field && prev.direction === "asc" ? "desc" : "asc",
-      }));
-    },
-    []
-  );
+  const handleSort = useCallback((field: SortableField) => {
+    setSort((prev) => ({
+      field,
+      direction:
+        prev.field === field && prev.direction === "asc" ? "desc" : "asc",
+    }));
+  }, []);
+  const handleFilterClear = useCallback(() => {
+    setFilterInput("");
+    setFilterQuery("");
+  }, []);
 
   // ── Loading state ──
   if (loading) {
@@ -356,8 +513,32 @@ export function MarketsTable({ apiUrl = "/api/markets" }: MarketsTableProps) {
   // ── Data state ──
   return (
     <div data-testid="markets-table">
+      <MarketsToolbar
+        filterValue={filterInput}
+        resultCount={visibleMarkets.length}
+        totalCount={markets.length}
+        onFilterInputChange={setFilterInput}
+        onFilterClear={handleFilterClear}
+      />
+
+      {visibleMarkets.length === 0 ? (
+        <div data-testid="markets-filter-empty">
+          <EmptyState
+            title="No matching markets"
+            description="Clear the filter or search for another asset symbol or name."
+            actionLabel="Clear filter"
+            onAction={handleFilterClear}
+          />
+        </div>
+      ) : null}
+
       {/* Desktop table */}
-      <div className="hidden md:block overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div
+        className={cn(
+          "hidden md:block overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm",
+          visibleMarkets.length === 0 && "hidden",
+        )}
+      >
         <table className="min-w-full text-sm">
           <thead>
             <tr className="border-b border-slate-200 bg-slate-50">
@@ -366,16 +547,27 @@ export function MarketsTable({ apiUrl = "/api/markets" }: MarketsTableProps) {
                   key={col.key}
                   className={cn(
                     "py-3 px-4 whitespace-nowrap",
-                    col.align === "right" ? "text-right" : "text-left"
+                    col.align === "right" ? "text-right" : "text-left",
                   )}
+                  aria-sort={
+                    sort.field === col.key
+                      ? sort.direction === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none"
+                  }
                 >
-                  <SortHeader column={col} currentSort={sort} onSort={handleSort} />
+                  <SortHeader
+                    column={col}
+                    currentSort={sort}
+                    onSort={handleSort}
+                  />
                 </th>
               ))}
             </tr>
           </thead>
           <tbody>
-            {sortedMarkets.map((market) => (
+            {visibleMarkets.map((market) => (
               <MarketRow key={market.asset} market={market} />
             ))}
           </tbody>
@@ -383,8 +575,13 @@ export function MarketsTable({ apiUrl = "/api/markets" }: MarketsTableProps) {
       </div>
 
       {/* Mobile cards */}
-      <div className="md:hidden space-y-3">
-        {sortedMarkets.map((market) => (
+      <div
+        className={cn(
+          "md:hidden space-y-3",
+          visibleMarkets.length === 0 && "hidden",
+        )}
+      >
+        {visibleMarkets.map((market) => (
           <MarketCard key={market.asset} market={market} />
         ))}
       </div>

--- a/docs/markets-table.md
+++ b/docs/markets-table.md
@@ -1,0 +1,39 @@
+# Markets Table Sort and Filter
+
+The markets page renders the data returned by `GET /api/markets` without adding
+extra API calls for sorting or filtering. `MarketsTable` keeps the fetched
+`AssetMarket` rows in memory, applies the active sort order, and then filters the
+sorted rows by the debounced asset query.
+
+## Sort Keys
+
+Desktop column headers are keyboard-operable buttons. The active header exposes
+`aria-sort="ascending"` or `aria-sort="descending"`; inactive sortable headers
+expose `aria-sort="none"`.
+
+Supported sort keys:
+
+- Asset symbol
+- Supply APR
+- Borrow APR
+- Utilization
+- Total supplied
+- Total borrowed
+
+Numeric ties fall back to the asset symbol so the rendered order stays stable.
+
+## Asset Filter
+
+The toolbar filter matches the asset symbol and the canonical asset name from
+the shared asset registry. Matching is case-insensitive and runs client-side over
+the already-loaded market rows.
+
+The input is debounced before it changes the visible rows, while the clear action
+resets immediately. When no rows match, the table and mobile cards are hidden and
+an empty state offers a clear-filter action.
+
+## Accessibility
+
+The filter input has an explicit accessible name and the visible result count is
+announced through a polite live region. Sorting remains available from table
+headers, and the mobile cards reuse the same sorted and filtered row set.


### PR DESCRIPTION
## Summary
- add a MarketsToolbar with debounced client-side asset symbol/name filtering and immediate clear behavior
- keep desktop/mobile rows driven by the same sorted and filtered market set
- expose aria-sort on sortable table headers and document the sort/filter contract

Closes #659

## Tests
- pnpm vitest run components/features/lending/components/MarketsTable.test.tsx --project accessibility --project server-unit --reporter=dot
- pnpm exec prettier --check components/features/lending/components/MarketsTable.tsx components/features/lending/components/MarketsTable.test.tsx docs/markets-table.md
- git diff --check

## Notes
- pnpm exec tsc --noEmit is currently blocked by existing repository issues in components/molecules/SearchBar/SearchBar.tsx and @vitejs/plugin-react declaration parsing.
- pnpm exec eslint components/features/lending/components/MarketsTable.tsx components/features/lending/components/MarketsTable.test.tsx is currently blocked because ESLint 9 cannot find a flat eslint.config.* file.