### PR TITLE
[646] Add Subresource Integrity and strict referrer policy to app/layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,6 +29,14 @@ export default async function RootLayout({
 
   return (
     <html lang="en" suppressHydrationWarning={true}>
+      <head>
+        {/*
+         * Strict referrer policy: browsers will only send the origin (no path/query)
+         * when navigating cross-origin, and the full URL for same-origin requests.
+         * This prevents sensitive URL parameters from leaking to third parties.
+         */}
+        <meta name="referrer" content="strict-origin-when-cross-origin" />
+      </head>
       <body className={`${inter.variable} antialiased`}>
         {/* Top progress bar */}
         <NextTopLoader
@@ -43,10 +51,13 @@ export default async function RootLayout({
           shadow="0 0 10px #15a350, 0 0 5px #15a350"
           zIndex={9999}
         />
-        {/* Example inline script that uses the CSP nonce */}
+        {/* Inline script that exposes the CSP nonce for client-side use.
+             referrerPolicy is set on this element as belt-and-suspenders even
+             though <script> elements without src do not generate HTTP requests. */}
         {nonce && (
           <script
             nonce={nonce}
+            referrerPolicy="strict-origin-when-cross-origin"
             dangerouslySetInnerHTML={{
               __html: `window.CSP_NONCE = "${nonce}";`,
             }}

--- a/lib/http/client.ts
+++ b/lib/http/client.ts
@@ -140,3 +140,9 @@ export async function httpPost<T>(url: string, body: unknown, options: RequestOp
   });
 }
 
+/**
+ * Generic fetch wrapper that propagates the active x-request-id from async context.
+ * Alias for httpGet, exported separately to satisfy callers that import httpFetch by name.
+ */
+export const httpFetch = httpGet;
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,6 +30,7 @@ export function middleware(request: NextRequest) {
     const nonce = crypto.randomBytes(16).toString('base64');
     const response = NextResponse.next();
     response.headers.set('Content-Security-Policy', `default-src 'self'; script-src 'self' 'nonce-${nonce}';`);
+    response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
     response.headers.set('x-csp-nonce', nonce);
     return response;
   }
@@ -40,6 +41,7 @@ export function middleware(request: NextRequest) {
   if (pathname === '/api/health') {
     const response = setRequestIdHeader(NextResponse.next({ request: { headers: requestHeaders } }), requestId);
     response.headers.set('Content-Security-Policy', `default-src 'self'; script-src 'self' 'nonce-${nonce}';`);
+    response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
     return response;
   }
 
@@ -50,6 +52,7 @@ export function middleware(request: NextRequest) {
   if (isAuth) {
     const response = setRequestIdHeader(NextResponse.next({ request: { headers: requestHeaders } }), requestId);
     response.headers.set('Content-Security-Policy', `default-src 'self'; script-src 'self' 'nonce-${nonce}';`);
+    response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
     return response;
   }
 
@@ -80,6 +83,7 @@ export function middleware(request: NextRequest) {
 
   // Set CSP header on every response
   response.headers.set('Content-Security-Policy', `default-src 'self'; script-src 'self' 'nonce-${nonce}';`);
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 
   // 6. Standard Rate Limit Headers
   response.headers.set('X-RateLimit-Limit', limit.toString());

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,24 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    sri: {
+      algorithm: 'sha256',
+    },
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/test/server/security-headers.test.ts
+++ b/test/server/security-headers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  rateLimit: vi.fn(() => ({ success: true, limit: 100, remaining: 99, reset: Date.now() + 60_000 })),
+}));
+
+vi.mock('@/lib/chaos/inject', () => ({
+  chaosInject: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/telemetry/sentry', () => ({
+  captureServerError: vi.fn(),
+}));
+
+function apiRequest(path: string = '/api/test') {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'GET',
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Security Headers Middleware', () => {
+  it('applies Referrer-Policy strict-origin-when-cross-origin on API routes', async () => {
+    const response = middleware(apiRequest('/api/test'));
+    expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+  });
+
+  it('applies Referrer-Policy strict-origin-when-cross-origin on non-API routes', async () => {
+    const response = middleware(apiRequest('/some-page'));
+    expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+  });
+
+  it('applies Content-Security-Policy with nonce on page routes', async () => {
+    const response = middleware(apiRequest('/about'));
+    const csp = response.headers.get('Content-Security-Policy');
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self' 'nonce-");
+    expect(response.headers.get('x-csp-nonce')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the application against resource-tampering and referrer-header leakage by wiring in Subresource Integrity (SRI) and a strict `Referrer-Policy` at every layer of the stack.

---

## Changes

### `next.config.ts`
- **SRI**: enables `experimental.sri.algorithm = 'sha256'` so Next.js automatically injects `integrity` hashes on all generated `<script>` and `<link>` tags at build time, letting browsers reject any tampered asset.
- **Referrer-Policy header**: adds a `headers()` entry that sends `Referrer-Policy: strict-origin-when-cross-origin` on every route, ensuring the policy is applied even before the middleware runs.

### `middleware.ts`
- Adds `response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')` to **all four** response paths (non-API page routes, `/api/health`, authenticated API routes, and rate-limited anonymous routes) for defence-in-depth.

### `app/layout.tsx`
- Adds `<meta name="referrer" content="strict-origin-when-cross-origin" />` inside `<head>` — the HTML-level declaration that enforces the policy for browsers that do not honour the HTTP header.
- Sets `referrerPolicy="strict-origin-when-cross-origin"` on the inline CSP-nonce `<script>` element as belt-and-suspenders.

### `lib/http/client.ts`
- Exports `httpFetch` (alias for `httpGet`) to resolve the pre-existing TypeScript error `TS2305` raised by `lib/http/index.ts`.

### `test/server/security-headers.test.ts` (new)
- 3 Vitest unit tests verifying that the middleware emits:
  - `Referrer-Policy: strict-origin-when-cross-origin` on API routes.
  - `Referrer-Policy: strict-origin-when-cross-origin` on non-API page routes.
  - A `Content-Security-Policy` header containing a nonce, plus an `x-csp-nonce` response header.

---

## Test Results

```
Test Files  1 passed (1)
     Tests  3 passed (3)
  Duration  10.52s
```

Closes #646
