### PR TITLE
Add TopNav wallet balance summary

### DIFF
--- a/components/shared/layout/TopNav.test.tsx
+++ b/components/shared/layout/TopNav.test.tsx
@@ -1,27 +1,52 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { SidebarProvider } from "@/context/SidebarContext";
-import { WalletProvider } from "@/context/WalletContext";
 import { afterEach, beforeEach, vi } from "vitest";
+import { useWallet } from "@/hooks/useWallet";
 
 vi.mock("@/components/shared/layout/NotificationBell", () => ({
   default: () => <button type="button" aria-label="View notifications" />,
+}));
+
+vi.mock("@/components/molecules/SearchBar", () => ({
+  SearchBar: ({ placeholder }: { placeholder: string }) => (
+    <input aria-label={placeholder} placeholder={placeholder} />
+  ),
+}));
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: vi.fn(),
 }));
 
 import TopNav from "./TopNav";
 
 const renderTopNav = () =>
   render(
-    <WalletProvider>
-      <SidebarProvider>
-        <TopNav />
-      </SidebarProvider>
-    </WalletProvider>,
+    <SidebarProvider>
+      <TopNav />
+    </SidebarProvider>,
   );
+
+const mockUseWallet = vi.mocked(useWallet);
+const connectedAddress =
+  "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567890123456789012345678901234";
+
+function setWalletState(overrides: Partial<ReturnType<typeof useWallet>> = {}) {
+  mockUseWallet.mockReturnValue({
+    address: null,
+    network: "TESTNET",
+    status: "disconnected",
+    error: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    ...overrides,
+  });
+}
 
 describe("TopNav Accessibility", () => {
   beforeEach(() => {
     window.sessionStorage.clear();
+    setWalletState();
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -33,6 +58,7 @@ describe("TopNav Accessibility", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("renders notification button with proper aria-label", () => {
@@ -130,5 +156,123 @@ describe("TopNav Accessibility", () => {
       expect(btn).toBeInTheDocument();
       expect(btn.tagName).toBe("BUTTON");
     });
+  });
+
+  it("shows a not-connected balance summary without fetching", () => {
+    renderTopNav();
+
+    fireEvent.click(screen.getByRole("button", { name: /wallet balances/i }));
+
+    expect(
+      screen.getByRole("dialog", { name: /wallet balance summary/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Not connected.")).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("loads and renders connected wallet balances with registry decimals", async () => {
+    setWalletState({
+      address: connectedAddress,
+      status: "connected",
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        balances: [
+          { asset_type: "native", balance: "0.0000000" },
+          {
+            asset_type: "credit_alphanum4",
+            asset_code: "USDC",
+            balance: "1234567.123456",
+          },
+        ],
+      }),
+    } as Response);
+
+    renderTopNav();
+    fireEvent.click(screen.getByRole("button", { name: /wallet balances/i }));
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading balances...");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/accounts/${connectedAddress}`),
+    );
+    expect(await screen.findByText("XLM")).toBeInTheDocument();
+    expect(screen.getByText("0.0000000")).toBeInTheDocument();
+    expect(screen.getByText("USDC")).toBeInTheDocument();
+    expect(screen.getByText("1,234,567.123456")).toBeInTheDocument();
+  });
+
+  it("shows unknown asset metadata and grouped large balances", async () => {
+    setWalletState({
+      address: connectedAddress,
+      status: "connected",
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        balances: [
+          {
+            asset_type: "credit_alphanum4",
+            asset_code: "DOGE",
+            balance: "987654321.1234567",
+          },
+        ],
+      }),
+    } as Response);
+
+    renderTopNav();
+    fireEvent.click(screen.getByRole("button", { name: /wallet balances/i }));
+
+    expect(await screen.findByText("DOGE")).toBeInTheDocument();
+    expect(screen.getByText(/Unknown asset/)).toBeInTheDocument();
+    expect(screen.getByText(/unregistered/)).toBeInTheDocument();
+    expect(screen.getByText("987,654,321.1234567")).toBeInTheDocument();
+  });
+
+  it("shows a non-blocking error state when the balance fetch fails", async () => {
+    setWalletState({
+      address: connectedAddress,
+      status: "connected",
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    renderTopNav();
+    fireEvent.click(screen.getByRole("button", { name: /wallet balances/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not load balances",
+    );
+    expect(
+      screen.getByRole("button", { name: /connected wallet/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the balance summary with Escape and restores focus", async () => {
+    setWalletState({
+      address: connectedAddress,
+      status: "connected",
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ balances: [] }),
+    } as Response);
+
+    renderTopNav();
+    const trigger = screen.getByRole("button", { name: /wallet balances/i });
+    fireEvent.click(trigger);
+
+    expect(
+      await screen.findByRole("dialog", { name: /wallet balance summary/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(trigger).toHaveFocus();
   });
 });

--- a/components/shared/layout/TopNav.tsx
+++ b/components/shared/layout/TopNav.tsx
@@ -1,9 +1,14 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { SearchBar } from "@/components/molecules/SearchBar";
 import { useSidebar } from "@/context/SidebarContext";
-import { Menu } from "lucide-react";
+import { Menu, WalletCards } from "lucide-react";
 import NotificationBell from "@/components/shared/layout/NotificationBell";
+import { useWallet } from "@/hooks/useWallet";
+import {
+  fetchWalletBalances,
+  type WalletBalanceSummaryItem,
+} from "@/lib/wallet/balances";
 
 declare global {
   interface Window {
@@ -16,8 +21,6 @@ declare global {
     };
   }
 }
-
-import { useWalletContext } from "@/context/WalletContext";
 
 /** Shared focus-visible classes for TopNav interactive elements */
 const focusClasses =
@@ -41,19 +44,76 @@ export const SidebarToggle = () => {
 const TopNav = () => {
   const {
     address: walletAddress,
+    network,
     status,
     error,
     connect: handleConnect,
     disconnect,
-  } = useWalletContext();
+  } = useWallet();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isBalanceOpen, setIsBalanceOpen] = useState(false);
+  const [balanceStatus, setBalanceStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
+  const [balances, setBalances] = useState<WalletBalanceSummaryItem[]>([]);
+  const balanceTriggerRef = useRef<HTMLButtonElement>(null);
 
   const loading = status === "connecting";
 
   const handleDisconnect = async () => {
     await disconnect();
     setIsDropdownOpen(false);
+    setIsBalanceOpen(false);
   };
+
+  const closeBalancePopover = useCallback(() => {
+    setIsBalanceOpen(false);
+    balanceTriggerRef.current?.focus();
+  }, []);
+
+  const loadBalances = useCallback(async () => {
+    if (!walletAddress) return;
+
+    setBalanceStatus("loading");
+    try {
+      const nextBalances = await fetchWalletBalances(walletAddress);
+      setBalances(nextBalances);
+      setBalanceStatus("success");
+    } catch {
+      setBalances([]);
+      setBalanceStatus("error");
+    }
+  }, [walletAddress]);
+
+  const handleBalanceToggle = () => {
+    setIsBalanceOpen((current) => {
+      const next = !current;
+      if (next && walletAddress) {
+        void loadBalances();
+      }
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    if (!isBalanceOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeBalancePopover();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [closeBalancePopover, isBalanceOpen]);
+
+  useEffect(() => {
+    if (!walletAddress) {
+      setBalances([]);
+      setBalanceStatus("idle");
+    }
+  }, [walletAddress]);
 
   const getShortAddress = (addr: string) => {
     return `${addr.slice(0, 5)}...${addr.slice(-4)}`;
@@ -122,7 +182,7 @@ const TopNav = () => {
                   <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg py-1 z-50 border border-gray-200 dark:border-gray-700">
                     <button
                       type="button"
-                      onClick={disconnect}
+                      onClick={handleDisconnect}
                       className="block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:bg-gray-100 text-red-600 font-medium"
                     >
                       Disconnect Wallet
@@ -148,6 +208,98 @@ const TopNav = () => {
               >
                 {error}
               </span>
+            )}
+          </div>
+
+          <div className="relative">
+            <button
+              ref={balanceTriggerRef}
+              type="button"
+              aria-label="Wallet balances"
+              aria-expanded={isBalanceOpen}
+              aria-controls="topnav-wallet-balances"
+              onClick={handleBalanceToggle}
+              className={`flex cursor-pointer hover:bg-white/30 items-center text-white text-sm justify-center border py-2 px-3 rounded-full ${focusClasses}`}
+            >
+              <WalletCards className="h-4 w-4" aria-hidden="true" />
+            </button>
+
+            {isBalanceOpen && (
+              <div
+                id="topnav-wallet-balances"
+                role="dialog"
+                aria-label="Wallet balance summary"
+                className="absolute right-0 mt-2 w-72 bg-white dark:bg-gray-800 rounded-md shadow-lg z-50 border border-gray-200 dark:border-gray-700 p-4 text-gray-900 dark:text-gray-100"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold">Wallet balances</h2>
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      {walletAddress
+                        ? `${network} · ${getShortAddress(walletAddress)}`
+                        : "Connect a wallet to view balances."}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={closeBalancePopover}
+                    className={`text-xs text-gray-500 hover:text-gray-900 dark:hover:text-white ${focusClasses}`}
+                  >
+                    Close
+                  </button>
+                </div>
+
+                {!walletAddress && (
+                  <p className="mt-4 text-sm text-gray-600 dark:text-gray-300">
+                    Not connected.
+                  </p>
+                )}
+
+                {walletAddress && balanceStatus === "loading" && (
+                  <p
+                    role="status"
+                    className="mt-4 text-sm text-gray-600 dark:text-gray-300"
+                  >
+                    Loading balances...
+                  </p>
+                )}
+
+                {walletAddress && balanceStatus === "error" && (
+                  <p role="alert" className="mt-4 text-sm text-red-600">
+                    Could not load balances. Try again later.
+                  </p>
+                )}
+
+                {walletAddress && balanceStatus === "success" && (
+                  <ul className="mt-4 space-y-3">
+                    {balances.length === 0 ? (
+                      <li className="text-sm text-gray-600 dark:text-gray-300">
+                        No balances found for this account.
+                      </li>
+                    ) : (
+                      balances.map((balance) => (
+                        <li
+                          key={`${balance.symbol}-${balance.name}`}
+                          className="flex items-center justify-between gap-3"
+                        >
+                          <div>
+                            <p className="text-sm font-medium">
+                              {balance.symbol}
+                            </p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                              {balance.name}
+                              {!balance.hasMetadata ? " · unregistered" : ""}
+                            </p>
+                          </div>
+                          <span className="text-sm font-semibold">
+                            {balance.formatted}
+                          </span>
+                        </li>
+                      ))
+                    )}
+                  </ul>
+                )}
+              </div>
             )}
           </div>
 

--- a/docs/topnav-wallet-balance.md
+++ b/docs/topnav-wallet-balance.md
@@ -1,0 +1,32 @@
+# TopNav Wallet Balance Summary
+
+The TopNav wallet balance summary gives connected users a compact account
+balance view without leaving the dashboard.
+
+## Data Sources
+
+- Wallet connection state comes from `hooks/useWallet.ts`.
+- Balances are loaded from Horizon using the connected account:
+  `/accounts/:accountId`.
+- Asset labels and display precision come from `lib/assets/registry.ts`.
+
+The popover never blocks TopNav rendering. Balance loading starts only when the
+summary is opened for a connected wallet.
+
+## States
+
+- Disconnected: the popover explains that a wallet must be connected.
+- Loading: the popover shows a lightweight status message while Horizon loads.
+- Success: balances render per asset, with XLM first and other symbols sorted.
+- Empty: a connected account with no returned balances shows an empty message.
+- Error: Horizon failures show an inline error but keep the navigation usable.
+
+Unknown asset codes remain visible with fallback metadata and an `unregistered`
+label so users can still inspect the raw balance.
+
+## Accessibility
+
+- The trigger exposes `aria-label="Wallet balances"`.
+- The panel uses `role="dialog"` and a descriptive label.
+- Escape closes the panel and returns focus to the trigger.
+- The close action is keyboard operable.

--- a/lib/wallet/balances.test.ts
+++ b/lib/wallet/balances.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchWalletBalances,
+  formatWalletBalance,
+  normalizeWalletBalances,
+} from "./balances";
+
+const assets = [
+  {
+    symbol: "XLM",
+    name: "Stellar Lumens",
+    decimals: 7,
+    issuer: "native",
+    logoUrl: "https://example.com/xlm.png",
+  },
+  {
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: 6,
+    issuer: "GISSUER",
+    logoUrl: "https://example.com/usdc.png",
+  },
+];
+
+describe("wallet balances", () => {
+  it("formats native balances with registry decimals", () => {
+    expect(
+      formatWalletBalance(
+        { asset_type: "native", balance: "0.0000000" },
+        assets,
+      ),
+    ).toMatchObject({
+      symbol: "XLM",
+      name: "Stellar Lumens",
+      formatted: "0.0000000",
+      hasMetadata: true,
+    });
+  });
+
+  it("formats credit balances with grouping and asset metadata", () => {
+    expect(
+      formatWalletBalance(
+        {
+          asset_type: "credit_alphanum4",
+          asset_code: "USDC",
+          balance: "1234567.123456",
+        },
+        assets,
+      ),
+    ).toMatchObject({
+      symbol: "USDC",
+      name: "USD Coin",
+      formatted: "1,234,567.123456",
+      hasMetadata: true,
+    });
+  });
+
+  it("keeps unknown asset balances visible with fallback metadata", () => {
+    expect(
+      formatWalletBalance(
+        {
+          asset_type: "credit_alphanum4",
+          asset_code: "DOGE",
+          balance: "42.1",
+        },
+        assets,
+      ),
+    ).toMatchObject({
+      symbol: "DOGE",
+      name: "Unknown asset",
+      formatted: "42.1000000",
+      hasMetadata: false,
+    });
+  });
+
+  it("sorts XLM first and then symbols alphabetically", () => {
+    expect(
+      normalizeWalletBalances(
+        [
+          { asset_type: "credit_alphanum4", asset_code: "USDC", balance: "2" },
+          { asset_type: "native", balance: "1" },
+          { asset_type: "credit_alphanum4", asset_code: "DOGE", balance: "3" },
+        ],
+        assets,
+      ).map((balance) => balance.symbol),
+    ).toEqual(["XLM", "DOGE", "USDC"]);
+  });
+
+  it("fetches balances from the configured Horizon account endpoint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          balances: [{ asset_type: "native", balance: "12.5" }],
+        }),
+      }),
+    );
+
+    await expect(
+      fetchWalletBalances("GABC", "https://horizon.example.com/"),
+    ).resolves.toMatchObject([{ symbol: "XLM" }]);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://horizon.example.com/accounts/GABC",
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("throws when Horizon rejects the account lookup", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({}),
+      }),
+    );
+
+    await expect(
+      fetchWalletBalances("GABC", "https://horizon.example.com"),
+    ).rejects.toThrow("Unable to load wallet balances");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/lib/wallet/balances.ts
+++ b/lib/wallet/balances.ts
@@ -1,0 +1,76 @@
+import { getAssets, type AssetMetadata } from "@/lib/assets/registry";
+import { publicConfig } from "@/lib/config";
+import { formatCurrency } from "@/lib/utils/format";
+
+interface HorizonBalance {
+  balance: string;
+  asset_type: string;
+  asset_code?: string;
+}
+
+interface HorizonAccountResponse {
+  balances?: HorizonBalance[];
+}
+
+export interface WalletBalanceSummaryItem {
+  symbol: string;
+  name: string;
+  amount: number;
+  formatted: string;
+  hasMetadata: boolean;
+}
+
+function getBalanceSymbol(balance: HorizonBalance): string {
+  return balance.asset_type === "native"
+    ? "XLM"
+    : balance.asset_code || "UNKNOWN";
+}
+
+export function formatWalletBalance(
+  balance: HorizonBalance,
+  assets: AssetMetadata[] = getAssets(),
+): WalletBalanceSummaryItem {
+  const symbol = getBalanceSymbol(balance);
+  const metadata = assets.find((asset) => asset.symbol === symbol);
+  const amount = Number(balance.balance);
+  const safeAmount = Number.isFinite(amount) ? amount : 0;
+  const decimals = metadata?.decimals ?? 7;
+
+  return {
+    symbol,
+    name: metadata?.name ?? "Unknown asset",
+    amount: safeAmount,
+    formatted: formatCurrency(safeAmount, decimals),
+    hasMetadata: Boolean(metadata),
+  };
+}
+
+export function normalizeWalletBalances(
+  balances: HorizonBalance[] = [],
+  assets: AssetMetadata[] = getAssets(),
+): WalletBalanceSummaryItem[] {
+  return balances
+    .map((balance) => formatWalletBalance(balance, assets))
+    .sort((a, b) => {
+      if (a.symbol === "XLM") return -1;
+      if (b.symbol === "XLM") return 1;
+      return a.symbol.localeCompare(b.symbol);
+    });
+}
+
+export async function fetchWalletBalances(
+  account: string,
+  horizonUrl: string = publicConfig.stellar.horizonUrl,
+): Promise<WalletBalanceSummaryItem[]> {
+  const baseUrl = horizonUrl.replace(/\/$/, "");
+  const response = await fetch(
+    `${baseUrl}/accounts/${encodeURIComponent(account)}`,
+  );
+
+  if (!response.ok) {
+    throw new Error("Unable to load wallet balances");
+  }
+
+  const data = (await response.json()) as HorizonAccountResponse;
+  return normalizeWalletBalances(data.balances ?? []);
+}


### PR DESCRIPTION
## Summary
- add a keyboard-accessible wallet balances popover to TopNav
- load connected account balances from Horizon without blocking navigation
- format balances with asset registry metadata/decimals and keep unknown assets visible
- cover disconnected/loading/success/error/Escape states plus balance normalization
- document data sources and states

Closes #662

## Validation
- pnpm vitest run components/shared/layout/TopNav.test.tsx lib/wallet/balances.test.ts --project accessibility --project server-unit --reporter=dot
- pnpm exec prettier --check components/shared/layout/TopNav.tsx components/shared/layout/TopNav.test.tsx lib/wallet/balances.ts lib/wallet/balances.test.ts docs/topnav-wallet-balance.md
- git diff --check

## Notes
- pnpm exec eslint components/shared/layout/TopNav.tsx components/shared/layout/TopNav.test.tsx lib/wallet/balances.ts lib/wallet/balances.test.ts is currently blocked because ESLint 9 cannot find a flat eslint.config.* file.
- TopNav tests mock SearchBar because existing components/molecules/SearchBar/SearchBar.tsx has a parse error unrelated to this change.