### PR TITLE
Add Stellar Expert transaction links

### DIFF
--- a/components/shared/common/RecentTransactions.memo.test.tsx
+++ b/components/shared/common/RecentTransactions.memo.test.tsx
@@ -22,10 +22,17 @@ vi.mock("@headlessui/react", () => ({
   TransitionChild: ({ children }: any) => <>{children}</>,
 }));
 
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => ({ network: "TESTNET" }),
+}));
+
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-const makeTxn = (id: string, overrides: Partial<Transaction> = {}): Transaction => ({
+const makeTxn = (
+  id: string,
+  overrides: Partial<Transaction> = {},
+): Transaction => ({
   id,
   type: "Deposit",
   amount: 100,

--- a/components/shared/common/RecentTransactions.test.tsx
+++ b/components/shared/common/RecentTransactions.test.tsx
@@ -25,6 +25,12 @@ vi.mock("@headlessui/react", () => ({
   TransitionChild: ({ children }: any) => <>{children}</>,
 }));
 
+const mockWalletNetwork = vi.hoisted(() => ({ current: "TESTNET" }));
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => ({ network: mockWalletNetwork.current }),
+}));
+
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
@@ -43,12 +49,48 @@ const makeTxn = (overrides: Partial<Transaction> = {}): Transaction => ({
   ...overrides,
 });
 
-const inflowTxn  = makeTxn({ id: "txn-in",   type: "Deposit",      amount: 250,  asset: "XLM"  });
-const outflowTxn = makeTxn({ id: "txn-out",  type: "Withdrawal",   amount: -80,  asset: "USDC" });
-const zeroTxn    = makeTxn({ id: "txn-zero", type: "Loan Payment", amount: 0,    asset: "ETH"  });
-const processTxn = makeTxn({ id: "txn-proc", type: "Lend Funds",   amount: 500,  asset: "BTC",  status: "Processing" });
-const failedTxn  = makeTxn({ id: "txn-fail", type: "Withdrawal",   amount: -40,  asset: "USDC", status: "Failed" });
-const negTxn     = makeTxn({ id: "txn-neg",  type: "Loan Payment", amount: -999, asset: "ETH",  status: "Completed" });
+const inflowTxn = makeTxn({
+  id: "txn-in",
+  type: "Deposit",
+  amount: 250,
+  asset: "XLM",
+});
+const outflowTxn = makeTxn({
+  id: "txn-out",
+  type: "Withdrawal",
+  amount: -80,
+  asset: "USDC",
+});
+const zeroTxn = makeTxn({
+  id: "txn-zero",
+  type: "Loan Payment",
+  amount: 0,
+  asset: "ETH",
+});
+const processTxn = makeTxn({
+  id: "txn-proc",
+  type: "Lend Funds",
+  amount: 500,
+  asset: "BTC",
+  status: "Processing",
+});
+const failedTxn = makeTxn({
+  id: "txn-fail",
+  type: "Withdrawal",
+  amount: -40,
+  asset: "USDC",
+  status: "Failed",
+});
+const negTxn = makeTxn({
+  id: "txn-neg",
+  type: "Loan Payment",
+  amount: -999,
+  asset: "ETH",
+  status: "Completed",
+});
+
+const txHash =
+  "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd";
 
 function mockApi(transactions: Transaction[], total = transactions.length) {
   mockFetch.mockResolvedValue({
@@ -64,6 +106,7 @@ function mockApi(transactions: Transaction[], total = transactions.length) {
 describe("RecentTransactions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWalletNetwork.current = "TESTNET";
     mockApi([]);
   });
 
@@ -76,7 +119,9 @@ describe("RecentTransactions", () => {
 
   it("renders the View All button", () => {
     render(<RecentTransactions />);
-    expect(screen.getByRole("button", { name: /view all/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /view all/i }),
+    ).toBeInTheDocument();
   });
 
   // --- Loading state ---
@@ -125,14 +170,18 @@ describe("RecentTransactions", () => {
     mockApi([inflowTxn]);
     render(<RecentTransactions />);
     await screen.findAllByText("Deposit");
-    expect(screen.getAllByText(`+$${inflowTxn.amount}`).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(`+$${inflowTxn.amount}`).length).toBeGreaterThan(
+      0,
+    );
   });
 
   it("displays outflow amount with leading -", async () => {
     mockApi([outflowTxn]);
     render(<RecentTransactions />);
     await screen.findAllByText("Withdrawal");
-    expect(screen.getAllByText(`-$${Math.abs(outflowTxn.amount)}`).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(`-$${Math.abs(outflowTxn.amount)}`).length,
+    ).toBeGreaterThan(0);
   });
 
   it("displays large negative amount correctly", async () => {
@@ -197,6 +246,39 @@ describe("RecentTransactions", () => {
     render(<RecentTransactions />);
     await screen.findAllByText("Loan Payment");
     expect(screen.getAllByAltText("ETH").length).toBeGreaterThan(0);
+  });
+
+  it("renders Stellar Expert links for real transaction hashes", async () => {
+    mockApi([makeTxn({ id: "TXN-001", txHash })]);
+    render(<RecentTransactions />);
+
+    await screen.findAllByText("Deposit");
+
+    const links = screen.getAllByRole("link", {
+      name: /view transaction TXN-001 on Stellar Expert/i,
+    });
+    expect(links.length).toBeGreaterThan(0);
+    links.forEach((link) => {
+      expect(link).toHaveAttribute(
+        "href",
+        `https://stellar.expert/explorer/testnet/tx/${txHash}`,
+      );
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  });
+
+  it("does not render explorer links for mock transaction ids", async () => {
+    mockApi([makeTxn({ id: "TXN-001" })]);
+    render(<RecentTransactions />);
+
+    await screen.findAllByText("Deposit");
+
+    expect(
+      screen.queryByRole("link", {
+        name: /view transaction TXN-001 on Stellar Expert/i,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   // --- Wrapped inside Transactions with infiniteScroll — toolbar IS present ---

--- a/components/shared/common/Transaction.test.tsx
+++ b/components/shared/common/Transaction.test.tsx
@@ -1,19 +1,48 @@
-import React from 'react';
+import React from "react";
 import { render, screen, waitFor, fireEvent } from "@/test/test-utils";
 import { Transactions } from "./Transaction";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ── Hoisted mock data (must be declared before vi.mock calls are hoisted) ───
 
+const mockWalletNetwork = vi.hoisted(() => ({ current: "TESTNET" }));
+
+const txHash =
+  "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd";
+
 const mockFetchTransactions = vi.hoisted(() =>
   vi.fn().mockResolvedValue({
     transactions: [
-      { id: "TXN-001", type: "Deposit",    amount: 100,  asset: "XLM",  date: "2024-04-01", time: "10:00AM", status: "Completed" },
-      { id: "TXN-002", type: "Withdrawal", amount: -50,  asset: "USDC", date: "2024-04-02", time: "11:00AM", status: "Processing" },
-      { id: "TXN-003", type: "Lend",       amount: 200,  asset: "BTC",  date: "2024-04-03", time: "12:00PM", status: "Completed" },
+      {
+        id: "TXN-001",
+        type: "Deposit",
+        amount: 100,
+        asset: "XLM",
+        date: "2024-04-01",
+        time: "10:00AM",
+        status: "Completed",
+      },
+      {
+        id: "TXN-002",
+        type: "Withdrawal",
+        amount: -50,
+        asset: "USDC",
+        date: "2024-04-02",
+        time: "11:00AM",
+        status: "Processing",
+      },
+      {
+        id: "TXN-003",
+        type: "Lend",
+        amount: 200,
+        asset: "BTC",
+        date: "2024-04-03",
+        time: "12:00PM",
+        status: "Completed",
+      },
     ],
     total: 3,
-  })
+  }),
 );
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
@@ -25,22 +54,53 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("next/dynamic", () => ({
-  default: (loader: () => Promise<{ default: React.ComponentType<unknown> }>) => {
-    let Comp: React.ComponentType<unknown> | null = null;
-    loader().then((m) => { Comp = m.default; });
-    return function DynamicResolved(props: unknown) {
-      return Comp
-        ? React.createElement(Comp, props as Record<string, unknown>)
-        : React.createElement("div", null, "Loading\u2026");
-    };
-  },
+  default: () =>
+    function DynamicTransactionDetail({
+      isOpen,
+      onClose,
+    }: {
+      isOpen: boolean;
+      onClose: () => void;
+    }) {
+      if (!isOpen) return null;
+      return (
+        <div>
+          <h2>Transaction Details</h2>
+          <button type="button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      );
+    },
 }));
 
 vi.mock("next/image", () => ({
-  default: ({ src, alt, width, height, className }: { src: string; alt: string; width: number; height: number; className?: string }) => (
+  default: ({
+    src,
+    alt,
+    width,
+    height,
+    className,
+  }: {
+    src: string;
+    alt: string;
+    width: number;
+    height: number;
+    className?: string;
+  }) => (
     // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
-    <img src={src} alt={alt} width={width} height={height} className={className} />
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      className={className}
+    />
   ),
+}));
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => ({ network: mockWalletNetwork.current }),
 }));
 
 vi.mock("@/types/Transaction", async (importOriginal) => {
@@ -53,16 +113,44 @@ vi.mock("@/types/Transaction", async (importOriginal) => {
 describe("Transactions Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWalletNetwork.current = "TESTNET";
     // Re-assert the resolved value after clearAllMocks resets it
     mockFetchTransactions.mockResolvedValue({
       transactions: [
-        { id: "TXN-001", type: "Deposit",    amount: 100,  asset: "XLM",  date: "2024-04-01", time: "10:00AM", status: "Completed" },
-        { id: "TXN-002", type: "Withdrawal", amount: -50,  asset: "USDC", date: "2024-04-02", time: "11:00AM", status: "Processing" },
-        { id: "TXN-003", type: "Lend",       amount: 200,  asset: "BTC",  date: "2024-04-03", time: "12:00PM", status: "Completed" },
+        {
+          id: "TXN-001",
+          type: "Deposit",
+          amount: 100,
+          asset: "XLM",
+          date: "2024-04-01",
+          time: "10:00AM",
+          status: "Completed",
+        },
+        {
+          id: "TXN-002",
+          type: "Withdrawal",
+          amount: -50,
+          asset: "USDC",
+          date: "2024-04-02",
+          time: "11:00AM",
+          status: "Processing",
+        },
+        {
+          id: "TXN-003",
+          type: "Lend",
+          amount: 200,
+          asset: "BTC",
+          date: "2024-04-03",
+          time: "12:00PM",
+          status: "Completed",
+        },
       ],
       total: 3,
     });
-    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 0; });
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
   });
 
   afterEach(() => {
@@ -79,7 +167,9 @@ describe("Transactions Component", () => {
     render(<Transactions />);
 
     await waitFor(() => {
-      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Loading transactions"),
+      ).not.toBeInTheDocument();
     });
 
     expect(screen.getByText("Transaction Type")).toBeInTheDocument();
@@ -93,7 +183,9 @@ describe("Transactions Component", () => {
     render(<Transactions />);
 
     await waitFor(() => {
-      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Loading transactions"),
+      ).not.toBeInTheDocument();
     });
 
     expect(screen.getAllByText("Deposit").length).toBeGreaterThan(0);
@@ -104,7 +196,9 @@ describe("Transactions Component", () => {
     render(<Transactions />);
 
     await waitFor(() => {
-      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Loading transactions"),
+      ).not.toBeInTheDocument();
     });
 
     expect(screen.getAllByText("Type").length).toBeGreaterThan(0);
@@ -115,7 +209,9 @@ describe("Transactions Component", () => {
     render(<Transactions />);
 
     await waitFor(() => {
-      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Loading transactions"),
+      ).not.toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByText("Search"));
@@ -126,10 +222,14 @@ describe("Transactions Component", () => {
     render(<Transactions />);
 
     await waitFor(() => {
-      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Loading transactions"),
+      ).not.toBeInTheDocument();
     });
 
-    const detailButtons = await screen.findAllByRole("button", { name: /details/i });
+    const detailButtons = await screen.findAllByRole("button", {
+      name: /details/i,
+    });
     expect(detailButtons.length).toBeGreaterThan(0);
     fireEvent.click(detailButtons[0]);
 
@@ -142,10 +242,14 @@ describe("Transactions Component", () => {
     render(<Transactions />);
 
     await waitFor(() => {
-      expect(screen.queryByLabelText("Loading transactions")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Loading transactions"),
+      ).not.toBeInTheDocument();
     });
 
-    const detailButtons = await screen.findAllByRole("button", { name: /details/i });
+    const detailButtons = await screen.findAllByRole("button", {
+      name: /details/i,
+    });
     fireEvent.click(detailButtons[0]);
 
     await waitFor(() => {
@@ -156,6 +260,41 @@ describe("Transactions Component", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("Transaction Details")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders public Stellar Expert links when a transaction has a hash", async () => {
+    mockWalletNetwork.current = "PUBLIC";
+
+    render(
+      <Transactions
+        showPagination={false}
+        transactions={[
+          {
+            id: "TXN-001",
+            hash: txHash,
+            type: "Deposit",
+            amount: 100,
+            asset: "XLM",
+            date: "2024-04-01",
+            time: "10:00AM",
+            status: "Completed",
+          },
+        ]}
+      />,
+    );
+
+    const links = screen.getAllByRole("link", {
+      name: /view transaction TXN-001 on Stellar Expert/i,
+    });
+    expect(links.length).toBeGreaterThan(0);
+    links.forEach((link) => {
+      expect(link).toHaveAttribute(
+        "href",
+        `https://stellar.expert/explorer/public/tx/${txHash}`,
+      );
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });
   });
 });

--- a/components/shared/common/TransactionRow.tsx
+++ b/components/shared/common/TransactionRow.tsx
@@ -2,7 +2,16 @@
 
 import React, { useCallback } from "react";
 import Image from "next/image";
-import { StatusBadge, transactionStatusToVariant } from "@/components/shared/ui/StatusBadge";
+import { ExternalLink } from "lucide-react";
+import {
+  StatusBadge,
+  transactionStatusToVariant,
+} from "@/components/shared/ui/StatusBadge";
+import { useWallet } from "@/hooks/useWallet";
+import {
+  buildStellarExpertTransactionUrl,
+  getTransactionHash,
+} from "@/lib/utils/explorer";
 import type { Transaction } from "@/types/Transaction";
 
 export const rowRenderCounts = new Map<string, number>();
@@ -45,7 +54,10 @@ export interface TransactionRowProps {
   isFocused: boolean;
   isExpanded: boolean;
   onFocusRow: (index: number) => void;
-  onKeyDownRow: (event: React.KeyboardEvent<HTMLTableRowElement>, index: number) => void;
+  onKeyDownRow: (
+    event: React.KeyboardEvent<HTMLTableRowElement>,
+    index: number,
+  ) => void;
   onSelectTxn: (txn: Transaction) => void;
   setRowRef: (index: number, node: HTMLTableRowElement | null) => void;
 }
@@ -65,12 +77,17 @@ export const TransactionRow = React.memo(
       const count = rowRenderCounts.get(txn.id) ?? 0;
       rowRenderCounts.set(txn.id, count + 1);
     }
+    const { network } = useWallet();
+    const transactionHash = getTransactionHash(txn);
+    const explorerUrl = transactionHash
+      ? buildStellarExpertTransactionUrl(transactionHash, network)
+      : null;
 
     const handleRef = useCallback(
       (node: HTMLTableRowElement | null) => {
         setRowRef(actualIndex, node);
       },
-      [actualIndex, setRowRef]
+      [actualIndex, setRowRef],
     );
 
     const handleFocus = useCallback(() => {
@@ -81,7 +98,7 @@ export const TransactionRow = React.memo(
       (event: React.KeyboardEvent<HTMLTableRowElement>) => {
         onKeyDownRow(event, actualIndex);
       },
-      [actualIndex, onKeyDownRow]
+      [actualIndex, onKeyDownRow],
     );
 
     const handleSelect = useCallback(() => {
@@ -115,9 +132,7 @@ export const TransactionRow = React.memo(
           />
           <span className="ml-1 font-medium ">{txn.asset}</span>
         </td>
-        <td className="py-3 px-4 ">
-          {formatDateTime(txn.date, txn.time)}
-        </td>
+        <td className="py-3 px-4 ">{formatDateTime(txn.date, txn.time)}</td>
         <td className="py-3 px-4">
           <StatusBadge
             variant={transactionStatusToVariant(txn.status)}
@@ -125,6 +140,18 @@ export const TransactionRow = React.memo(
           />
         </td>
         <td className="py-3 px-4">
+          {explorerUrl && (
+            <a
+              href={explorerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mr-4 inline-flex items-center gap-1 text-blue-600 hover:underline"
+              aria-label={`View transaction ${txn.id} on Stellar Expert`}
+            >
+              Explorer
+              <ExternalLink aria-hidden="true" size={14} />
+            </a>
+          )}
           <button
             onClick={handleSelect}
             className="text-blue-600 hover:underline"
@@ -136,7 +163,7 @@ export const TransactionRow = React.memo(
         </td>
       </tr>
     );
-  }
+  },
 );
 TransactionRow.displayName = "TransactionRow";
 
@@ -152,6 +179,11 @@ export const TransactionMobileRow = React.memo(
       const count = mobileRowRenderCounts.get(txn.id) ?? 0;
       mobileRowRenderCounts.set(txn.id, count + 1);
     }
+    const { network } = useWallet();
+    const transactionHash = getTransactionHash(txn);
+    const explorerUrl = transactionHash
+      ? buildStellarExpertTransactionUrl(transactionHash, network)
+      : null;
 
     const handleSelect = useCallback(() => {
       onSelectTxn(txn);
@@ -211,17 +243,31 @@ export const TransactionMobileRow = React.memo(
               {formatDateTime(txn.date, txn.time)}
             </div>
           </div>
-          <button
-            onClick={handleSelect}
-            className="mt-2 text-blue-600 hover:underline"
-            aria-expanded={isExpanded}
-            aria-controls="transaction-detail-drawer"
-          >
-            Details
-          </button>
+          <div className="flex flex-col items-end gap-2">
+            {explorerUrl && (
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                aria-label={`View transaction ${txn.id} on Stellar Expert`}
+              >
+                Explorer
+                <ExternalLink aria-hidden="true" size={14} />
+              </a>
+            )}
+            <button
+              onClick={handleSelect}
+              className="text-blue-600 hover:underline"
+              aria-expanded={isExpanded}
+              aria-controls="transaction-detail-drawer"
+            >
+              Details
+            </button>
+          </div>
         </div>
       </div>
     );
-  }
+  },
 );
 TransactionMobileRow.displayName = "TransactionMobileRow";

--- a/components/shared/common/__tests__/transactions-virtualization.test.tsx
+++ b/components/shared/common/__tests__/transactions-virtualization.test.tsx
@@ -11,14 +11,18 @@ vi.mock("next/navigation", () => ({
 vi.mock("next/dynamic", () => ({
   __esModule: true,
   default: () => {
-    const DynamicComponent = (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />;
+    const DynamicComponent = (props: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props} />
+    );
     return DynamicComponent;
   },
 }));
 
 vi.mock("next/image", () => ({
   __esModule: true,
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} />
+  ),
 }));
 
 vi.mock("react-datepicker", () => ({
@@ -26,8 +30,14 @@ vi.mock("react-datepicker", () => ({
   default: () => <div />,
 }));
 
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => ({ network: "TESTNET" }),
+}));
+
 vi.mock("@/types/Transaction", async () => {
-  const actual = await vi.importActual<typeof import("@/types/Transaction")>("@/types/Transaction");
+  const actual = await vi.importActual<typeof import("@/types/Transaction")>(
+    "@/types/Transaction",
+  );
   return {
     ...actual,
     fetchTransactions: vi.fn(),
@@ -55,52 +65,85 @@ describe("Transactions virtualization", () => {
 
   it("renders the full list when the history is small", async () => {
     mockedFetchTransactions.mockResolvedValue({
-      transactions: Array.from({ length: 4 }, (_, index) => makeTransaction(index + 1)),
+      transactions: Array.from({ length: 4 }, (_, index) =>
+        makeTransaction(index + 1),
+      ),
       total: 4,
     });
 
     render(<Transactions showPagination={false} />);
 
-    await waitFor(() => expect(screen.getAllByText("#tx-4").length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-4").length).toBeGreaterThan(0),
+    );
 
-    expect(screen.queryByTestId("transactions-virtualizer")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("transactions-virtualizer"),
+    ).not.toBeInTheDocument();
   });
 
   it("only mounts visible rows for large histories", async () => {
-    const transactions = Array.from({ length: 200 }, (_, index) => makeTransaction(index + 1));
-    mockedFetchTransactions.mockResolvedValue({ transactions, total: transactions.length });
+    const transactions = Array.from({ length: 200 }, (_, index) =>
+      makeTransaction(index + 1),
+    );
+    mockedFetchTransactions.mockResolvedValue({
+      transactions,
+      total: transactions.length,
+    });
 
     render(<Transactions showPagination={false} />);
 
-    await waitFor(() => expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0),
+    );
 
     expect(screen.queryAllByText("#tx-150")).toHaveLength(0);
     expect(screen.getByTestId("transactions-virtualizer")).toBeInTheDocument();
   });
 
   it("supports keyboard navigation across the visible window", async () => {
-    const transactions = Array.from({ length: 20 }, (_, index) => makeTransaction(index + 1));
-    mockedFetchTransactions.mockResolvedValue({ transactions, total: transactions.length });
+    const transactions = Array.from({ length: 20 }, (_, index) =>
+      makeTransaction(index + 1),
+    );
+    mockedFetchTransactions.mockResolvedValue({
+      transactions,
+      total: transactions.length,
+    });
 
     render(<Transactions showPagination={false} rowHeight={40} />);
 
-    await waitFor(() => expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0),
+    );
 
-    const firstRow = screen.getAllByRole("row", { name: /transaction tx-1/i })[0];
+    const firstRow = screen.getAllByRole("row", {
+      name: /transaction tx-1/i,
+    })[0];
     firstRow.focus();
 
     fireEvent.keyDown(firstRow, { key: "ArrowDown" });
 
-    await waitFor(() => expect(screen.getAllByRole("row", { name: /transaction tx-2/i })[0]).toHaveFocus());
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("row", { name: /transaction tx-2/i })[0],
+      ).toHaveFocus(),
+    );
   });
 
   it("uses the provided row height for the virtualized window", async () => {
-    const transactions = Array.from({ length: 50 }, (_, index) => makeTransaction(index + 1));
-    mockedFetchTransactions.mockResolvedValue({ transactions, total: transactions.length });
+    const transactions = Array.from({ length: 50 }, (_, index) =>
+      makeTransaction(index + 1),
+    );
+    mockedFetchTransactions.mockResolvedValue({
+      transactions,
+      total: transactions.length,
+    });
 
     render(<Transactions showPagination={false} rowHeight={44} />);
 
-    await waitFor(() => expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0),
+    );
 
     const virtualizer = screen.getByTestId("transactions-virtualizer");
     expect(virtualizer).toHaveStyle({ height: "560px" });

--- a/docs/explorer-links.md
+++ b/docs/explorer-links.md
@@ -1,0 +1,16 @@
+# Transaction Explorer Links
+
+Transaction rows render a Stellar Expert link when the transaction data includes
+a real Stellar transaction hash.
+
+The row helper checks `txHash`, then `hash`, then `id`. Values must be
+64-character hexadecimal hashes, so mock ids such as `TXN-001` and `txn-001`
+do not produce external links.
+
+Links use the connected wallet network:
+
+- `PUBLIC` opens `https://stellar.expert/explorer/public/tx/<hash>`.
+- `TESTNET` opens `https://stellar.expert/explorer/testnet/tx/<hash>`.
+
+Explorer links open in a new tab with `rel="noopener noreferrer"` and a
+descriptive accessible label.

--- a/lib/utils/explorer.test.ts
+++ b/lib/utils/explorer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStellarExpertTransactionUrl,
+  getTransactionHash,
+} from "./explorer";
+import type { Transaction } from "@/types/Transaction";
+
+const hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd";
+
+const transaction: Transaction = {
+  id: "TXN-001",
+  type: "Deposit",
+  amount: 100,
+  asset: "XLM",
+  date: "2024-01-15",
+  time: "10:30AM",
+  status: "Completed",
+};
+
+describe("Stellar Expert transaction links", () => {
+  it("prefers txHash over hash and id", () => {
+    expect(
+      getTransactionHash({
+        ...transaction,
+        txHash: hash.toUpperCase(),
+        hash: "b".repeat(64),
+        id: "c".repeat(64),
+      }),
+    ).toBe(hash);
+  });
+
+  it("falls back to hash and then a hash-shaped id", () => {
+    expect(getTransactionHash({ ...transaction, hash })).toBe(hash);
+    expect(getTransactionHash({ ...transaction, id: hash })).toBe(hash);
+  });
+
+  it("does not treat mock ids as explorer hashes", () => {
+    expect(getTransactionHash(transaction)).toBeNull();
+    expect(getTransactionHash({ ...transaction, id: "txn-001" })).toBeNull();
+  });
+
+  it("builds network-specific Stellar Expert URLs", () => {
+    expect(buildStellarExpertTransactionUrl(hash, "PUBLIC")).toBe(
+      `https://stellar.expert/explorer/public/tx/${hash}`,
+    );
+    expect(buildStellarExpertTransactionUrl(hash, "TESTNET")).toBe(
+      `https://stellar.expert/explorer/testnet/tx/${hash}`,
+    );
+  });
+});

--- a/lib/utils/explorer.ts
+++ b/lib/utils/explorer.ts
@@ -1,0 +1,22 @@
+import type { StellarNetwork } from "@/context/WalletContext";
+import type { Transaction } from "@/types/Transaction";
+
+const STELLAR_TX_HASH_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+export function getTransactionHash(transaction: Transaction) {
+  const candidate = transaction.txHash ?? transaction.hash ?? transaction.id;
+
+  if (!STELLAR_TX_HASH_PATTERN.test(candidate)) {
+    return null;
+  }
+
+  return candidate.toLowerCase();
+}
+
+export function buildStellarExpertTransactionUrl(
+  hash: string,
+  network: StellarNetwork,
+) {
+  const explorerNetwork = network === "PUBLIC" ? "public" : "testnet";
+  return `https://stellar.expert/explorer/${explorerNetwork}/tx/${hash}`;
+}

--- a/types/Transaction.ts
+++ b/types/Transaction.ts
@@ -4,6 +4,8 @@ export type { AssetSymbol, TransactionType, TransactionStatus };
 
 export interface Transaction {
   id: string;
+  txHash?: string;
+  hash?: string;
   type: TransactionType;
   amount: number;
   asset: AssetSymbol;
@@ -33,7 +35,7 @@ export type FetchTransactionsResponse = {
 };
 
 export const fetchTransactions = async (
-  params: FetchTransactionsOptions = {}
+  params: FetchTransactionsOptions = {},
 ): Promise<FetchTransactionsResponse> => {
   const searchParams = new URLSearchParams();
 


### PR DESCRIPTION
Closes #664

## Summary

- add a Stellar Expert URL helper that accepts real 64-character transaction hashes from `txHash`, `hash`, or `id`
- render network-aware explorer links in both desktop and mobile transaction rows when a valid hash is available
- keep mock ids such as `TXN-001` link-free, and document the public/testnet URL behavior

## Validation

- `npm test -- --run components/shared/common/RecentTransactions.test.tsx components/shared/common/Transaction.test.tsx components/shared/common/RecentTransactions.memo.test.tsx components/shared/common/__tests__/transactions-virtualization.test.tsx lib/utils/explorer.test.ts`
- `npm run check-secrets`
- `npx prettier --check components/shared/common/TransactionRow.tsx components/shared/common/RecentTransactions.test.tsx components/shared/common/Transaction.test.tsx components/shared/common/RecentTransactions.memo.test.tsx components/shared/common/__tests__/transactions-virtualization.test.tsx types/Transaction.ts lib/utils/explorer.ts lib/utils/explorer.test.ts docs/explorer-links.md`
- `npx next lint --file components/shared/common/TransactionRow.tsx --file components/shared/common/RecentTransactions.test.tsx --file components/shared/common/Transaction.test.tsx --file components/shared/common/RecentTransactions.memo.test.tsx --file components/shared/common/__tests__/transactions-virtualization.test.tsx --file types/Transaction.ts --file lib/utils/explorer.ts --file lib/utils/explorer.test.ts`
- `git diff --check`
- `git diff --cached --check`

## Notes

- `npx next lint ...` exits 0 with one existing warning in the virtualization test image mock.
- `npm run type-check` is currently blocked by existing syntax errors in `components/molecules/SearchBar/SearchBar.tsx`.
