### PR TITLE
Harden TopNav account menu focus handling

### DIFF
--- a/components/shared/layout/TopNav.test.tsx
+++ b/components/shared/layout/TopNav.test.tsx
@@ -1,14 +1,37 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { SidebarProvider } from "@/context/SidebarContext";
 import { WalletProvider } from "@/context/WalletContext";
 import { afterEach, beforeEach, vi } from "vitest";
+
+const routerMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
 
 vi.mock("@/components/shared/layout/NotificationBell", () => ({
   default: () => <button type="button" aria-label="View notifications" />,
 }));
 
+vi.mock("@/components/molecules/SearchBar", () => ({
+  SearchBar: ({ placeholder }: { placeholder: string }) => (
+    <input aria-label={placeholder} />
+  ),
+}));
+
 import TopNav from "./TopNav";
+
+const TEST_ADDRESS = "GABCD1234567890EFGH";
+
+const mockSessionResponse = (walletAddress: string | null = TEST_ADDRESS) => ({
+  ok: Boolean(walletAddress),
+  json: async () =>
+    walletAddress ? { session: { user: { walletAddress } } } : {},
+});
 
 const renderTopNav = () =>
   render(
@@ -19,16 +42,24 @@ const renderTopNav = () =>
     </WalletProvider>,
   );
 
+const renderConnectedTopNav = async () => {
+  sessionStorage.setItem("walletAddress", TEST_ADDRESS);
+  vi.mocked(fetch).mockResolvedValue(mockSessionResponse());
+
+  const view = renderTopNav();
+  await screen.findByRole("button", { name: /connected wallet/i });
+  return view;
+};
+
 describe("TopNav Accessibility", () => {
   beforeEach(() => {
     window.sessionStorage.clear();
+    routerMock.push.mockReset();
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        json: async () => ({}),
-      }),
+      vi.fn().mockResolvedValue(mockSessionResponse(null)),
     );
+    delete window.stellar;
   });
 
   afterEach(() => {
@@ -130,5 +161,171 @@ describe("TopNav Accessibility", () => {
       expect(btn).toBeInTheDocument();
       expect(btn.tagName).toBe("BUTTON");
     });
+  });
+
+  it("opens the account menu with menu semantics without focusing the destructive action first", async () => {
+    const user = userEvent.setup();
+    await renderConnectedTopNav();
+
+    const walletButton = screen.getByRole("button", {
+      name: /connected wallet/i,
+    });
+    await user.click(walletButton);
+
+    const menu = await screen.findByRole("menu", {
+      name: /connected wallet actions/i,
+    });
+    const disconnectItem = within(menu).getByRole("menuitem", {
+      name: /disconnect wallet/i,
+    });
+
+    expect(walletButton).toHaveAttribute("aria-expanded", "true");
+    expect(walletButton).toHaveAttribute("aria-controls", "topnav-wallet-menu");
+    await waitFor(() => expect(menu).toHaveFocus());
+    expect(disconnectItem).not.toHaveFocus();
+  });
+
+  it("traps Tab focus inside the open account menu", async () => {
+    const user = userEvent.setup();
+    await renderConnectedTopNav();
+
+    await user.click(screen.getByRole("button", { name: /connected wallet/i }));
+
+    const menu = await screen.findByRole("menu", {
+      name: /connected wallet actions/i,
+    });
+    const disconnectItem = within(menu).getByRole("menuitem", {
+      name: /disconnect wallet/i,
+    });
+    await waitFor(() => expect(menu).toHaveFocus());
+
+    await user.tab();
+    expect(disconnectItem).toHaveFocus();
+
+    await user.tab();
+    expect(disconnectItem).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(disconnectItem).toHaveFocus();
+  });
+
+  it("closes on Escape and restores focus to the wallet trigger", async () => {
+    const user = userEvent.setup();
+    await renderConnectedTopNav();
+
+    const walletButton = screen.getByRole("button", {
+      name: /connected wallet/i,
+    });
+    await user.click(walletButton);
+    const menu = await screen.findByRole("menu", {
+      name: /connected wallet actions/i,
+    });
+    await waitFor(() => expect(menu).toHaveFocus());
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menu", { name: /connected wallet actions/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(walletButton).toHaveAttribute("aria-expanded", "false");
+    await waitFor(() => expect(walletButton).toHaveFocus());
+  });
+
+  it("closes on outside click and restores the collapsed ARIA state", async () => {
+    const user = userEvent.setup();
+    await renderConnectedTopNav();
+
+    const walletButton = screen.getByRole("button", {
+      name: /connected wallet/i,
+    });
+    const networkButton = screen.getByRole("button", {
+      name: /select network/i,
+    });
+
+    await user.click(walletButton);
+    expect(
+      await screen.findByRole("menu", { name: /connected wallet actions/i }),
+    ).toBeInTheDocument();
+
+    await user.click(networkButton);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menu", { name: /connected wallet actions/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(walletButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("supports rapid trigger open and close without leaving stale menu state", async () => {
+    const user = userEvent.setup();
+    await renderConnectedTopNav();
+
+    const walletButton = screen.getByRole("button", {
+      name: /connected wallet/i,
+    });
+
+    await user.click(walletButton);
+    expect(
+      await screen.findByRole("menu", { name: /connected wallet actions/i }),
+    ).toBeInTheDocument();
+
+    await user.click(walletButton);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menu", { name: /connected wallet actions/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(walletButton).toHaveAttribute("aria-expanded", "false");
+    expect(walletButton).toHaveFocus();
+  });
+
+  it("disconnects from the menu without restoring focus to the removed wallet trigger", async () => {
+    const user = userEvent.setup();
+    await renderConnectedTopNav();
+
+    await user.click(screen.getByRole("button", { name: /connected wallet/i }));
+    const menu = await screen.findByRole("menu", {
+      name: /connected wallet actions/i,
+    });
+    const disconnectItem = within(menu).getByRole("menuitem", {
+      name: /disconnect wallet/i,
+    });
+
+    await user.click(disconnectItem);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menu", { name: /connected wallet actions/i }),
+      ).not.toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /connected wallet/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(sessionStorage.getItem("walletAddress")).toBeNull();
+  });
+
+  it("renders and invokes the connect wallet action when disconnected", async () => {
+    const user = userEvent.setup();
+    renderTopNav();
+
+    const connectButton = screen.getByRole("button", {
+      name: /connect wallet/i,
+    });
+    expect(connectButton).toHaveTextContent("Connect Wallet");
+    expect(connectButton).toBeEnabled();
+
+    await user.click(connectButton);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("wallet-error")).toHaveTextContent(
+        /not detected/i,
+      ),
+    );
   });
 });

--- a/components/shared/layout/TopNav.tsx
+++ b/components/shared/layout/TopNav.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from "react";
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { SearchBar } from "@/components/molecules/SearchBar";
 import { useSidebar } from "@/context/SidebarContext";
@@ -47,17 +49,101 @@ const TopNav = () => {
     disconnect,
   } = useWalletContext();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const walletButtonRef = useRef<HTMLButtonElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
 
   const loading = status === "connecting";
 
+  const closeDropdown = useCallback((restoreFocus = true) => {
+    setIsDropdownOpen(false);
+
+    if (restoreFocus) {
+      requestAnimationFrame(() => walletButtonRef.current?.focus());
+    }
+  }, []);
+
   const handleDisconnect = async () => {
     await disconnect();
-    setIsDropdownOpen(false);
+    closeDropdown(false);
   };
 
   const getShortAddress = (addr: string) => {
     return `${addr.slice(0, 5)}...${addr.slice(-4)}`;
   };
+
+  useEffect(() => {
+    if (!isDropdownOpen) {
+      return;
+    }
+
+    requestAnimationFrame(() => dropdownRef.current?.focus());
+
+    const getFocusableMenuItems = () =>
+      Array.from(
+        dropdownRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      ).filter(
+        (element) =>
+          !element.hasAttribute("disabled") && element.tabIndex !== -1,
+      );
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeDropdown();
+        return;
+      }
+
+      if (event.key !== "Tab" || !dropdownRef.current) {
+        return;
+      }
+
+      const focusableItems = getFocusableMenuItems();
+      if (focusableItems.length === 0) {
+        event.preventDefault();
+        dropdownRef.current.focus();
+        return;
+      }
+
+      const firstItem = focusableItems[0];
+      const lastItem = focusableItems[focusableItems.length - 1];
+
+      if (document.activeElement === dropdownRef.current) {
+        event.preventDefault();
+        (event.shiftKey ? lastItem : firstItem).focus();
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === firstItem) {
+        event.preventDefault();
+        lastItem.focus();
+      } else if (!event.shiftKey && document.activeElement === lastItem) {
+        event.preventDefault();
+        firstItem.focus();
+      }
+    };
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        dropdownRef.current?.contains(target) ||
+        walletButtonRef.current?.contains(target)
+      ) {
+        return;
+      }
+
+      closeDropdown(false);
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("mousedown", handleMouseDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [closeDropdown, isDropdownOpen]);
 
   return (
     <div className="w-full flex flex-col-reverse sm:flex-row items-start sm:items-center justify-between bg-green-600 px-6 md:px-12 py-4 rounded-md gap-4 sm:gap-0">
@@ -100,9 +186,21 @@ const TopNav = () => {
             {walletAddress ? (
               <div className="relative">
                 <button
+                  ref={walletButtonRef}
                   type="button"
                   aria-label="Connected wallet"
-                  onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                  aria-haspopup="menu"
+                  aria-expanded={isDropdownOpen}
+                  aria-controls={
+                    isDropdownOpen ? "topnav-wallet-menu" : undefined
+                  }
+                  onClick={() => {
+                    if (isDropdownOpen) {
+                      closeDropdown();
+                    } else {
+                      setIsDropdownOpen(true);
+                    }
+                  }}
                   className={`flex cursor-pointer hover:bg-white/30 items-center text-white text-sm justify-between border py-2 px-4 w-[139px] rounded-full ${focusClasses}`}
                 >
                   <span>{getShortAddress(walletAddress)}</span>
@@ -119,10 +217,18 @@ const TopNav = () => {
                   </svg>
                 </button>
                 {isDropdownOpen && (
-                  <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg py-1 z-50 border border-gray-200 dark:border-gray-700">
+                  <div
+                    id="topnav-wallet-menu"
+                    ref={dropdownRef}
+                    role="menu"
+                    aria-label="Connected wallet actions"
+                    tabIndex={-1}
+                    className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg py-1 z-50 border border-gray-200 dark:border-gray-700 focus:outline-none"
+                  >
                     <button
                       type="button"
-                      onClick={disconnect}
+                      role="menuitem"
+                      onClick={handleDisconnect}
                       className="block w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:bg-gray-100 text-red-600 font-medium"
                     >
                       Disconnect Wallet

--- a/docs/topnav-menu-a11y.md
+++ b/docs/topnav-menu-a11y.md
@@ -1,0 +1,13 @@
+# TopNav Account Menu Accessibility
+
+The TopNav connected-wallet trigger opens a small account action menu. The menu follows these keyboard and screen-reader contracts:
+
+- The trigger exposes `aria-haspopup="menu"` and updates `aria-expanded` while the menu is open.
+- The open menu is labelled as "Connected wallet actions" and uses `role="menu"`.
+- Menu actions use `role="menuitem"`.
+- Focus moves to the menu container first so the destructive Disconnect Wallet action is not the default focus target.
+- `Tab` and `Shift+Tab` stay inside the open menu.
+- `Escape` closes the menu and returns focus to the connected-wallet trigger.
+- Clicking outside the menu closes it and restores the collapsed ARIA state.
+
+Keep future account actions inside the same menu container so the focus trap can include them automatically.


### PR DESCRIPTION
Fixes StellarLend/Stellarlend-frontend#680.

## Summary

- Add menu semantics, ARIA expanded/controls state, and focus restoration to the connected-wallet TopNav trigger.
- Focus the wallet actions menu container on open so the destructive Disconnect action is not the default focus target.
- Trap Tab/Shift+Tab inside the open menu, close on Escape, and dismiss on outside click.
- Document the keyboard and focus contract in `docs/topnav-menu-a11y.md`.

## Validation

- `npm test -- --run components/shared/layout/TopNav.test.tsx`
- `npm run check-secrets`
- `npx prettier --check components/shared/layout/TopNav.tsx components/shared/layout/TopNav.test.tsx docs/topnav-menu-a11y.md`
- `npx next lint --file components/shared/layout/TopNav.tsx --file components/shared/layout/TopNav.test.tsx`
- `git diff --check origin/main..HEAD`

Notes:

- The focused test intentionally mocks `SearchBar` because current upstream `components/molecules/SearchBar/SearchBar.tsx` has an unrelated parse error around its prop comments. This same baseline issue blocks broader type/build checks before reaching the TopNav files.
- Vitest logs the expected Freighter-not-detected error in the disconnected-wallet test and Storybook cannot write global settings under this sandboxed user home, but the focused TopNav suite passes: 15 tests.
