### PR TITLE
test: cover requireFlag enforcement

### DIFF
--- a/docs/require-flag.md
+++ b/docs/require-flag.md
@@ -1,0 +1,33 @@
+# Feature Flag Enforcement Contract
+
+`lib/flags/requireFlag.ts` is the server-side assertion helper for code paths
+that must fail closed when a feature is disabled.
+
+## Runtime Contract
+
+```ts
+requireFlag("accountExport", userId);
+```
+
+- Calls `evaluateFlag(flagKey, userId)` with the exact flag key and user id.
+- Returns `void` when the evaluator says the flag is enabled.
+- Throws `Error("Feature flag '<flag>' is disabled for user '<user>'.")` when
+  the evaluator returns `false`.
+- Unknown flags are safe by default because `evaluateFlag` returns `false` for
+  missing config entries.
+- Percentage or bucketed rollout decisions are owned by `evaluateFlag`;
+  `requireFlag` only enforces the boolean decision it receives.
+
+## Failure Modes
+
+`requireFlag` does not catch or rewrite evaluator exceptions. If the evaluator
+throws because configuration cannot be loaded or parsed, the original error
+propagates to the caller. Route handlers that need a specific HTTP envelope
+should catch this at the route boundary and map it to the standard API error
+shape.
+
+## Review Notes
+
+The test coverage for this helper uses a mocked evaluator so it can focus on
+the enforcement contract without mutating `config/feature-flags.json` or relying
+on a particular rollout hash bucket.

--- a/lib/flags/requireFlag.test.ts
+++ b/lib/flags/requireFlag.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { evaluateFlag } from "./evaluator";
+import { requireFlag } from "./requireFlag";
+
+vi.mock("./evaluator", () => ({
+  evaluateFlag: vi.fn(),
+}));
+
+const evaluateFlagMock = vi.mocked(evaluateFlag);
+
+describe("requireFlag", () => {
+  beforeEach(() => {
+    evaluateFlagMock.mockReset();
+  });
+
+  it("allows an enabled flag to pass through without throwing", () => {
+    evaluateFlagMock.mockReturnValue(true);
+
+    expect(() => requireFlag("accountExport", "user-123")).not.toThrow();
+    expect(evaluateFlagMock).toHaveBeenCalledWith("accountExport", "user-123");
+  });
+
+  it("blocks a disabled flag with the existing enforcement error", () => {
+    evaluateFlagMock.mockReturnValue(false);
+
+    expect(() => requireFlag("accountExport", "user-123")).toThrow(
+      "Feature flag 'accountExport' is disabled for user 'user-123'.",
+    );
+  });
+
+  it("treats unknown flags as safely closed when the evaluator returns false", () => {
+    evaluateFlagMock.mockReturnValue(false);
+
+    expect(() => requireFlag("unknownFlag", "user-456")).toThrow(
+      "Feature flag 'unknownFlag' is disabled for user 'user-456'.",
+    );
+    expect(evaluateFlagMock).toHaveBeenCalledWith("unknownFlag", "user-456");
+  });
+
+  it("respects bucketed or percentage rollout decisions from the evaluator", () => {
+    evaluateFlagMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    expect(() => requireFlag("rolloutFlag", "bucket-in")).not.toThrow();
+    expect(() => requireFlag("rolloutFlag", "bucket-out")).toThrow(
+      "Feature flag 'rolloutFlag' is disabled for user 'bucket-out'.",
+    );
+    expect(evaluateFlagMock).toHaveBeenNthCalledWith(
+      1,
+      "rolloutFlag",
+      "bucket-in",
+    );
+    expect(evaluateFlagMock).toHaveBeenNthCalledWith(
+      2,
+      "rolloutFlag",
+      "bucket-out",
+    );
+  });
+
+  it("propagates evaluator errors without rewriting production behavior", () => {
+    const evaluatorError = new Error("feature flag config could not be read");
+    evaluateFlagMock.mockImplementation(() => {
+      throw evaluatorError;
+    });
+
+    expect(() => requireFlag("configBackedFlag", "user-789")).toThrow(
+      evaluatorError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add focused unit coverage for `lib/flags/requireFlag.ts` without changing production code
- cover enabled pass-through, disabled enforcement, unknown-flag fail-closed behavior, bucketed evaluator outcomes, and evaluator error propagation
- document the feature flag enforcement contract in `docs/require-flag.md`

## Validation
- `npx --yes vitest@3.2.4 run --config vitest.require-flag.config.ts` -> 5 tests passed using a temporary no-dependency config for this single file
- `npx --yes prettier@3.6.2 --check lib\flags\requireFlag.test.ts docs\require-flag.md` -> passed
- `git diff --check` -> passed

Note: I did not run the full repository `npm test` because this shallow checkout has no local `node_modules`; the default Vitest config requires project dev dependencies/plugins that are not installed locally.

Closes #676
