### PR TITLE
Add liquidation alert subscription toggles

### DIFF
--- a/app/api/account/notification-preferences/route.ts
+++ b/app/api/account/notification-preferences/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const LIQUIDATION_WARNING_EVENT = "liquidation_warning";
+const subscriptionsByEvent = new Map<string, Set<string>>();
+
+function getSubscriptions(eventType: string): Set<string> {
+  const existing = subscriptionsByEvent.get(eventType);
+  if (existing) {
+    return existing;
+  }
+
+  const created = new Set<string>();
+  subscriptionsByEvent.set(eventType, created);
+  return created;
+}
+
+function isValidEventType(eventType: unknown): eventType is string {
+  return eventType === LIQUIDATION_WARNING_EVENT;
+}
+
+function isValidPositionId(positionId: unknown): positionId is string {
+  return typeof positionId === "string" && positionId.length > 0;
+}
+
+export async function GET(request: NextRequest) {
+  const eventType =
+    request.nextUrl.searchParams.get("eventType") ?? LIQUIDATION_WARNING_EVENT;
+
+  if (!isValidEventType(eventType)) {
+    return NextResponse.json(
+      { error: "Unsupported notification event type" },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json({
+    eventType,
+    subscriptions: Array.from(getSubscriptions(eventType)),
+  });
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = (await request.json()) as {
+      eventType?: unknown;
+      positionId?: unknown;
+      enabled?: unknown;
+    };
+    const eventType = body.eventType ?? LIQUIDATION_WARNING_EVENT;
+
+    if (!isValidEventType(eventType) || !isValidPositionId(body.positionId)) {
+      return NextResponse.json(
+        { error: "Invalid notification preference payload" },
+        { status: 400 },
+      );
+    }
+
+    if (typeof body.enabled !== "boolean") {
+      return NextResponse.json(
+        { error: "enabled must be a boolean" },
+        { status: 400 },
+      );
+    }
+
+    const subscriptions = getSubscriptions(eventType);
+    if (body.enabled) {
+      subscriptions.add(body.positionId);
+    } else {
+      subscriptions.delete(body.positionId);
+    }
+
+    return NextResponse.json({
+      eventType,
+      positionId: body.positionId,
+      enabled: body.enabled,
+      subscriptions: Array.from(subscriptions),
+    });
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+}

--- a/components/features/dashboard/components/LiquidationsPanel.test.tsx
+++ b/components/features/dashboard/components/LiquidationsPanel.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 import LiquidationsPanel, {
   getDistanceToLiquidationPercent,
 } from "./LiquidationsPanel";
@@ -19,45 +20,101 @@ const position = (
   ...overrides,
 });
 
+const alertIdFor = (item: LiquidationPosition, index = 0): string =>
+  [
+    item.asset,
+    item.collateralAsset,
+    item.borrowedAmount,
+    item.collateralAmount,
+    index,
+  ].join(":");
+
+function preferenceFetcher(
+  subscriptions: string[] = [],
+  persistOk = true,
+): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    if (url.startsWith("/api/account/notification-preferences")) {
+      if (init?.method === "PUT") {
+        return {
+          ok: persistOk,
+          json: async () => ({}),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ subscriptions }),
+      } as Response;
+    }
+
+    return {
+      ok: true,
+      json: async () => ({ positions: [] }),
+    } as Response;
+  }) as typeof fetch;
+}
+
+function renderPanel(
+  positions: LiquidationPosition[],
+  fetcher = preferenceFetcher(),
+) {
+  return render(
+    <LiquidationsPanel initialPositions={positions} fetcher={fetcher} />,
+  );
+}
+
 describe("LiquidationsPanel", () => {
   it("renders liquidation price and distance columns from API outputs", () => {
-    render(
-      <LiquidationsPanel
-        initialPositions={[
-          position({
-            asset: "USDC",
-            borrowedAmount: 250,
-            collateralAsset: "XLM",
-            collateralAmount: 500,
-            healthFactor: 1.25,
-            liquidationPriceFactor: 0.5,
-          }),
-        ]}
-      />,
-    );
+    renderPanel([
+      position({
+        asset: "USDC",
+        borrowedAmount: 250,
+        collateralAsset: "XLM",
+        collateralAmount: 500,
+        healthFactor: 1.25,
+        liquidationPriceFactor: 0.5,
+      }),
+    ]);
 
-    expect(screen.getByRole("heading", { name: "Liquidation Risk" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Liquidation price" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Distance" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Liquidation Risk" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Liquidation price" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Distance" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("0.50x")).toBeInTheDocument();
     expect(screen.getByText("25.0%")).toBeInTheDocument();
   });
 
   it("sorts by distance ascending while preserving stable order for ties", () => {
-    render(
-      <LiquidationsPanel
-        initialPositions={[
-          position({ asset: "XLM", healthFactor: 1.2, liquidationPriceFactor: 0.7 }),
-          position({ asset: "USDC", healthFactor: 0.95, liquidationPriceFactor: 1.05 }),
-          position({ asset: "ETH", healthFactor: 1.2, liquidationPriceFactor: 0.7 }),
-          position({
-            asset: "BTC",
-            healthFactor: Number.POSITIVE_INFINITY,
-            liquidationPriceFactor: 0,
-          }),
-        ]}
-      />,
-    );
+    renderPanel([
+      position({
+        asset: "XLM",
+        healthFactor: 1.2,
+        liquidationPriceFactor: 0.7,
+      }),
+      position({
+        asset: "USDC",
+        healthFactor: 0.95,
+        liquidationPriceFactor: 1.05,
+      }),
+      position({
+        asset: "ETH",
+        healthFactor: 1.2,
+        liquidationPriceFactor: 0.7,
+      }),
+      position({
+        asset: "BTC",
+        healthFactor: Number.POSITIVE_INFINITY,
+        liquidationPriceFactor: 0,
+      }),
+    ]);
 
     const rows = screen.getAllByRole("row").slice(1);
 
@@ -68,15 +125,23 @@ describe("LiquidationsPanel", () => {
   });
 
   it("shows color-safe text labels for near and past liquidation rows", () => {
-    render(
-      <LiquidationsPanel
-        initialPositions={[
-          position({ asset: "USDC", healthFactor: 0.9, liquidationPriceFactor: 1.11 }),
-          position({ asset: "XLM", healthFactor: 1.08, liquidationPriceFactor: 0.93 }),
-          position({ asset: "ETH", healthFactor: 1.2, liquidationPriceFactor: 0.83 }),
-        ]}
-      />,
-    );
+    renderPanel([
+      position({
+        asset: "USDC",
+        healthFactor: 0.9,
+        liquidationPriceFactor: 1.11,
+      }),
+      position({
+        asset: "XLM",
+        healthFactor: 1.08,
+        liquidationPriceFactor: 0.93,
+      }),
+      position({
+        asset: "ETH",
+        healthFactor: 1.2,
+        liquidationPriceFactor: 0.83,
+      }),
+    ]);
 
     expect(screen.getByText("Past liquidation")).toBeInTheDocument();
     expect(screen.getByText("Critical")).toBeInTheDocument();
@@ -84,18 +149,18 @@ describe("LiquidationsPanel", () => {
   });
 
   it("places missing price and distance data after measurable positions", () => {
-    render(
-      <LiquidationsPanel
-        initialPositions={[
-          position({
-            asset: "BTC",
-            healthFactor: Number.POSITIVE_INFINITY,
-            liquidationPriceFactor: 0,
-          }),
-          position({ asset: "XLM", healthFactor: 1.1, liquidationPriceFactor: 0.91 }),
-        ]}
-      />,
-    );
+    renderPanel([
+      position({
+        asset: "BTC",
+        healthFactor: Number.POSITIVE_INFINITY,
+        liquidationPriceFactor: 0,
+      }),
+      position({
+        asset: "XLM",
+        healthFactor: 1.1,
+        liquidationPriceFactor: 0.91,
+      }),
+    ]);
 
     const rows = screen.getAllByRole("row").slice(1);
 
@@ -111,5 +176,81 @@ describe("LiquidationsPanel", () => {
         healthFactor: Number.POSITIVE_INFINITY,
       }),
     ).toBeNull();
+  });
+
+  it("reflects the current liquidation alert subscription state on load", async () => {
+    const item = position({ asset: "USDC" });
+    renderPanel([item], preferenceFetcher([alertIdFor(item)]));
+
+    const toggle = await screen.findByRole("switch", {
+      name: /disable liquidation alerts/i,
+    });
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(toggle).toHaveTextContent("On");
+  });
+
+  it("optimistically enables and disables liquidation alerts", async () => {
+    const user = userEvent.setup();
+    const fetcher = preferenceFetcher();
+
+    renderPanel([position({ asset: "USDC" })], fetcher);
+
+    const toggle = await screen.findByRole("switch", {
+      name: /enable liquidation alerts/i,
+    });
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(fetcher).toHaveBeenLastCalledWith(
+      "/api/account/notification-preferences",
+      expect.objectContaining({
+        method: "PUT",
+        body: expect.stringContaining('"enabled":true'),
+      }),
+    );
+
+    await waitFor(() => expect(toggle).not.toBeDisabled());
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(fetcher).toHaveBeenLastCalledWith(
+      "/api/account/notification-preferences",
+      expect.objectContaining({
+        method: "PUT",
+        body: expect.stringContaining('"enabled":false'),
+      }),
+    );
+  });
+
+  it("rolls optimistic changes back when persistence fails", async () => {
+    const user = userEvent.setup();
+
+    renderPanel([position({ asset: "USDC" })], preferenceFetcher([], false));
+
+    const toggle = await screen.findByRole("switch", {
+      name: /enable liquidation alerts/i,
+    });
+
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+    expect(
+      screen.getByText("Unable to save alert preference"),
+    ).toHaveTextContent("Unable to save alert preference");
+  });
+
+  it("does not load alert preferences when there are no at-risk rows", () => {
+    const fetcher = preferenceFetcher();
+
+    renderPanel([], fetcher);
+
+    expect(
+      screen.getByText("No liquidation risk positions found."),
+    ).toBeInTheDocument();
+    expect(fetcher).not.toHaveBeenCalled();
   });
 });

--- a/components/features/dashboard/components/LiquidationsPanel.tsx
+++ b/components/features/dashboard/components/LiquidationsPanel.tsx
@@ -6,6 +6,8 @@ import type {
   LiquidationsResponse,
 } from "@/lib/positions/liquidation";
 
+const LIQUIDATION_ALERT_EVENT = "liquidation_warning";
+
 interface LiquidationsPanelProps {
   initialPositions?: LiquidationPosition[];
   fetcher?: typeof fetch;
@@ -21,6 +23,10 @@ type Severity = {
   label: "Past liquidation" | "Critical" | "Warning" | "Buffer" | "Unavailable";
   className: string;
 };
+
+interface NotificationPreferencesResponse {
+  subscriptions?: string[];
+}
 
 export function getDistanceToLiquidationPercent(
   position: Pick<LiquidationPosition, "healthFactor">,
@@ -97,7 +103,10 @@ function toSortedRows(positions: LiquidationPosition[]): LiquidationRow[] {
       originalIndex,
     }))
     .sort((a, b) => {
-      if (a.distanceToLiquidation === null && b.distanceToLiquidation === null) {
+      if (
+        a.distanceToLiquidation === null &&
+        b.distanceToLiquidation === null
+      ) {
         return a.originalIndex - b.originalIndex;
       }
 
@@ -117,6 +126,16 @@ function toSortedRows(positions: LiquidationPosition[]): LiquidationRow[] {
     });
 }
 
+function getLiquidationAlertId(position: LiquidationRow): string {
+  return [
+    position.asset,
+    position.collateralAsset,
+    position.borrowedAmount,
+    position.collateralAmount,
+    position.originalIndex,
+  ].join(":");
+}
+
 export default function LiquidationsPanel({
   initialPositions,
   fetcher = fetch,
@@ -127,6 +146,13 @@ export default function LiquidationsPanel({
   );
   const [isLoading, setIsLoading] = useState(initialPositions === undefined);
   const [error, setError] = useState<string | null>(null);
+  const [alertSubscriptions, setAlertSubscriptions] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [pendingAlertIds, setPendingAlertIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [alertError, setAlertError] = useState<string | null>(null);
 
   useEffect(() => {
     if (initialPositions !== undefined) {
@@ -134,7 +160,9 @@ export default function LiquidationsPanel({
     }
 
     const controller = new AbortController();
-    const query = walletAddress ? `?wallet=${encodeURIComponent(walletAddress)}` : "";
+    const query = walletAddress
+      ? `?wallet=${encodeURIComponent(walletAddress)}`
+      : "";
 
     setIsLoading(true);
     fetcher(`/api/liquidations${query}`, { signal: controller.signal })
@@ -164,6 +192,104 @@ export default function LiquidationsPanel({
   }, [fetcher, initialPositions, walletAddress]);
 
   const rows = useMemo(() => toSortedRows(positions), [positions]);
+  const rowAlertIds = useMemo(
+    () => rows.map((position) => getLiquidationAlertId(position)),
+    [rows],
+  );
+
+  useEffect(() => {
+    if (rowAlertIds.length === 0) {
+      setAlertSubscriptions(new Set());
+      return;
+    }
+
+    const controller = new AbortController();
+
+    fetcher(
+      `/api/account/notification-preferences?eventType=${LIQUIDATION_ALERT_EVENT}`,
+      {
+        signal: controller.signal,
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    )
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Unable to load alert preferences");
+        }
+
+        return response.json() as Promise<NotificationPreferencesResponse>;
+      })
+      .then((data) => {
+        const knownAlertIds = new Set(rowAlertIds);
+        const subscriptions = Array.isArray(data.subscriptions)
+          ? data.subscriptions.filter((id) => knownAlertIds.has(id))
+          : [];
+
+        setAlertSubscriptions(new Set(subscriptions));
+        setAlertError(null);
+      })
+      .catch((cause) => {
+        if (cause instanceof DOMException && cause.name === "AbortError") {
+          return;
+        }
+
+        setAlertError("Unable to load alert preferences");
+      });
+
+    return () => controller.abort();
+  }, [fetcher, rowAlertIds]);
+
+  async function toggleLiquidationAlert(alertId: string, enabled: boolean) {
+    setAlertError(null);
+    setPendingAlertIds((current) => new Set(current).add(alertId));
+    setAlertSubscriptions((current) => {
+      const next = new Set(current);
+      if (enabled) {
+        next.add(alertId);
+      } else {
+        next.delete(alertId);
+      }
+      return next;
+    });
+
+    try {
+      const response = await fetcher("/api/account/notification-preferences", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          eventType: LIQUIDATION_ALERT_EVENT,
+          positionId: alertId,
+          enabled,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Unable to save alert preference");
+      }
+    } catch {
+      setAlertSubscriptions((current) => {
+        const next = new Set(current);
+        if (enabled) {
+          next.delete(alertId);
+        } else {
+          next.add(alertId);
+        }
+        return next;
+      });
+      setAlertError("Unable to save alert preference");
+    } finally {
+      setPendingAlertIds((current) => {
+        const next = new Set(current);
+        next.delete(alertId);
+        return next;
+      });
+    }
+  }
 
   if (isLoading) {
     return (
@@ -237,11 +363,17 @@ export default function LiquidationsPanel({
                 <th scope="col" className="px-3 py-2 font-semibold">
                   Status
                 </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Alerts
+                </th>
               </tr>
             </thead>
             <tbody>
               {rows.map((position) => {
                 const severity = getSeverity(position.distanceToLiquidation);
+                const alertId = getLiquidationAlertId(position);
+                const isSubscribed = alertSubscriptions.has(alertId);
+                const isPending = pendingAlertIds.has(alertId);
 
                 return (
                   <tr
@@ -270,18 +402,42 @@ export default function LiquidationsPanel({
                     <td className="px-3 py-3 font-mono">
                       {formatDistance(position.distanceToLiquidation)}
                     </td>
-                    <td className="rounded-r-lg px-3 py-3">
+                    <td className="px-3 py-3">
                       <span
                         className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${severity.className}`}
                       >
                         {severity.label}
                       </span>
                     </td>
+                    <td className="rounded-r-lg px-3 py-3">
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={isSubscribed}
+                        aria-label={`${isSubscribed ? "Disable" : "Enable"} liquidation alerts for ${position.asset} borrowed against ${position.collateralAsset}`}
+                        disabled={isPending}
+                        onClick={() =>
+                          toggleLiquidationAlert(alertId, !isSubscribed)
+                        }
+                        className={`inline-flex min-w-20 items-center justify-center rounded-full border px-3 py-1 text-xs font-semibold transition-colors disabled:cursor-wait disabled:opacity-60 ${
+                          isSubscribed
+                            ? "border-emerald-500 bg-emerald-950 text-emerald-100"
+                            : "border-[#71B48D66] bg-[#0A3D1E] text-[#D4F3E6]"
+                        }`}
+                      >
+                        {isSubscribed ? "On" : "Off"}
+                      </button>
+                    </td>
                   </tr>
                 );
               })}
             </tbody>
           </table>
+          {alertError ? (
+            <p role="alert" className="mt-3 text-sm font-medium text-red-200">
+              {alertError}
+            </p>
+          ) : null}
         </div>
       )}
     </section>

--- a/docs/liquidation-alerts.md
+++ b/docs/liquidation-alerts.md
@@ -1,0 +1,34 @@
+# Liquidation Alert Subscriptions
+
+`LiquidationsPanel` includes a per-row alert toggle so users can opt into
+liquidation-warning notifications for specific at-risk positions.
+
+## Preference flow
+
+The panel loads current subscriptions from:
+
+```text
+GET /api/account/notification-preferences?eventType=liquidation_warning
+```
+
+Each row derives a stable position subscription id from the borrowed asset,
+collateral asset, borrowed amount, collateral amount, and row index. Toggling a
+row persists through:
+
+```text
+PUT /api/account/notification-preferences
+```
+
+with a JSON body containing `eventType`, `positionId`, and `enabled`.
+
+## UI behavior
+
+- Toggles update optimistically so users get immediate feedback.
+- Failed persistence rolls the toggle back and shows an inline alert.
+- A pending toggle is disabled to avoid overlapping writes during rapid clicks.
+- Empty liquidation-risk tables do not request alert preferences.
+
+## Accessibility
+
+Each toggle is rendered as a keyboard-operable switch with an accessible label
+that identifies the borrowed and collateral assets for the row.


### PR DESCRIPTION
## Summary
- add per-row liquidation alert switches to LiquidationsPanel with accessible switch labels
- load current liquidation_warning subscriptions from /api/account/notification-preferences
- persist toggle changes optimistically with rollback and inline error feedback on failure
- add a minimal notification-preferences route for liquidation alert subscription state
- document the subscription flow and UI behavior in docs/liquidation-alerts.md

Closes #665

## Validation
- npm test -- components/features/dashboard/components/LiquidationsPanel.test.tsx (9 passed; existing async act warnings from alert preference loading effects)
- npx prettier --check components/features/dashboard/components/LiquidationsPanel.tsx components/features/dashboard/components/LiquidationsPanel.test.tsx app/api/account/notification-preferences/route.ts docs/liquidation-alerts.md
- git diff --check

## Known existing blockers
- npm run lint is blocked by existing unrelated parse/lint issues in components/features/dashboard/components/TransactionDetail.test.tsx, components/molecules/SearchBar/SearchBar.tsx, components/shared/common/AlertBanner.test.tsx, components/shared/common/NotificationToastBridge.test.tsx, and components/shared/common/__tests__/transactions-virtualization.test.tsx.
- npm run type-check is blocked by existing unrelated SearchBar.tsx parse errors plus an upstream @vitejs/plugin-react declaration parse error.

## Overlap note
- Open PR #747 also touches LiquidationsPanel to add a Utilization column. This change adds an independent Alerts column and the preference flow for #665.