### PR TITLE
Add collateral ratio history chart to PositionSummary

### DIFF
--- a/components/features/dashboard/components/CollateralRatioHistoryChart.test.tsx
+++ b/components/features/dashboard/components/CollateralRatioHistoryChart.test.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CollateralRatioHistoryChart from "./CollateralRatioHistoryChart";
+
+const fetchMock = vi.fn();
+let reducedMotion = false;
+
+vi.stubGlobal("fetch", fetchMock);
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => reducedMotion,
+}));
+
+function historyResponse(snapshots: unknown[]) {
+  return {
+    ok: true,
+    json: async () => ({
+      walletAddress: "wallet-1",
+      snapshots,
+      interval: "1d",
+      bucketCount: snapshots.length,
+    }),
+  } as Response;
+}
+
+describe("CollateralRatioHistoryChart", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    reducedMotion = false;
+  });
+
+  it("shows a loading state while history is being fetched", () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined));
+
+    render(<CollateralRatioHistoryChart />);
+
+    expect(
+      screen.getByRole("status", { name: /loading collateral ratio history/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an empty state when no valid ratio points exist", async () => {
+    fetchMock.mockResolvedValueOnce(historyResponse([]));
+
+    render(<CollateralRatioHistoryChart />);
+
+    expect(
+      await screen.findByText(/No collateral ratio history available/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a populated collateral ratio series with the liquidation threshold", async () => {
+    fetchMock.mockResolvedValueOnce(
+      historyResponse([
+        {
+          timestamp: Date.UTC(2026, 0, 1),
+          supplied: 3_000,
+          borrowed: 1_000,
+          effectiveSupplyApy: 4,
+          effectiveBorrowApy: 7,
+        },
+        {
+          timestamp: Date.UTC(2026, 0, 2),
+          supplied: 2_000,
+          borrowed: 1_000,
+          effectiveSupplyApy: 4,
+          effectiveBorrowApy: 7,
+        },
+      ]),
+    );
+
+    render(<CollateralRatioHistoryChart />);
+
+    expect(
+      await screen.findByRole("img", { name: /latest ratio 2\.00x/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Threshold reference: 1.00x")).toBeInTheDocument();
+    expect(screen.getByText("Latest ratio")).toBeInTheDocument();
+  });
+
+  it("renders a single valid snapshot without breaking the chart", async () => {
+    fetchMock.mockResolvedValueOnce(
+      historyResponse([
+        {
+          timestamp: Date.UTC(2026, 0, 1),
+          supplied: 1_500,
+          borrowed: 1_000,
+          effectiveSupplyApy: 3,
+          effectiveBorrowApy: 6,
+        },
+      ]),
+    );
+
+    render(<CollateralRatioHistoryChart />);
+
+    expect(await screen.findByText("1.50x")).toBeInTheDocument();
+  });
+
+  it("flags the latest ratio when it crosses the liquidation threshold", async () => {
+    fetchMock.mockResolvedValueOnce(
+      historyResponse([
+        {
+          timestamp: Date.UTC(2026, 0, 1),
+          supplied: 1_200,
+          borrowed: 1_000,
+          effectiveSupplyApy: 3,
+          effectiveBorrowApy: 6,
+        },
+        {
+          timestamp: Date.UTC(2026, 0, 2),
+          supplied: 900,
+          borrowed: 1_000,
+          effectiveSupplyApy: 3,
+          effectiveBorrowApy: 6,
+        },
+      ]),
+    );
+
+    render(<CollateralRatioHistoryChart />);
+
+    expect(await screen.findByText("0.90x")).toBeInTheDocument();
+    expect(screen.getByText("At liquidation threshold")).toBeInTheDocument();
+  });
+
+  it("ignores snapshots missing usable collateral or debt values", async () => {
+    fetchMock.mockResolvedValueOnce(
+      historyResponse([
+        {
+          timestamp: Date.UTC(2026, 0, 1),
+          supplied: 0,
+          borrowed: 1_000,
+          effectiveSupplyApy: 3,
+          effectiveBorrowApy: 6,
+        },
+        {
+          timestamp: Date.UTC(2026, 0, 2),
+          supplied: 2_400,
+          borrowed: 1_200,
+          effectiveSupplyApy: 3,
+          effectiveBorrowApy: 6,
+        },
+      ]),
+    );
+
+    render(<CollateralRatioHistoryChart />);
+
+    expect(await screen.findByText("2.00x")).toBeInTheDocument();
+  });
+
+  it("shows an error state when the history request fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    render(<CollateralRatioHistoryChart />);
+
+    expect(
+      await screen.findByText(/Collateral ratio history unavailable/i),
+    ).toBeInTheDocument();
+  });
+
+  it("disables inline svg transitions when reduced motion is requested", async () => {
+    reducedMotion = true;
+    fetchMock.mockResolvedValueOnce(
+      historyResponse([
+        {
+          timestamp: Date.UTC(2026, 0, 1),
+          supplied: 2_000,
+          borrowed: 1_000,
+          effectiveSupplyApy: 3,
+          effectiveBorrowApy: 6,
+        },
+      ]),
+    );
+
+    render(<CollateralRatioHistoryChart />);
+
+    expect(
+      await screen.findByRole("img", {
+        name: /collateral ratio history chart/i,
+      }),
+    ).toHaveStyle({
+      transition: "none",
+    });
+  });
+});

--- a/components/features/dashboard/components/CollateralRatioHistoryChart.tsx
+++ b/components/features/dashboard/components/CollateralRatioHistoryChart.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import type { SnapshotHistoryResponse } from "@/lib/positions/snapshot";
+
+interface CollateralRatioPoint {
+  timestamp: number;
+  ratio: number;
+}
+
+interface CollateralRatioHistoryChartProps {
+  className?: string;
+  liquidationThreshold?: number;
+}
+
+const CHART_WIDTH = 280;
+const CHART_HEIGHT = 108;
+const CHART_PADDING = 10;
+const DEFAULT_LIQUIDATION_THRESHOLD = 1;
+
+function isFinitePositive(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function formatRatio(value: number): string {
+  return `${value.toFixed(2)}x`;
+}
+
+function formatDate(timestamp: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(timestamp));
+}
+
+function buildPath(points: Array<{ x: number; y: number }>): string {
+  if (points.length === 0) {
+    return "";
+  }
+
+  if (points.length === 1) {
+    return `M ${points[0].x.toFixed(2)} ${points[0].y.toFixed(2)}`;
+  }
+
+  return points
+    .map((point, index) => {
+      const command = index === 0 ? "M" : "L";
+      return `${command} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+function toCollateralRatioPoints(
+  snapshots: SnapshotHistoryResponse["snapshots"],
+): CollateralRatioPoint[] {
+  return snapshots
+    .map((snapshot) => {
+      if (
+        !isFinitePositive(snapshot.supplied) ||
+        !isFinitePositive(snapshot.borrowed)
+      ) {
+        return null;
+      }
+
+      return {
+        timestamp: snapshot.timestamp,
+        ratio: snapshot.supplied / snapshot.borrowed,
+      };
+    })
+    .filter((point): point is CollateralRatioPoint => point !== null);
+}
+
+export function CollateralRatioHistoryChart({
+  className,
+  liquidationThreshold = DEFAULT_LIQUIDATION_THRESHOLD,
+}: CollateralRatioHistoryChartProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const [status, setStatus] = useState<"loading" | "ready" | "empty" | "error">(
+    "loading",
+  );
+  const [points, setPoints] = useState<CollateralRatioPoint[]>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadHistory() {
+      setStatus("loading");
+
+      try {
+        const response = await fetch("/api/positions/history?interval=1d", {
+          signal: controller.signal,
+          headers: {
+            Accept: "application/json",
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error("Position history request failed");
+        }
+
+        const payload = (await response.json()) as SnapshotHistoryResponse;
+        const snapshots = Array.isArray(payload?.snapshots)
+          ? payload.snapshots
+          : [];
+        const ratioPoints = toCollateralRatioPoints(snapshots);
+
+        if (ratioPoints.length === 0) {
+          setPoints([]);
+          setStatus("empty");
+          return;
+        }
+
+        setPoints(ratioPoints);
+        setStatus("ready");
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        setPoints([]);
+        setStatus("error");
+      }
+    }
+
+    loadHistory();
+
+    return () => controller.abort();
+  }, []);
+
+  const chart = useMemo(() => {
+    if (points.length === 0) {
+      return null;
+    }
+
+    const ratioValues = points.map((point) => point.ratio);
+    const minValue = Math.min(...ratioValues, liquidationThreshold);
+    const maxValue = Math.max(...ratioValues, liquidationThreshold);
+    const range = maxValue - minValue || 1;
+    const lowerBound = Math.max(0, minValue - range * 0.18);
+    const upperBound = maxValue + range * 0.18;
+    const yForRatio = (ratio: number) => {
+      const normalized = (ratio - lowerBound) / (upperBound - lowerBound || 1);
+      return (
+        CHART_HEIGHT -
+        CHART_PADDING -
+        normalized * (CHART_HEIGHT - CHART_PADDING * 2)
+      );
+    };
+
+    const mappedPoints = points.map((point, index) => ({
+      x:
+        CHART_PADDING +
+        (points.length === 1 ? 0.5 : index / (points.length - 1)) *
+          (CHART_WIDTH - CHART_PADDING * 2),
+      y: yForRatio(point.ratio),
+    }));
+    const latestPoint = points[points.length - 1];
+
+    return {
+      linePath: buildPath(mappedPoints),
+      thresholdY: yForRatio(liquidationThreshold),
+      latestPoint,
+      latestSvgPoint: mappedPoints[mappedPoints.length - 1],
+      firstLabel: formatDate(points[0].timestamp),
+      lastLabel: formatDate(latestPoint.timestamp),
+      isBelowThreshold: latestPoint.ratio <= liquidationThreshold,
+    };
+  }, [liquidationThreshold, points]);
+
+  if (status === "loading") {
+    return (
+      <div
+        className={`rounded-xl border border-[#71B48D33] bg-[#072815] p-4 ${className ?? ""}`}
+        role="status"
+        aria-label="Loading collateral ratio history"
+      >
+        <div className="mb-2 h-3 w-36 rounded bg-[#71B48D33]" />
+        <div className="h-24 rounded-lg bg-[#0A3D1E] motion-reduce:animate-none" />
+      </div>
+    );
+  }
+
+  if (status === "empty") {
+    return (
+      <div
+        className={`rounded-xl border border-[#71B48D33] bg-[#072815] p-4 ${className ?? ""}`}
+      >
+        <p className="text-sm font-medium text-[#D4F3E6]">
+          Collateral ratio history
+        </p>
+        <p className="mt-2 text-sm text-[#AAABAB]">
+          No collateral ratio history available
+        </p>
+      </div>
+    );
+  }
+
+  if (status === "error" || !chart) {
+    return (
+      <div
+        className={`rounded-xl border border-[#71B48D33] bg-[#072815] p-4 ${className ?? ""}`}
+        role="alert"
+      >
+        <p className="text-sm font-medium text-[#D4F3E6]">
+          Collateral ratio history
+        </p>
+        <p className="mt-2 text-sm text-[#AAABAB]">
+          Collateral ratio history unavailable
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`rounded-xl border border-[#71B48D33] bg-[#072815] p-4 ${className ?? ""}`}
+    >
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-[#D4F3E6]">
+            Collateral ratio history
+          </p>
+          <p className="text-xs text-[#AAABAB]">
+            Threshold reference: {formatRatio(liquidationThreshold)}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-base font-semibold text-white">
+            {formatRatio(chart.latestPoint.ratio)}
+          </p>
+          <p
+            className={
+              chart.isBelowThreshold
+                ? "text-xs text-red-300"
+                : "text-xs text-[#AAABAB]"
+            }
+          >
+            {chart.isBelowThreshold
+              ? "At liquidation threshold"
+              : "Latest ratio"}
+          </p>
+        </div>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        role="img"
+        aria-label={`Collateral ratio history chart. Latest ratio ${formatRatio(
+          chart.latestPoint.ratio,
+        )}; liquidation threshold ${formatRatio(liquidationThreshold)}.`}
+        className="h-28 w-full"
+        style={shouldReduceMotion ? { transition: "none" } : undefined}
+      >
+        <line
+          x1={CHART_PADDING}
+          x2={CHART_WIDTH - CHART_PADDING}
+          y1={chart.thresholdY}
+          y2={chart.thresholdY}
+          stroke="#F59E0B"
+          strokeDasharray="5 5"
+          strokeWidth="1.5"
+        />
+        <path
+          d={chart.linePath}
+          fill="none"
+          stroke={chart.isBelowThreshold ? "#FCA5A5" : "#71B48D"}
+          strokeLinecap="round"
+          strokeWidth="2.5"
+        />
+        <circle
+          cx={chart.latestSvgPoint.x}
+          cy={chart.latestSvgPoint.y}
+          r="3.5"
+          fill="#D4F3E6"
+        />
+      </svg>
+
+      <div className="mt-2 flex items-center justify-between text-xs text-[#AAABAB]">
+        <span>{chart.firstLabel}</span>
+        <span>{chart.lastLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+export default CollateralRatioHistoryChart;

--- a/components/features/dashboard/components/PositionSummary.tsx
+++ b/components/features/dashboard/components/PositionSummary.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, TrendingUp } from "lucide-react";
 import SupplyApyChart from "./SupplyApyChart";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { CollateralBreakdown } from "./CollateralBreakdown";
+import CollateralRatioHistoryChart from "./CollateralRatioHistoryChart";
 import { useCollateralShares } from "@/hooks/usePositions";
 
 interface PositionData {
@@ -277,6 +278,9 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({
 
       <div className="mt-6">
         <SupplyApyChart className="w-full" />
+      </div>
+      <div className="mt-6">
+        <CollateralRatioHistoryChart className="w-full" />
       </div>
       {/* Collateral Breakdown */}
       <CollateralBreakdown shares={shares} isLoading={sharesLoading} />

--- a/docs/position-collateral-history.md
+++ b/docs/position-collateral-history.md
@@ -1,0 +1,34 @@
+# Position Collateral Ratio History
+
+`PositionSummary` renders a collateral ratio history chart so borrowers can see
+whether their collateral-to-debt ratio is drifting toward liquidation.
+
+## Data source
+
+The chart uses the existing `/api/positions/history?interval=1d` endpoint. It
+reads the snapshot shape from `lib/positions/snapshot.ts` and derives each point
+as:
+
+```text
+collateral ratio = supplied / borrowed
+```
+
+Snapshots without positive supplied or borrowed values are ignored because they
+cannot produce a meaningful finite ratio.
+
+## Liquidation reference
+
+The chart draws a dashed `1.00x` reference line. A latest ratio at or below this
+line is marked as being at the liquidation threshold, matching the current
+PositionSummary health-band boundary where health factors below `1.0` are
+critical.
+
+## States
+
+The component handles:
+
+- loading while the history request is in flight;
+- empty when no usable snapshot ratio exists;
+- error when the existing history endpoint fails;
+- single-snapshot histories;
+- reduced-motion users by disabling inline SVG transitions.


### PR DESCRIPTION
## Summary
- add a CollateralRatioHistoryChart that reads the existing /api/positions/history endpoint
- plot supplied/borrowed collateral ratio with a 1.00x liquidation threshold reference line
- handle loading, empty, error, single-snapshot, invalid snapshot, and reduced-motion states
- document the data source and threshold behavior in docs/position-collateral-history.md

Closes #658

## Validation
- npm test -- components/features/dashboard/components/CollateralRatioHistoryChart.test.tsx components/features/dashboard/components/PositionSummary.test.tsx (52 passed; existing async act warnings from PositionSummary chart effects)
- npx prettier --check components/features/dashboard/components/CollateralRatioHistoryChart.tsx components/features/dashboard/components/CollateralRatioHistoryChart.test.tsx components/features/dashboard/components/PositionSummary.tsx docs/position-collateral-history.md
- git diff --check

## Known existing blockers
- npm run lint is blocked by existing unrelated parse/lint issues in components/features/dashboard/components/TransactionDetail.test.tsx, components/molecules/SearchBar/SearchBar.tsx, components/shared/common/AlertBanner.test.tsx, components/shared/common/NotificationToastBridge.test.tsx, and components/shared/common/__tests__/transactions-virtualization.test.tsx.
- npm run type-check is blocked by the existing SearchBar.tsx parse errors plus an upstream @vitejs/plugin-react declaration parse error.