### PR TITLE
docs: add rate-limiting strategy guide

### DIFF
--- a/__tests__/config/rate-limiting-doc.test.ts
+++ b/__tests__/config/rate-limiting-doc.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const rootDir = path.resolve(__dirname, "../..");
+
+function readProjectFile(relativePath: string) {
+  return readFileSync(path.join(rootDir, relativePath), "utf8");
+}
+
+describe("rate-limiting documentation", () => {
+  it("documents the exported limiter symbols and tuning keys", () => {
+    const doc = readProjectFile("docs/rate-limiting.md");
+    const globalLimiter = readProjectFile("lib/rate-limit.ts");
+    const accountBucket = readProjectFile("lib/rate-limit/account-bucket.ts");
+    const config = readProjectFile("lib/config.ts");
+
+    const requiredExports = [
+      "RateLimitResult",
+      "rateLimit",
+      "clearRateLimitCache",
+      "AccountBucketOptions",
+      "AccountBucketResult",
+      "accountBucketRateLimit",
+      "clearAccountBucketCache",
+    ];
+
+    for (const exportedName of requiredExports) {
+      expect(`${globalLimiter}\n${accountBucket}`).toContain(exportedName);
+      expect(doc).toContain(exportedName);
+    }
+
+    const requiredEnvKeys = [
+      "RATE_LIMIT_MAX",
+      "RATE_LIMIT_WINDOW",
+      "TX_ACCOUNT_RATE_LIMIT_MAX",
+      "TX_ACCOUNT_RATE_LIMIT_WINDOW_MS",
+      "TX_ACCOUNT_RATE_LIMIT_BURST",
+    ];
+
+    for (const envKey of requiredEnvKeys) {
+      expect(config).toContain(envKey);
+      expect(doc).toContain(envKey);
+    }
+  });
+
+  it("documents every route that applies account bucket rate limiting", () => {
+    const doc = readProjectFile("docs/rate-limiting.md");
+    const rateLimitedRoutes = [
+      "app/api/tx/build/route.ts",
+      "app/api/tx/submit/route.ts",
+      "app/api/account/delete/challenge/route.ts",
+    ];
+
+    for (const route of rateLimitedRoutes) {
+      const source = readProjectFile(route);
+      expect(source).toContain("accountBucketRateLimit");
+      expect(doc).toContain(route);
+    }
+  });
+
+  it("keeps documented rate-limit headers and error codes in sync", () => {
+    const doc = readProjectFile("docs/rate-limiting.md");
+    const middleware = readProjectFile("middleware.ts");
+    const txBuildRoute = readProjectFile("app/api/tx/build/route.ts");
+
+    const headers = [
+      "X-RateLimit-Limit",
+      "X-RateLimit-Remaining",
+      "X-RateLimit-Reset",
+      "Retry-After",
+    ];
+
+    for (const header of headers) {
+      expect(`${middleware}\n${txBuildRoute}`).toContain(header);
+      expect(doc).toContain(header);
+    }
+
+    expect(txBuildRoute).toContain("RATE_LIMIT_EXCEEDED");
+    expect(doc).toContain("RATE_LIMIT_EXCEEDED");
+    expect(middleware).toContain("Too Many Requests");
+    expect(doc).toContain("Too Many Requests");
+  });
+});

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -92,6 +92,14 @@ Cache keys follow the convention `<domain>:<dimension>:<value>`:
 | `/api/markets` | `markets:assets:BTC,ETH` | 30 s / 60 s |
 | `/api/positions` | `positions:public` | 10 s / 20 s |
 
+### lib/rate-limit.ts and lib/rate-limit/account-bucket.ts
+
+Anonymous API requests are limited in `middleware.ts` through the fixed-window
+`rateLimit` utility. Authenticated transaction and account-deletion challenge
+routes use the token-bucket `accountBucketRateLimit` utility. The current
+strategy, headers, response shapes, and tuning knobs are documented in
+[docs/rate-limiting.md](./rate-limiting.md).
+
 ### lib/http/client.ts — HTTP client
 
 `httpGet<T>(url, options?)` — GET with exponential-backoff retry (3 attempts).

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,102 @@
+# Rate Limiting Strategy
+
+Stellarlend uses two in-memory limiters:
+
+- `rateLimit` in `lib/rate-limit.ts` protects anonymous API traffic with a fixed-window counter.
+- `accountBucketRateLimit` in `lib/rate-limit/account-bucket.ts` protects authenticated account actions with a token bucket.
+
+Both limiters return the same core shape from `RateLimitResult`: `success`, `limit`, `remaining`, and `reset`. The account bucket extends that shape with `retryAfter` through `AccountBucketResult`.
+
+## Global API Limiter
+
+`middleware.ts` applies the global limiter to `app/api/*` through the Next.js middleware matcher. It identifies anonymous requests by `x-forwarded-for` and stores them as `api-ratelimit:<ip>`.
+
+Authenticated internal calls are skipped when the configured session cookie is present. Skipped calls still receive the request ID, content security policy, and referrer policy headers.
+
+Global settings come from:
+
+| Config path               | Environment variable | Default    |
+| ------------------------- | -------------------- | ---------- |
+| `config.rateLimit.max`    | `RATE_LIMIT_MAX`     | `100`      |
+| `config.rateLimit.window` | `RATE_LIMIT_WINDOW`  | `60000` ms |
+
+When the global limiter blocks a request, middleware returns:
+
+```json
+{
+  "error": "Too Many Requests",
+  "message": "Rate limit exceeded. Please try again later."
+}
+```
+
+The response status is `429`.
+
+## Account Bucket Limiter
+
+`accountBucketRateLimit` normalizes the wallet or user identifier to lowercase and refills tokens over time. Its `AccountBucketOptions` input provides `limit`, `windowMs`, and `burst`. The bucket starts with `burst` capacity, refills at `limit / windowMs`, and returns `retryAfter` when there are not enough tokens for another request.
+
+Account bucket settings come from:
+
+| Config path                         | Environment variable              | Default    |
+| ----------------------------------- | --------------------------------- | ---------- |
+| `config.rateLimit.account.limit`    | `TX_ACCOUNT_RATE_LIMIT_MAX`       | `30`       |
+| `config.rateLimit.account.windowMs` | `TX_ACCOUNT_RATE_LIMIT_WINDOW_MS` | `60000` ms |
+| `config.rateLimit.account.burst`    | `TX_ACCOUNT_RATE_LIMIT_BURST`     | `60`       |
+
+The account bucket is currently applied by:
+
+- `app/api/tx/build/route.ts`, keyed by `session.user.walletAddress`.
+- `app/api/tx/submit/route.ts`, keyed by `session.user.walletAddress`.
+- `app/api/account/delete/challenge/route.ts`, keyed by the authenticated user ID.
+
+When an account bucket blocks a request, routes return a structured error envelope:
+
+```json
+{
+  "error": {
+    "code": "RATE_LIMIT_EXCEEDED",
+    "message": "Account rate limit exceeded. Please try again later.",
+    "limit": 30,
+    "remaining": 0,
+    "reset": 1730000000,
+    "retryAfter": 2
+  }
+}
+```
+
+`app/api/account/delete/challenge/route.ts` uses the same `RATE_LIMIT_EXCEEDED` code with a route-specific message.
+
+## Headers
+
+Blocked and allowed global middleware responses include:
+
+- `X-RateLimit-Limit`
+- `X-RateLimit-Remaining`
+- `X-RateLimit-Reset`
+
+Blocked global responses and blocked account bucket responses also include:
+
+- `Retry-After`
+
+The global limiter stores `reset` internally in milliseconds and sends `X-RateLimit-Reset` as seconds. The account bucket computes `reset` in seconds and sends it directly.
+
+## Tuning Guidance
+
+Use the global limiter for broad anonymous API pressure, such as bots or unauthenticated scraping.
+
+Use the account bucket for operations where a signed-in account or wallet can create load or irreversible side effects. Transaction build, transaction submit, and account deletion challenge issuance are account-scoped because they should not share a rate budget with unrelated users behind the same IP.
+
+When tuning a route:
+
+1. Keep `RATE_LIMIT_MAX` and `RATE_LIMIT_WINDOW` broad enough for normal page loads and background polling.
+2. Tune `TX_ACCOUNT_RATE_LIMIT_MAX` and `TX_ACCOUNT_RATE_LIMIT_WINDOW_MS` around expected authenticated bursts.
+3. Set `TX_ACCOUNT_RATE_LIMIT_BURST` higher than `TX_ACCOUNT_RATE_LIMIT_MAX` only when short bursts are acceptable and sustained traffic still needs throttling.
+4. Preserve `Retry-After` on blocked account routes so clients can stop retrying until the bucket refills.
+
+## Test Coverage
+
+`lib/rate-limit.test.ts` covers the fixed-window utility and `clearRateLimitCache`.
+
+`lib/rate-limit/account-bucket.test.ts` covers burst capacity, refill behavior, `retryAfter`, and `clearAccountBucketCache`.
+
+`__tests__/config/rate-limiting-doc.test.ts` keeps this document tied to the exported limiter symbols, route files, headers, and configuration keys.


### PR DESCRIPTION
Fixes StellarLend/Stellarlend-frontend#685.

## Summary

- Add docs/rate-limiting.md covering the global limiter, account-bucket limiter, route usage, response headers, error shape, and tuning knobs.
- Cross-link the guide from docs/backend-architecture.md.
- Add a Vitest sync check that verifies the docs mention the actual limiter exports, env keys, route files, headers, and rate-limit error text.

## Validation

- npm test -- --run __tests__/config/rate-limiting-doc.test.ts
- npm run check-secrets
- npx prettier --check __tests__/config/rate-limiting-doc.test.ts docs/rate-limiting.md
- git diff --check origin/main..HEAD

Notes:

- The focused test passes with 3 tests. Vitest emits existing upstream warnings about duplicate include keys in vitest.config.ts and Storybook global settings write permission under this sandboxed home, but the targeted docs sync suite passes.
- I did not run Prettier across the existing docs/backend-architecture.md file because it rewrites broad pre-existing table/list formatting unrelated to this issue.