### PR TITLE
test: add api error envelope coverage

### DIFF
--- a/docs/api-error-envelope.md
+++ b/docs/api-error-envelope.md
@@ -1,0 +1,48 @@
+# API Error Envelope
+
+`lib/api/errors.ts` defines the small server-side contract used to classify
+common API failures before route handlers serialize them.
+
+## Domain Errors
+
+| Error class       | HTTP status | Envelope code          | Use case                                                               |
+| ----------------- | ----------: | ---------------------- | ---------------------------------------------------------------------- |
+| `ValidationError` |         400 | `VALIDATION_ERROR`     | Request body, query, or field validation failed.                       |
+| `AuthError`       |         401 | `AUTHENTICATION_ERROR` | The caller is missing a valid authenticated session or credential.     |
+| `UpstreamError`   |         502 | `UPSTREAM_ERROR`       | A dependency such as Horizon, Soroban RPC, or a price provider failed. |
+| Unknown error     |         500 | `INTERNAL_ERROR`       | Any unexpected failure that should not expose internals.               |
+
+## Envelope Shape
+
+```ts
+{
+  error: {
+    code: 'VALIDATION_ERROR',
+    message: 'Invalid request body',
+    requestId: '01HZ0000000000000000000000',
+    details: {
+      email: ['email is required']
+    }
+  }
+}
+```
+
+`requestId` is always present in the helper output and is `null` when a caller
+does not provide one. Validation details are only included for
+`ValidationError` instances that carry field-level detail.
+
+## Safety Rules
+
+- Known domain errors keep their public message so callers can fix the request
+  or retry the right dependency.
+- Unknown errors are mapped to `INTERNAL_ERROR` with the generic message
+  `Internal server error`.
+- Nested causes, stack traces, connection strings, credentials, tokens, and raw
+  exception messages from unknown errors must not be serialized into the client
+  envelope.
+
+## Review Notes
+
+The current helper is pure and does not change existing route behavior by
+itself. Route handlers can opt into it when they need a stable JSON error
+contract with typed status mapping and request-id propagation.

--- a/lib/api/errors.test.ts
+++ b/lib/api/errors.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  AuthError,
+  UpstreamError,
+  ValidationError,
+  getApiErrorStatus,
+  toApiErrorEnvelope,
+} from "./errors";
+
+describe("lib/api/errors", () => {
+  it("maps domain errors to stable HTTP status codes", () => {
+    expect(getApiErrorStatus(new ValidationError("Invalid profile"))).toBe(400);
+    expect(getApiErrorStatus(new AuthError("Unauthorized"))).toBe(401);
+    expect(getApiErrorStatus(new UpstreamError("Horizon unavailable"))).toBe(
+      502,
+    );
+  });
+
+  it("falls back to a safe 500 status for unknown errors", () => {
+    expect(
+      getApiErrorStatus(new Error("database password leaked in message")),
+    ).toBe(500);
+    expect(getApiErrorStatus("unexpected string failure")).toBe(500);
+  });
+
+  it("builds a validation envelope with request id and field details", () => {
+    const envelope = toApiErrorEnvelope(
+      new ValidationError("Invalid request body", {
+        email: ["email is required", "email must be valid"],
+        wallet: ["wallet address is invalid"],
+      }),
+      { requestId: "01HZ0000000000000000000000" },
+    );
+
+    expect(envelope).toEqual({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid request body",
+        requestId: "01HZ0000000000000000000000",
+        details: {
+          email: ["email is required", "email must be valid"],
+          wallet: ["wallet address is invalid"],
+        },
+      },
+    });
+  });
+
+  it("builds auth and upstream envelopes without validation details", () => {
+    expect(toApiErrorEnvelope(new AuthError("Session required"))).toEqual({
+      error: {
+        code: "AUTHENTICATION_ERROR",
+        message: "Session required",
+        requestId: null,
+      },
+    });
+
+    expect(
+      toApiErrorEnvelope(new UpstreamError("Price oracle unavailable"), {
+        requestId: "req-123",
+      }),
+    ).toEqual({
+      error: {
+        code: "UPSTREAM_ERROR",
+        message: "Price oracle unavailable",
+        requestId: "req-123",
+      },
+    });
+  });
+
+  it("sanitizes unknown and nested errors without leaking internals", () => {
+    const error = new Error("postgres://user:secret@example/db failed", {
+      cause: new Error("nested token should stay private"),
+    });
+
+    expect(toApiErrorEnvelope(error, { requestId: "req-private" })).toEqual({
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Internal server error",
+        requestId: "req-private",
+      },
+    });
+  });
+});

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -1,29 +1,110 @@
 /**
  * Domain-specific error classes for API route handlers.
- * Each class carries a `statusCode` so the handler can map it to an HTTP status
- * without coupling routing logic to business logic.
+ * Each class carries a `statusCode` so handlers can map errors to HTTP status
+ * codes without coupling routing logic to business logic.
  */
+
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "AUTHENTICATION_ERROR"
+  | "UPSTREAM_ERROR"
+  | "INTERNAL_ERROR";
+
+export type ValidationFieldErrors = Record<string, string[]>;
+
+export interface ApiErrorEnvelope {
+  error: {
+    code: ApiErrorCode;
+    message: string;
+    requestId: string | null;
+    details?: ValidationFieldErrors;
+  };
+}
 
 export class ValidationError extends Error {
   readonly statusCode = 400;
-  constructor(message: string) {
+
+  constructor(
+    message: string,
+    readonly details?: ValidationFieldErrors,
+  ) {
     super(message);
-    this.name = 'ValidationError';
+    this.name = "ValidationError";
   }
 }
 
 export class AuthError extends Error {
   readonly statusCode = 401;
+
   constructor(message: string) {
     super(message);
-    this.name = 'AuthError';
+    this.name = "AuthError";
   }
 }
 
 export class UpstreamError extends Error {
   readonly statusCode = 502;
+
   constructor(message: string) {
     super(message);
-    this.name = 'UpstreamError';
+    this.name = "UpstreamError";
   }
+}
+
+export function getApiErrorStatus(error: unknown): number {
+  if (
+    error instanceof ValidationError ||
+    error instanceof AuthError ||
+    error instanceof UpstreamError
+  ) {
+    return error.statusCode;
+  }
+
+  return 500;
+}
+
+export function toApiErrorEnvelope(
+  error: unknown,
+  options: { requestId?: string | null } = {},
+): ApiErrorEnvelope {
+  const requestId = options.requestId ?? null;
+
+  if (error instanceof ValidationError) {
+    return {
+      error: {
+        code: "VALIDATION_ERROR",
+        message: error.message,
+        requestId,
+        ...(error.details ? { details: error.details } : {}),
+      },
+    };
+  }
+
+  if (error instanceof AuthError) {
+    return {
+      error: {
+        code: "AUTHENTICATION_ERROR",
+        message: error.message,
+        requestId,
+      },
+    };
+  }
+
+  if (error instanceof UpstreamError) {
+    return {
+      error: {
+        code: "UPSTREAM_ERROR",
+        message: error.message,
+        requestId,
+      },
+    };
+  }
+
+  return {
+    error: {
+      code: "INTERNAL_ERROR",
+      message: "Internal server error",
+      requestId,
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add API error envelope helpers for typed API errors with status mapping and request-id slots
- cover validation details, auth/upstream mappings, unknown error fallback, and nested-error sanitization in `lib/api/errors.test.ts`
- document the tested API error envelope contract in `docs/api-error-envelope.md`

## Validation
- `npx --yes vitest@3.2.4 run --config vitest.api-errors.config.ts` -> 5 tests passed using a temporary no-dependency config for this single file
- `npx --yes tsx@4.20.5 -e "..."` -> API error helper smoke passed
- `npx --yes prettier@3.6.2 --check lib\api\errors.ts lib\api\errors.test.ts docs\api-error-envelope.md` -> passed
- `git diff --check` -> passed with Windows LF/CRLF warnings only

Note: I did not run the full repository `npm test` because this shallow checkout has no local `node_modules`; the default Vitest config requires project dev dependencies/plugins that are not installed locally.

Closes #675
