### PR TITLE
Add notification dismiss and clear-all actions

### DIFF
--- a/app/api/notifications/[id]/route.test.ts
+++ b/app/api/notifications/[id]/route.test.ts
@@ -1,29 +1,41 @@
-import { NextRequest } from 'next/server';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock('@/lib/auth', () => ({
+vi.mock("@/lib/auth", () => ({
   getUser: vi.fn(),
 }));
 
-vi.mock('@/lib/notifications/repository', () => ({
+vi.mock("@/lib/notifications/repository", () => ({
+  deleteNotification: vi.fn(),
   markNotificationRead: vi.fn(),
 }));
 
-vi.mock('@/lib/api/handler', () => ({
-  withCsrfProtection: <T extends (...args: any[]) => any>(handler: T) => handler,
+vi.mock("@/lib/api/handler", () => ({
+  withCsrfProtection: <T extends (...args: any[]) => any>(handler: T) =>
+    handler,
 }));
 
-import { PATCH } from './route';
-import { getUser } from '@/lib/auth';
-import { markNotificationRead } from '@/lib/notifications/repository';
-import type { Notification } from '@/lib/notifications/types';
+import { DELETE, PATCH } from "./route";
+import { getUser } from "@/lib/auth";
+import {
+  deleteNotification,
+  markNotificationRead,
+} from "@/lib/notifications/repository";
+import type { Notification } from "@/lib/notifications/types";
 
 const mockGetUser = vi.mocked(getUser);
+const mockDeleteNotification = vi.mocked(deleteNotification);
 const mockMarkNotificationRead = vi.mocked(markNotificationRead);
 
-function patchRequest(id = 'notif-1') {
+function patchRequest(id = "notif-1") {
   return new NextRequest(`http://localhost:3000/api/notifications/${id}`, {
-    method: 'PATCH',
+    method: "PATCH",
+  });
+}
+
+function deleteRequest(id = "notif-1") {
+  return new NextRequest(`http://localhost:3000/api/notifications/${id}`, {
+    method: "DELETE",
   });
 }
 
@@ -35,86 +47,171 @@ function routeContext(id: string) {
 
 function notification(overrides: Partial<Notification> = {}): Notification {
   return {
-    id: 'notif-1',
-    userId: 'user-1',
-    title: 'Deposit Confirmed',
-    message: 'Your deposit has been confirmed.',
+    id: "notif-1",
+    userId: "user-1",
+    title: "Deposit Confirmed",
+    message: "Your deposit has been confirmed.",
     read: true,
-    createdAt: '2026-05-26T10:00:00.000Z',
-    type: 'success',
+    createdAt: "2026-05-26T10:00:00.000Z",
+    type: "success",
     ...overrides,
   };
 }
 
-describe('PATCH /api/notifications/[id]', () => {
+describe("PATCH /api/notifications/[id]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns 401 when the user is not authenticated', async () => {
+  it("returns 401 when the user is not authenticated", async () => {
     mockGetUser.mockResolvedValueOnce(null as any);
 
-    const response = await PATCH(patchRequest(), routeContext('notif-1'));
+    const response = await PATCH(patchRequest(), routeContext("notif-1"));
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body).toEqual({ error: 'Unauthorized' });
+    expect(body).toEqual({ error: "Unauthorized" });
     expect(mockMarkNotificationRead).not.toHaveBeenCalled();
   });
 
-  it('returns 400 for a blank notification id', async () => {
-    mockGetUser.mockResolvedValueOnce({ id: 'user-1' } as any);
+  it("returns 400 for a blank notification id", async () => {
+    mockGetUser.mockResolvedValueOnce({ id: "user-1" } as any);
 
-    const response = await PATCH(patchRequest('blank'), routeContext('   '));
+    const response = await PATCH(patchRequest("blank"), routeContext("   "));
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body).toEqual({ error: 'Invalid notification id' });
+    expect(body).toEqual({ error: "Invalid notification id" });
     expect(mockMarkNotificationRead).not.toHaveBeenCalled();
   });
 
-  it('marks the current user notification read and returns the updated record', async () => {
+  it("marks the current user notification read and returns the updated record", async () => {
     const updated = notification();
-    mockGetUser.mockResolvedValueOnce({ id: 'user-1' } as any);
+    mockGetUser.mockResolvedValueOnce({ id: "user-1" } as any);
     mockMarkNotificationRead.mockResolvedValueOnce(updated);
 
-    const response = await PATCH(patchRequest(), routeContext('notif-1'));
+    const response = await PATCH(patchRequest(), routeContext("notif-1"));
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mockMarkNotificationRead).toHaveBeenCalledWith('user-1', 'notif-1');
+    expect(mockMarkNotificationRead).toHaveBeenCalledWith("user-1", "notif-1");
     expect(body).toEqual({ notification: updated });
   });
 
-  it('trims the route id before sending it to the repository', async () => {
-    const updated = notification({ id: 'notif-trimmed' });
-    mockGetUser.mockResolvedValueOnce({ id: 'user-1' } as any);
+  it("trims the route id before sending it to the repository", async () => {
+    const updated = notification({ id: "notif-trimmed" });
+    mockGetUser.mockResolvedValueOnce({ id: "user-1" } as any);
     mockMarkNotificationRead.mockResolvedValueOnce(updated);
 
-    const response = await PATCH(patchRequest('notif-trimmed'), routeContext(' notif-trimmed '));
+    const response = await PATCH(
+      patchRequest("notif-trimmed"),
+      routeContext(" notif-trimmed "),
+    );
 
     expect(response.status).toBe(200);
-    expect(mockMarkNotificationRead).toHaveBeenCalledWith('user-1', 'notif-trimmed');
+    expect(mockMarkNotificationRead).toHaveBeenCalledWith(
+      "user-1",
+      "notif-trimmed",
+    );
   });
 
-  it('returns 404 when the notification id is unknown for the current user', async () => {
-    mockGetUser.mockResolvedValueOnce({ id: 'user-1' } as any);
+  it("returns 404 when the notification id is unknown for the current user", async () => {
+    mockGetUser.mockResolvedValueOnce({ id: "user-1" } as any);
     mockMarkNotificationRead.mockResolvedValueOnce(null);
 
-    const response = await PATCH(patchRequest('missing'), routeContext('missing'));
+    const response = await PATCH(
+      patchRequest("missing"),
+      routeContext("missing"),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(404);
-    expect(body).toEqual({ error: 'Notification not found' });
+    expect(body).toEqual({ error: "Notification not found" });
   });
 
-  it('does not expose another user notification when the repository denies ownership', async () => {
-    mockGetUser.mockResolvedValueOnce({ id: 'user-2' } as any);
+  it("does not expose another user notification when the repository denies ownership", async () => {
+    mockGetUser.mockResolvedValueOnce({ id: "user-2" } as any);
     mockMarkNotificationRead.mockResolvedValueOnce(null);
 
-    const response = await PATCH(patchRequest('notif-1'), routeContext('notif-1'));
+    const response = await PATCH(
+      patchRequest("notif-1"),
+      routeContext("notif-1"),
+    );
 
     expect(response.status).toBe(404);
-    expect(mockMarkNotificationRead).toHaveBeenCalledWith('user-2', 'notif-1');
+    expect(mockMarkNotificationRead).toHaveBeenCalledWith("user-2", "notif-1");
+  });
+});
+
+describe("DELETE /api/notifications/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when the user is not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce(null as any);
+
+    const response = await DELETE(deleteRequest(), routeContext("notif-1"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: "Unauthorized" });
+    expect(mockDeleteNotification).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a blank notification id", async () => {
+    mockGetUser.mockResolvedValueOnce({ id: "user-1" } as any);
+
+    const response = await DELETE(deleteRequest("blank"), routeContext("   "));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ error: "Invalid notification id" });
+    expect(mockDeleteNotification).not.toHaveBeenCalled();
+  });
+
+  it("deletes the current user notification and returns the removed record", async () => {
+    const removed = notification({ read: false });
+    mockGetUser.mockResolvedValueOnce({ id: "user-1" } as any);
+    mockDeleteNotification.mockResolvedValueOnce(removed);
+
+    const response = await DELETE(deleteRequest(), routeContext("notif-1"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteNotification).toHaveBeenCalledWith("user-1", "notif-1");
+    expect(body).toEqual({ notification: removed });
+  });
+
+  it("trims the route id before deleting", async () => {
+    const removed = notification({ id: "notif-trimmed" });
+    mockGetUser.mockResolvedValueOnce({ id: "user-1" } as any);
+    mockDeleteNotification.mockResolvedValueOnce(removed);
+
+    const response = await DELETE(
+      deleteRequest("notif-trimmed"),
+      routeContext(" notif-trimmed "),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteNotification).toHaveBeenCalledWith(
+      "user-1",
+      "notif-trimmed",
+    );
+  });
+
+  it("returns 404 when the notification is not owned by the current user", async () => {
+    mockGetUser.mockResolvedValueOnce({ id: "user-2" } as any);
+    mockDeleteNotification.mockResolvedValueOnce(null);
+
+    const response = await DELETE(
+      deleteRequest("notif-1"),
+      routeContext("notif-1"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({ error: "Notification not found" });
+    expect(mockDeleteNotification).toHaveBeenCalledWith("user-2", "notif-1");
   });
 });

--- a/app/api/notifications/[id]/route.ts
+++ b/app/api/notifications/[id]/route.ts
@@ -1,9 +1,12 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getUser } from '@/lib/auth';
-import { markNotificationRead } from '@/lib/notifications/repository';
-import { withCsrfProtection } from '@/lib/api/handler';
+import { NextRequest, NextResponse } from "next/server";
+import { getUser } from "@/lib/auth";
+import {
+  deleteNotification,
+  markNotificationRead,
+} from "@/lib/notifications/repository";
+import { withCsrfProtection } from "@/lib/api/handler";
 
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
 /** PATCH /api/notifications/:id
  *
@@ -27,21 +30,62 @@ const patchHandler = async (
 ) => {
   const user = await getUser();
   if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const { id } = await params;
 
-  if (!id || typeof id !== 'string' || id.trim() === '') {
-    return NextResponse.json({ error: 'Invalid notification id' }, { status: 400 });
+  if (!id || typeof id !== "string" || id.trim() === "") {
+    return NextResponse.json(
+      { error: "Invalid notification id" },
+      { status: 400 },
+    );
   }
 
   const notification = await markNotificationRead(user.id, id.trim());
   if (!notification) {
-    return NextResponse.json({ error: 'Notification not found' }, { status: 404 });
+    return NextResponse.json(
+      { error: "Notification not found" },
+      { status: 404 },
+    );
   }
 
   return NextResponse.json({ notification });
 };
 
 export const PATCH = withCsrfProtection(patchHandler);
+
+/** DELETE /api/notifications/:id
+ *
+ * Deletes a notification for the authenticated user.
+ */
+const deleteHandler = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  if (!id || typeof id !== "string" || id.trim() === "") {
+    return NextResponse.json(
+      { error: "Invalid notification id" },
+      { status: 400 },
+    );
+  }
+
+  const notification = await deleteNotification(user.id, id.trim());
+  if (!notification) {
+    return NextResponse.json(
+      { error: "Notification not found" },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ notification });
+};
+
+export const DELETE = withCsrfProtection(deleteHandler);

--- a/components/shared/layout/NotificationBell.memo.test.tsx
+++ b/components/shared/layout/NotificationBell.memo.test.tsx
@@ -3,10 +3,15 @@ import { render, screen } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const { streamFn } = vi.hoisted(() => ({ streamFn: vi.fn() }));
+const { pinsFn } = vi.hoisted(() => ({ pinsFn: vi.fn() }));
 
 vi.mock("@/hooks/useNotificationStream", () => ({
   default: streamFn,
   useNotificationStream: streamFn,
+}));
+
+vi.mock("@/hooks/useNotificationPins", () => ({
+  useNotificationPins: pinsFn,
 }));
 
 import NotificationBell from "./NotificationBell";
@@ -14,15 +19,23 @@ import NotificationBell from "./NotificationBell";
 describe("NotificationBell memoization", () => {
   beforeEach(() => {
     streamFn.mockReturnValue({ unreadCount: 0 });
+    pinsFn.mockReturnValue({
+      pinnedIds: new Set<string>(),
+      togglePin: vi.fn(),
+      isPinned: vi.fn().mockReturnValue(false),
+    });
   });
 
   afterEach(() => {
     streamFn.mockReset();
+    pinsFn.mockReset();
   });
 
   it("does not recompute display values when unreadCount is unchanged", () => {
     const { container, rerender } = render(<NotificationBell />);
-    expect(screen.getByLabelText("No unread notifications")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("No unread notifications"),
+    ).toBeInTheDocument();
 
     const initialHtml = container.innerHTML;
 
@@ -33,15 +46,15 @@ describe("NotificationBell memoization", () => {
 
   it("updates badge when a new notification arrives", () => {
     const { rerender } = render(<NotificationBell />);
-    expect(screen.getByLabelText("No unread notifications")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("No unread notifications"),
+    ).toBeInTheDocument();
 
     streamFn.mockReturnValue({ unreadCount: 3 });
     rerender(<NotificationBell />);
 
     expect(screen.getByText("3")).toBeInTheDocument();
-    expect(
-      screen.getByLabelText("3 unread notifications"),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText("3 unread notifications")).toBeInTheDocument();
   });
 
   it("updates badge when notifications are marked as read", () => {
@@ -53,9 +66,7 @@ describe("NotificationBell memoization", () => {
     rerender(<NotificationBell />);
 
     expect(screen.getByText("2")).toBeInTheDocument();
-    expect(
-      screen.getByLabelText("2 unread notifications"),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText("2 unread notifications")).toBeInTheDocument();
   });
 
   it("transitions from zero to non-zero and back to zero", () => {
@@ -68,7 +79,9 @@ describe("NotificationBell memoization", () => {
 
     streamFn.mockReturnValue({ unreadCount: 0 });
     rerender(<NotificationBell />);
-    expect(screen.getByLabelText("No unread notifications")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("No unread notifications"),
+    ).toBeInTheDocument();
   });
 
   it("keeps 99+ cap when count stays above threshold across re-renders", () => {

--- a/components/shared/layout/NotificationBell.test.tsx
+++ b/components/shared/layout/NotificationBell.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, waitFor } from "@/test/test-utils";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const { streamFn } = vi.hoisted(() => ({ streamFn: vi.fn() }));
@@ -61,21 +62,65 @@ function setupDefaultMocks() {
   setupPinsMock();
 }
 
+function setupFetchMock(notifications: Notification[] = mockNotifications) {
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+
+      if (url === "/api/notifications" && method === "GET") {
+        return Response.json({ notifications });
+      }
+
+      if (url === "/api/notifications/read-all" && method === "PATCH") {
+        return Response.json({ ok: true });
+      }
+
+      if (url.startsWith("/api/notifications/") && method === "PATCH") {
+        return Response.json({ ok: true });
+      }
+
+      if (url.startsWith("/api/notifications/") && method === "DELETE") {
+        return Response.json({ ok: true });
+      }
+
+      return new Response(null, { status: 404 });
+    },
+  );
+
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+async function openPanel(options: { waitForFirstNotification?: boolean } = {}) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /notification/i }));
+  await screen.findByTestId("notification-panel");
+  if (options.waitForFirstNotification ?? true) {
+    await screen.findByText("Deposit Confirmed");
+  }
+  return user;
+}
+
 describe("NotificationBell", () => {
   beforeEach(() => {
     setupDefaultMocks();
+    setupFetchMock();
   });
 
   afterEach(() => {
     streamFn.mockReset();
     pinsFn.mockReset();
+    vi.unstubAllGlobals();
   });
 
   describe("badge and label", () => {
     it("hides the badge and exposes a no-unread label when count is zero", () => {
       render(<NotificationBell />);
       expect(screen.queryByText("99+")).not.toBeInTheDocument();
-      expect(screen.getByLabelText("No unread notifications")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("No unread notifications"),
+      ).toBeInTheDocument();
     });
 
     it("shows the count and a singular label when unreadCount is 1", () => {
@@ -121,6 +166,143 @@ describe("NotificationBell", () => {
       expect(
         screen.getByLabelText("1500 unread notifications"),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("dismiss actions", () => {
+    it("dismisses a single notification and updates the local unread badge", async () => {
+      streamFn.mockReturnValue({ unreadCount: 2 });
+      render(<NotificationBell />);
+
+      const user = await openPanel();
+      await user.click(screen.getByTestId("dismiss-n1"));
+
+      expect(screen.queryByText("Deposit Confirmed")).not.toBeInTheDocument();
+      expect(screen.getByText("1")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("1 unread notification"),
+      ).toBeInTheDocument();
+      expect(fetch).toHaveBeenCalledWith("/api/notifications/n1", {
+        method: "DELETE",
+      });
+    });
+
+    it("restores a dismissed notification when the delete request fails", async () => {
+      streamFn.mockReturnValue({ unreadCount: 2 });
+      const fetchMock = setupFetchMock();
+      fetchMock.mockImplementation(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = input.toString();
+          const method = init?.method ?? "GET";
+
+          if (url === "/api/notifications" && method === "GET") {
+            return Response.json({ notifications: mockNotifications });
+          }
+
+          if (url === "/api/notifications/n1" && method === "DELETE") {
+            return new Response(null, { status: 500 });
+          }
+
+          return Response.json({ ok: true });
+        },
+      );
+
+      render(<NotificationBell />);
+
+      const user = await openPanel();
+      await user.click(screen.getByTestId("dismiss-n1"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Deposit Confirmed")).toBeInTheDocument();
+      });
+      expect(screen.getByText("2")).toBeInTheDocument();
+    });
+
+    it("clears all loaded notifications by deleting each item", async () => {
+      streamFn.mockReturnValue({ unreadCount: 2 });
+      render(<NotificationBell />);
+
+      const user = await openPanel();
+      await user.click(screen.getByTestId("clear-all-notifications"));
+
+      expect(screen.getByTestId("empty-state")).toHaveTextContent(
+        "No notifications yet",
+      );
+      expect(
+        screen.getByLabelText("No unread notifications"),
+      ).toBeInTheDocument();
+      expect(fetch).toHaveBeenCalledWith("/api/notifications/n1", {
+        method: "DELETE",
+      });
+      expect(fetch).toHaveBeenCalledWith("/api/notifications/n2", {
+        method: "DELETE",
+      });
+      expect(fetch).toHaveBeenCalledWith("/api/notifications/n3", {
+        method: "DELETE",
+      });
+    });
+
+    it("shows the empty state after dismissing the last loaded notification", async () => {
+      streamFn.mockReturnValue({ unreadCount: 1 });
+      setupFetchMock([mockNotifications[0]]);
+      render(<NotificationBell />);
+
+      const user = await openPanel();
+      await user.click(screen.getByTestId("dismiss-n1"));
+
+      expect(screen.getByTestId("empty-state")).toHaveTextContent(
+        "No notifications yet",
+      );
+      expect(
+        screen.getByLabelText("No unread notifications"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render clear all when there are zero loaded notifications", async () => {
+      setupFetchMock([]);
+      render(<NotificationBell />);
+
+      await openPanel({ waitForFirstNotification: false });
+
+      expect(
+        screen.queryByTestId("clear-all-notifications"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("empty-state")).toHaveTextContent(
+        "No notifications yet",
+      );
+    });
+
+    it("restores the list when clear all cannot delete every notification", async () => {
+      streamFn.mockReturnValue({ unreadCount: 2 });
+      const fetchMock = setupFetchMock();
+      fetchMock.mockImplementation(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = input.toString();
+          const method = init?.method ?? "GET";
+
+          if (url === "/api/notifications" && method === "GET") {
+            return Response.json({ notifications: mockNotifications });
+          }
+
+          if (url === "/api/notifications/n2" && method === "DELETE") {
+            return new Response(null, { status: 500 });
+          }
+
+          return Response.json({ ok: true });
+        },
+      );
+
+      render(<NotificationBell />);
+
+      const user = await openPanel();
+      await user.click(screen.getByTestId("clear-all-notifications"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Deposit Confirmed")).toBeInTheDocument();
+        expect(screen.getByText("Rate Update")).toBeInTheDocument();
+        expect(screen.getByText("Old Notification")).toBeInTheDocument();
+      });
+      expect(screen.getByText("2")).toBeInTheDocument();
     });
   });
 });

--- a/components/shared/layout/NotificationBell.tsx
+++ b/components/shared/layout/NotificationBell.tsx
@@ -1,53 +1,73 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react';
-import dynamic from 'next/dynamic';
-import { IconButton } from '@/components/atoms/IconButton/IconButton';
-import { IconPlaceholder } from '@/components/shared/ui/icons/IconPlaceholder';
-import useNotificationStream from '@/hooks/useNotificationStream';
-import { useNotificationPins } from '@/hooks/useNotificationPins';
+import React, {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  useMemo,
+} from "react";
+import dynamic from "next/dynamic";
+import { IconButton } from "@/components/atoms/IconButton/IconButton";
+import { IconPlaceholder } from "@/components/shared/ui/icons/IconPlaceholder";
+import useNotificationStream from "@/hooks/useNotificationStream";
+import { useNotificationPins } from "@/hooks/useNotificationPins";
 import {
   groupNotifications,
   sortGroupedNotifications,
   getDateGroupLabel,
   type DateGroup,
-} from '@/lib/notifications/grouping';
-import type { Notification } from '@/lib/notifications/types';
+} from "@/lib/notifications/grouping";
+import type { Notification } from "@/lib/notifications/types";
 
-const NotificationIcon = dynamic(() => import('@/components/shared/ui/icons/Notification').then(mod => ({ default: mod.Notification })), {
-  loading: () => <IconPlaceholder />,
-  ssr: true,
-});
+const NotificationIcon = dynamic(
+  () =>
+    import("@/components/shared/ui/icons/Notification").then((mod) => ({
+      default: mod.Notification,
+    })),
+  {
+    loading: () => <IconPlaceholder />,
+    ssr: true,
+  },
+);
 
-const dateGroups: DateGroup[] = ['today', 'earlier_this_week', 'older'];
+const dateGroups: DateGroup[] = ["today", "earlier_this_week", "older"];
 
 function timeAgo(dateStr: string): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();
   const diffMs = now - then;
   const diffMins = Math.floor(diffMs / 60000);
-  if (diffMins < 1) return 'just now';
+  if (diffMins < 1) return "just now";
   if (diffMins < 60) return `${diffMins}m ago`;
   const diffHours = Math.floor(diffMins / 60);
   if (diffHours < 24) return `${diffHours}h ago`;
   const diffDays = Math.floor(diffHours / 24);
-  if (diffDays === 1) return 'yesterday';
+  if (diffDays === 1) return "yesterday";
   return `${diffDays}d ago`;
 }
 
-function typeIcon(type: Notification['type']): string {
+function typeIcon(type: Notification["type"]): string {
   switch (type) {
-    case 'success': return '●';
-    case 'warning': return '●';
-    case 'error': return '●';
-    default: return '●';
+    case "success":
+      return "●";
+    case "warning":
+      return "●";
+    case "error":
+      return "●";
+    default:
+      return "●";
   }
 }
 
-function typeColor(type: Notification['type']): string {
+function typeColor(type: Notification["type"]): string {
   switch (type) {
-    case 'success': return 'text-green-500';
-    case 'warning': return 'text-amber-500';
-    case 'error': return 'text-red-500';
-    default: return 'text-blue-500';
+    case "success":
+      return "text-green-500";
+    case "warning":
+      return "text-amber-500";
+    case "error":
+      return "text-red-500";
+    default:
+      return "text-blue-500";
   }
 }
 
@@ -58,7 +78,10 @@ const NotificationBell = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(false);
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<DateGroup>>(new Set());
+  const [hasLoadedNotifications, setHasLoadedNotifications] = useState(false);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<DateGroup>>(
+    new Set(),
+  );
 
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -66,27 +89,32 @@ const NotificationBell = () => {
 
   useEffect(() => {
     isMountedRef.current = true;
-    return () => { isMountedRef.current = false; };
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
   const fetchNotifications = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch('/api/notifications');
+      const res = await fetch("/api/notifications");
       if (!res.ok) {
         if (res.status === 401) {
           setNotifications([]);
+          setHasLoadedNotifications(true);
           return;
         }
-        throw new Error('Failed to fetch');
+        throw new Error("Failed to fetch");
       }
       const data = await res.json();
       if (isMountedRef.current) {
         setNotifications(data.notifications ?? []);
+        setHasLoadedNotifications(true);
       }
     } catch {
       if (isMountedRef.current) {
         setNotifications([]);
+        setHasLoadedNotifications(true);
       }
     } finally {
       if (isMountedRef.current) {
@@ -112,7 +140,7 @@ const NotificationBell = () => {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      if (e.key === "Escape") {
         closePanel();
       }
     },
@@ -128,25 +156,24 @@ const NotificationBell = () => {
     }
   }, [isOpen]);
 
-  const handleMarkRead = useCallback(
-    async (id: string) => {
-      try {
-        const res = await fetch(`/api/notifications/${id}`, { method: 'PATCH' });
-        if (res.ok) {
-          setNotifications((prev) =>
-            prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
-          );
-        }
-      } catch {
-        // silently fail
+  const handleMarkRead = useCallback(async (id: string) => {
+    try {
+      const res = await fetch(`/api/notifications/${id}`, { method: "PATCH" });
+      if (res.ok) {
+        setNotifications((prev) =>
+          prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+        );
       }
-    },
-    [],
-  );
+    } catch {
+      // silently fail
+    }
+  }, []);
 
   const handleMarkAllRead = useCallback(async () => {
     try {
-      const res = await fetch('/api/notifications/read-all', { method: 'PATCH' });
+      const res = await fetch("/api/notifications/read-all", {
+        method: "PATCH",
+      });
       if (res.ok) {
         setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
       }
@@ -154,6 +181,50 @@ const NotificationBell = () => {
       // silently fail
     }
   }, []);
+
+  const handleDismiss = useCallback(
+    async (id: string) => {
+      const previousNotifications = notifications;
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
+
+      try {
+        const res = await fetch(`/api/notifications/${id}`, {
+          method: "DELETE",
+        });
+        if (!res.ok) {
+          throw new Error("Failed to dismiss notification");
+        }
+      } catch {
+        if (isMountedRef.current) {
+          setNotifications(previousNotifications);
+        }
+      }
+    },
+    [notifications],
+  );
+
+  const handleClearAll = useCallback(async () => {
+    const previousNotifications = notifications;
+    if (previousNotifications.length === 0) return;
+
+    setNotifications([]);
+
+    try {
+      const results = await Promise.all(
+        previousNotifications.map((n) =>
+          fetch(`/api/notifications/${n.id}`, { method: "DELETE" }),
+        ),
+      );
+
+      if (results.some((res) => !res.ok)) {
+        throw new Error("Failed to clear notifications");
+      }
+    } catch {
+      if (isMountedRef.current) {
+        setNotifications(previousNotifications);
+      }
+    }
+  }, [notifications]);
 
   const toggleGroup = useCallback((group: DateGroup) => {
     setCollapsedGroups((prev) => {
@@ -173,27 +244,33 @@ const NotificationBell = () => {
   const hasPinned = grouped.pinned.length > 0;
   const hasUnread = notifications.some((n) => !n.read);
   const hasAny = notifications.length > 0;
+  const effectiveUnreadCount = hasLoadedNotifications
+    ? notifications.filter((n) => !n.read).length
+    : unreadCount;
 
   const displayCount = useMemo(
-    () => (unreadCount > 99 ? '99+' : unreadCount.toString()),
-    [unreadCount],
+    () => (effectiveUnreadCount > 99 ? "99+" : effectiveUnreadCount.toString()),
+    [effectiveUnreadCount],
   );
 
-  const showBadge = useMemo(() => unreadCount > 0, [unreadCount]);
+  const showBadge = useMemo(
+    () => effectiveUnreadCount > 0,
+    [effectiveUnreadCount],
+  );
 
   const ariaLabel = useMemo(
     () =>
       showBadge
-        ? `${unreadCount} unread notification${unreadCount === 1 ? '' : 's'}`
-        : 'No unread notifications',
-    [showBadge, unreadCount],
+        ? `${effectiveUnreadCount} unread notification${effectiveUnreadCount === 1 ? "" : "s"}`
+        : "No unread notifications",
+    [effectiveUnreadCount, showBadge],
   );
 
   return (
     <div className="relative inline-block">
       <IconButton
         ref={triggerRef}
-        aria-label={showBadge ? `${unreadCount} unread notification${unreadCount === 1 ? '' : 's'}` : 'No unread notifications'}
+        aria-label={ariaLabel}
         aria-expanded={isOpen}
         aria-haspopup="dialog"
         onClick={handleToggle}
@@ -216,22 +293,40 @@ const NotificationBell = () => {
           className="absolute top-full right-0 mt-2 w-[360px] bg-white rounded-lg shadow-lg border border-gray-200 z-50 max-h-[480px] flex flex-col"
         >
           <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 shrink-0">
-            <h2 className="text-sm font-semibold text-gray-900">Notifications</h2>
-            {hasAny && hasUnread && (
-              <button
-                type="button"
-                onClick={handleMarkAllRead}
-                data-testid="mark-all-read"
-                className="text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors"
-              >
-                Mark all read
-              </button>
+            <h2 className="text-sm font-semibold text-gray-900">
+              Notifications
+            </h2>
+            {hasAny && (
+              <div className="flex items-center gap-3">
+                {hasUnread && (
+                  <button
+                    type="button"
+                    onClick={handleMarkAllRead}
+                    data-testid="mark-all-read"
+                    className="text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors"
+                  >
+                    Mark all read
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={handleClearAll}
+                  data-testid="clear-all-notifications"
+                  className="text-xs font-medium text-gray-500 hover:text-red-600 transition-colors"
+                  aria-label="Clear all notifications"
+                >
+                  Clear all
+                </button>
+              </div>
             )}
           </div>
 
           <div className="overflow-y-auto flex-1">
             {loading && (
-              <div className="flex items-center justify-center py-8" data-testid="loading-state">
+              <div
+                className="flex items-center justify-center py-8"
+                data-testid="loading-state"
+              >
                 <div className="animate-spin h-5 w-5 border-2 border-blue-600 border-t-transparent rounded-full" />
               </div>
             )}
@@ -262,6 +357,7 @@ const NotificationBell = () => {
                           isPinned={true}
                           onTogglePin={togglePin}
                           onMarkRead={handleMarkRead}
+                          onDismiss={handleDismiss}
                         />
                       ))}
                     </ul>
@@ -286,14 +382,18 @@ const NotificationBell = () => {
                           {getDateGroupLabel(group)}
                         </span>
                         <svg
-                          className={`w-3 h-3 text-gray-400 transition-transform ${isCollapsed ? '' : 'rotate-180'}`}
+                          className={`w-3 h-3 text-gray-400 transition-transform ${isCollapsed ? "" : "rotate-180"}`}
                           fill="none"
                           viewBox="0 0 24 24"
                           stroke="currentColor"
                           strokeWidth={2}
                           aria-hidden="true"
                         >
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M19 9l-7 7-7-7"
+                          />
                         </svg>
                       </button>
                       {!isCollapsed && (
@@ -305,6 +405,7 @@ const NotificationBell = () => {
                               isPinned={false}
                               onTogglePin={togglePin}
                               onMarkRead={handleMarkRead}
+                              onDismiss={handleDismiss}
                             />
                           ))}
                         </ul>
@@ -326,6 +427,7 @@ interface NotificationItemProps {
   isPinned: boolean;
   onTogglePin: (id: string) => void;
   onMarkRead: (id: string) => void;
+  onDismiss: (id: string) => void;
 }
 
 const NotificationItem = React.memo(function NotificationItem({
@@ -333,11 +435,12 @@ const NotificationItem = React.memo(function NotificationItem({
   isPinned,
   onTogglePin,
   onMarkRead,
+  onDismiss,
 }: NotificationItemProps) {
   return (
     <li
       data-testid={`notification-item-${n.id}`}
-      className={`px-4 py-3 transition-colors ${n.read ? 'bg-white' : 'bg-blue-50/40'}`}
+      className={`px-4 py-3 transition-colors ${n.read ? "bg-white" : "bg-blue-50/40"}`}
     >
       <div className="flex items-start gap-2">
         <span
@@ -348,12 +451,18 @@ const NotificationItem = React.memo(function NotificationItem({
         </span>
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between gap-2">
-            <p className={`text-sm truncate ${n.read ? 'text-gray-700 font-normal' : 'text-gray-900 font-semibold'}`}>
+            <p
+              className={`text-sm truncate ${n.read ? "text-gray-700 font-normal" : "text-gray-900 font-semibold"}`}
+            >
               {n.title}
             </p>
-            <span className="text-xs text-gray-400 shrink-0">{timeAgo(n.createdAt)}</span>
+            <span className="text-xs text-gray-400 shrink-0">
+              {timeAgo(n.createdAt)}
+            </span>
           </div>
-          <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{n.message}</p>
+          <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">
+            {n.message}
+          </p>
           <div className="flex items-center gap-2 mt-2">
             <button
               type="button"
@@ -361,12 +470,12 @@ const NotificationItem = React.memo(function NotificationItem({
               data-testid={`pin-btn-${n.id}`}
               className={`text-xs transition-colors ${
                 isPinned
-                  ? 'text-blue-600 hover:text-blue-800'
-                  : 'text-gray-400 hover:text-gray-600'
+                  ? "text-blue-600 hover:text-blue-800"
+                  : "text-gray-400 hover:text-gray-600"
               }`}
-              aria-label={isPinned ? 'Unpin notification' : 'Pin notification'}
+              aria-label={isPinned ? "Unpin notification" : "Pin notification"}
             >
-              {isPinned ? 'Unpin' : 'Pin'}
+              {isPinned ? "Unpin" : "Pin"}
             </button>
             {!n.read && (
               <button
@@ -378,6 +487,15 @@ const NotificationItem = React.memo(function NotificationItem({
                 Mark as read
               </button>
             )}
+            <button
+              type="button"
+              onClick={() => onDismiss(n.id)}
+              data-testid={`dismiss-${n.id}`}
+              className="text-xs text-gray-400 hover:text-red-600 transition-colors"
+              aria-label={`Dismiss notification: ${n.title}`}
+            >
+              Dismiss
+            </button>
           </div>
         </div>
       </div>

--- a/docs/notification-dismiss.md
+++ b/docs/notification-dismiss.md
@@ -1,0 +1,27 @@
+# Notification Dismiss Actions
+
+The `NotificationBell` panel lets users remove notifications without leaving the
+current page.
+
+## Single Notification Dismiss
+
+- Each notification renders a `Dismiss` button with an accessible label that
+  includes the notification title.
+- The button calls `DELETE /api/notifications/[id]` for the current user's
+  notification.
+- The item is removed optimistically. If the request fails, the previous list is
+  restored so users do not lose a notification that was not deleted.
+
+## Clear All
+
+- `Clear all` is available when the panel has loaded at least one notification.
+- The action deletes every currently loaded notification through the same
+  per-notification API route.
+- The list is cleared optimistically. If any delete request fails, the full
+  previous list is restored.
+
+## Badge Behavior
+
+After notifications are fetched, the unread badge is derived from the local
+panel list. Dismissing unread notifications and clearing the list immediately
+updates the badge and accessible trigger label.

--- a/lib/notifications/repository.ts
+++ b/lib/notifications/repository.ts
@@ -1,43 +1,43 @@
-import type { Notification } from './types';
-import { enqueue, type NotificationsJobPayload } from '@/lib/queue';
-import { logger } from '@/lib/logger';
-import { db } from '@/lib/db';
-import { notifications as notificationsTable } from '@/lib/db/schema/notifications';
-import { eq, desc, and, sql } from 'drizzle-orm';
-import { notificationHub } from '@/lib/streams/notification-hub';
+import type { Notification } from "./types";
+import { enqueue, type NotificationsJobPayload } from "@/lib/queue";
+import { logger } from "@/lib/logger";
+import { db } from "@/lib/db";
+import { notifications as notificationsTable } from "@/lib/db/schema/notifications";
+import { eq, desc, and, sql } from "drizzle-orm";
+import { notificationHub } from "@/lib/streams/notification-hub";
 
 // Seeded demo notifications used to populate new users' inboxes.
-const SEED_NOTIFICATIONS: Omit<Notification, 'userId'>[] = [
+const SEED_NOTIFICATIONS: Omit<Notification, "userId">[] = [
   {
-    id: 'notif-1',
-    title: 'Deposit Confirmed',
-    message: 'Your XLM deposit of 500 XLM has been confirmed on-chain.',
+    id: "notif-1",
+    title: "Deposit Confirmed",
+    message: "Your XLM deposit of 500 XLM has been confirmed on-chain.",
     read: false,
-    createdAt: '2026-05-26T10:00:00Z',
-    type: 'success',
+    createdAt: "2026-05-26T10:00:00Z",
+    type: "success",
   },
   {
-    id: 'notif-2',
-    title: 'Loan Payment Due',
-    message: 'Your USDC loan payment of $150 is due in 3 days.',
+    id: "notif-2",
+    title: "Loan Payment Due",
+    message: "Your USDC loan payment of $150 is due in 3 days.",
     read: false,
-    createdAt: '2026-05-25T08:00:00Z',
-    type: 'warning',
+    createdAt: "2026-05-25T08:00:00Z",
+    type: "warning",
   },
   {
-    id: 'notif-3',
-    title: 'Interest Earned',
-    message: 'You earned 2.5 XLM in lending interest this week.',
+    id: "notif-3",
+    title: "Interest Earned",
+    message: "You earned 2.5 XLM in lending interest this week.",
     read: true,
-    createdAt: '2026-05-24T12:00:00Z',
-    type: 'info',
+    createdAt: "2026-05-24T12:00:00Z",
+    type: "info",
   },
 ];
 
 // In-process store keyed by userId.
 // Replace with a database-backed repository (e.g. Prisma, Supabase) in production.
 const store = new Map<string, Notification[]>();
-const ROUTE = 'lib/notifications/repository';
+const ROUTE = "lib/notifications/repository";
 
 async function seedUser(userId: string): Promise<Notification[]> {
   const seeded = SEED_NOTIFICATIONS.map((n) => ({
@@ -55,7 +55,7 @@ async function seedUser(userId: string): Promise<Notification[]> {
   }
 
   return seeded.map((x) => ({
-    id: x.id.replace(`${userId}-`, ''),
+    id: x.id.replace(`${userId}-`, ""),
     userId: x.userId,
     title: x.title,
     message: x.message,
@@ -66,7 +66,9 @@ async function seedUser(userId: string): Promise<Notification[]> {
 }
 
 /** Returns all notifications for `userId`, seeding demo data on first access. */
-export async function getNotifications(userId: string): Promise<Notification[]> {
+export async function getNotifications(
+  userId: string,
+): Promise<Notification[]> {
   const rows = await db
     .select()
     .from(notificationsTable)
@@ -78,7 +80,7 @@ export async function getNotifications(userId: string): Promise<Notification[]> 
   }
 
   return rows.map((r) => ({
-    id: r.id.replace(`${userId}-`, ''),
+    id: r.id.replace(`${userId}-`, ""),
     userId: r.userId,
     title: r.title,
     message: r.message,
@@ -91,7 +93,7 @@ export async function getNotifications(userId: string): Promise<Notification[]> 
 /** Adds a new notification for userId, emits hub events, and returns it. */
 export async function addNotification(
   userId: string,
-  n: Omit<Notification, 'userId'>,
+  n: Omit<Notification, "userId">,
 ): Promise<Notification> {
   const dbId = `${userId}-${n.id}`;
   const record = {
@@ -125,7 +127,7 @@ export async function addNotification(
 
   // Emit the raw notification event
   try {
-    notificationHub.publish(userId, { type: 'notification', notification });
+    notificationHub.publish(userId, { type: "notification", notification });
   } catch (e) {
     // Swallow errors from the hub to avoid breaking producers
   }
@@ -134,7 +136,7 @@ export async function addNotification(
   try {
     const list = await getNotifications(userId);
     const unreadCount = list.filter((x) => !x.read).length;
-    notificationHub.publish(userId, { type: 'unreadCount', unreadCount });
+    notificationHub.publish(userId, { type: "unreadCount", unreadCount });
   } catch (e) {
     // noop
   }
@@ -155,13 +157,68 @@ export async function markNotificationRead(
   const [row] = await db
     .update(notificationsTable)
     .set({ read: true })
-    .where(and(eq(notificationsTable.id, dbId), eq(notificationsTable.userId, userId)))
+    .where(
+      and(
+        eq(notificationsTable.id, dbId),
+        eq(notificationsTable.userId, userId),
+      ),
+    )
     .returning();
 
   if (!row) return null;
 
   return {
-    id: row.id.replace(`${userId}-`, ''),
+    id: row.id.replace(`${userId}-`, ""),
+    userId: row.userId,
+    title: row.title,
+    message: row.message,
+    read: row.read,
+    createdAt: row.createdAt.toISOString(),
+    type: row.type as any,
+  };
+}
+
+/**
+ * Deletes notification `id` for `userId`.
+ * Returns the deleted notification, or null if it was not owned by the user.
+ */
+export async function deleteNotification(
+  userId: string,
+  id: string,
+): Promise<Notification | null> {
+  const dbId = `${userId}-${id}`;
+
+  const [row] = await db
+    .delete(notificationsTable)
+    .where(
+      and(
+        eq(notificationsTable.id, dbId),
+        eq(notificationsTable.userId, userId),
+      ),
+    )
+    .returning();
+
+  if (!row) return null;
+
+  try {
+    const unreadRows = await db
+      .select({ id: notificationsTable.id })
+      .from(notificationsTable)
+      .where(
+        and(
+          eq(notificationsTable.userId, userId),
+          eq(notificationsTable.read, false),
+        ),
+      );
+
+    const unreadCount = unreadRows.length;
+    notificationHub.publish(userId, { type: "unreadCount", unreadCount });
+  } catch (e) {
+    // noop
+  }
+
+  return {
+    id: row.id.replace(`${userId}-`, ""),
     userId: row.userId,
     title: row.title,
     message: row.message,
@@ -175,18 +232,25 @@ export async function markNotificationRead(
  * Marks all unread notifications as read for `userId`.
  * Returns the count of updated notifications.
  */
-export async function markAllNotificationsRead(userId: string): Promise<number> {
+export async function markAllNotificationsRead(
+  userId: string,
+): Promise<number> {
   const rows = await db
     .update(notificationsTable)
     .set({ read: true })
-    .where(and(eq(notificationsTable.userId, userId), eq(notificationsTable.read, false)))
+    .where(
+      and(
+        eq(notificationsTable.userId, userId),
+        eq(notificationsTable.read, false),
+      ),
+    )
     .returning({ id: notificationsTable.id });
 
   const count = rows.length;
 
   if (count > 0) {
     try {
-      notificationHub.publish(userId, { type: 'unreadCount', unreadCount: 0 });
+      notificationHub.publish(userId, { type: "unreadCount", unreadCount: 0 });
     } catch (e) {
       // noop
     }
@@ -200,9 +264,9 @@ export async function markAllNotificationsRead(userId: string): Promise<number> 
  */
 export async function enqueueNotification(
   userId: string,
-  notification: Omit<NotificationsJobPayload, 'userId'>,
+  notification: Omit<NotificationsJobPayload, "userId">,
 ): Promise<void> {
-  await enqueue('notifications', {
+  await enqueue("notifications", {
     userId,
     ...notification,
   });
@@ -213,10 +277,10 @@ export async function enqueueNotification(
  */
 export function enqueueNotificationInBackground(
   userId: string,
-  notification: Omit<NotificationsJobPayload, 'userId'>,
+  notification: Omit<NotificationsJobPayload, "userId">,
 ): void {
   void enqueueNotification(userId, notification).catch((error) => {
-    logger.warn('Failed to enqueue notification', ROUTE, {
+    logger.warn("Failed to enqueue notification", ROUTE, {
       userId,
       error: String(error),
     });


### PR DESCRIPTION
Closes #661.\n\n## Summary\n- add DELETE support for /api/notifications/[id] through the notification repository\n- add per-notification Dismiss and Clear all controls to NotificationBell\n- keep dismiss/clear optimistic with rollback on failed delete requests\n- recompute the trigger badge and accessible label from the local loaded list after fetches\n- document the dismiss, clear-all, rollback, and badge behavior\n\n## Tests\n- pnpm vitest run components/shared/layout/NotificationBell.test.tsx components/shared/layout/NotificationBell.memo.test.tsx app/api/notifications/[id]/route.test.ts --project accessibility --project server-unit --reporter=dot\n- pnpm exec prettier --check docs/notification-dismiss.md app/api/notifications/[id]/route.ts app/api/notifications/[id]/route.test.ts components/shared/layout/NotificationBell.tsx components/shared/layout/NotificationBell.test.tsx components/shared/layout/NotificationBell.memo.test.tsx lib/notifications/repository.ts\n- git diff --check\n\n## Notes\n- pnpm exec tsc --noEmit --pretty false is currently blocked by pre-existing syntax errors in components/molecules/SearchBar/SearchBar.tsx and a plugin declaration file before reaching this change.\n- pnpm exec eslint on the changed files is currently blocked because ESLint 9 cannot find a flat eslint.config.* file in this repository.