### PR TITLE
test: cover audit events and logger

### DIFF
--- a/docs/audit-events.md
+++ b/docs/audit-events.md
@@ -1,0 +1,87 @@
+# Audit Events and Redaction
+
+Stellarlend currently has two audit utilities:
+
+- `lib/audit/events.ts` stores account-deletion and cleanup events in a local
+  in-memory audit list for account lifecycle workflows.
+- `lib/audit/logger.ts` stores request-scoped audit rows for profile, auth, and
+  transaction flows, and emits admin audit events as JSON lines.
+
+## Event Catalogue
+
+### Account Lifecycle Events
+
+`lib/audit/events.ts` supports:
+
+- `account.deleted`
+- `account.anonymized`
+- `sessions.revoked`
+- `data.cleanup.enqueued`
+- `data.cleanup.completed`
+- `data.cleanup.failed`
+- `auth.challenge.issued`
+- `auth.challenge.verified`
+- `auth.challenge.rate_limited`
+
+Each event includes:
+
+- `id`
+- `type`
+- `userId`
+- `timestamp`
+- `metadata`
+
+The metadata object is caller-provided. Callers should avoid placing raw
+credentials, tokens, signed envelopes, or wallet secrets there.
+
+### Request Audit Rows
+
+`lib/audit/logger.ts` appends rows with:
+
+- `actorWallet`
+- `action`
+- `resource`
+- `status`
+- `requestId`
+- `ipHash`
+- `createdAt`
+
+IP addresses should be passed through `hashIp()` before being stored. The
+current route usage stores wallet addresses as actor identifiers, not as payload
+metadata.
+
+### Admin Audit Events
+
+Admin audit events are emitted as one JSON object per line with:
+
+- `type: "AUDIT"`
+- `timestamp`
+- `action`
+- `actorId`
+- `context`
+
+## Redaction Rules
+
+Use `redactAuditPayload()` before attaching arbitrary payload objects to audit
+context. It removes known sensitive keys:
+
+- `actorWallet`
+- `password`
+- `privateKey`
+- `publicKey`
+- `secret`
+- `seed`
+- `signedEnvelopeXdr`
+- `token`
+- `transaction`
+- `walletAddress`
+
+Unknown fields are preserved so reviewers can see operational context without
+including credentials or signed transaction material.
+
+## Review Notes
+
+The dedicated tests cover event shape, timestamp behavior, request-id slots,
+filtering, fake stdout sinks, append-only reads, missing actor fallback values,
+oversized caller metadata, and redaction of token, wallet, and signed-envelope
+payload fields.

--- a/lib/audit/events.test.ts
+++ b/lib/audit/events.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "@/lib/logger";
+import { clearAuditLog, emitAuditEvent, getAuditEvents } from "./events";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+  },
+}));
+
+const loggerInfo = vi.mocked(logger.info);
+
+describe("lib/audit/events", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T09:00:00.000Z"));
+    clearAuditLog();
+    loggerInfo.mockClear();
+  });
+
+  it("shapes emitted events with actor, action, timestamp, request id metadata, and logger context", () => {
+    const event = emitAuditEvent("account.deleted", "user-123", {
+      requestId: "req-001",
+      reason: "user-requested-delete",
+    });
+
+    expect(event).toEqual({
+      id: "audit-1783414800000-1",
+      type: "account.deleted",
+      userId: "user-123",
+      timestamp: "2026-07-07T09:00:00.000Z",
+      metadata: {
+        requestId: "req-001",
+        reason: "user-requested-delete",
+      },
+    });
+    expect(loggerInfo).toHaveBeenCalledWith(
+      "audit: account.deleted",
+      "/api/audit",
+      {
+        eventId: event.id,
+        userId: "user-123",
+        type: "account.deleted",
+      },
+    );
+  });
+
+  it("filters stored events by user, type, and since timestamp", () => {
+    emitAuditEvent("account.deleted", "user-a", { requestId: "req-a" });
+
+    vi.setSystemTime(new Date("2026-07-07T09:01:00.000Z"));
+    emitAuditEvent("sessions.revoked", "user-a", { requestId: "req-b" });
+    emitAuditEvent("account.deleted", "user-b", { requestId: "req-c" });
+
+    expect(
+      getAuditEvents({ userId: "user-a" }).map((event) => event.type),
+    ).toEqual(["account.deleted", "sessions.revoked"]);
+    expect(
+      getAuditEvents({ type: "account.deleted" }).map((event) => event.userId),
+    ).toEqual(["user-a", "user-b"]);
+    expect(getAuditEvents({ since: "2026-07-07T09:00:30.000Z" })).toHaveLength(
+      2,
+    );
+  });
+
+  it("supports missing actor fallback values without dropping the audit record", () => {
+    const event = emitAuditEvent("data.cleanup.failed", "", {
+      requestId: null,
+      error: "missing actor in cleanup context",
+    });
+
+    expect(event.userId).toBe("");
+    expect(event.metadata.requestId).toBeNull();
+    expect(getAuditEvents()).toHaveLength(1);
+  });
+
+  it("stores oversized metadata payloads as explicit caller-provided context", () => {
+    const largeReason = "x".repeat(2_048);
+
+    const event = emitAuditEvent("data.cleanup.enqueued", "user-large", {
+      requestId: "req-large",
+      reason: largeReason,
+    });
+
+    expect(event.metadata.reason).toBe(largeReason);
+    expect(getAuditEvents({ userId: "user-large" })[0].metadata.reason).toBe(
+      largeReason,
+    );
+  });
+
+  it("clears stored events and resets generated ids for tests", () => {
+    emitAuditEvent("account.deleted", "user-before-clear");
+    clearAuditLog();
+
+    const event = emitAuditEvent("sessions.revoked", "user-after-clear");
+
+    expect(getAuditEvents()).toHaveLength(1);
+    expect(event.id).toBe("audit-1783414800000-1");
+  });
+});

--- a/lib/audit/logger.test.ts
+++ b/lib/audit/logger.test.ts
@@ -1,0 +1,131 @@
+import crypto from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  appendAuditEvent,
+  auditAdminUsersRead,
+  clearAuditEventsForTests,
+  emitAuditEvent,
+  getAuditEvents,
+  hashIp,
+  redactAuditPayload,
+} from "./logger";
+
+describe("lib/audit/logger", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T10:00:00.000Z"));
+    clearAuditEventsForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("hashes IP addresses deterministically and keeps missing IPs null", () => {
+    const expected = crypto
+      .createHash("sha256")
+      .update("203.0.113.10")
+      .digest("hex");
+
+    expect(hashIp("203.0.113.10")).toBe(expected);
+    expect(hashIp(null)).toBeNull();
+    expect(hashIp(undefined)).toBeNull();
+  });
+
+  it("redacts sensitive payload fields while preserving safe context", () => {
+    const redacted = redactAuditPayload({
+      actorWallet: "GACTOR",
+      page: 1,
+      password: "plain-password",
+      publicKey: "GPUBLIC",
+      query: "status:active",
+      secret: "secret-value",
+      signedEnvelopeXdr: "AAAA...",
+      token: "session-token",
+      transaction: "signed-transaction",
+      walletAddress: "GWALLET",
+    });
+
+    expect(redacted).toEqual({
+      page: 1,
+      query: "status:active",
+    });
+  });
+
+  it("appends audit records with actor, action, timestamp, request id slot, and status", async () => {
+    const row = await appendAuditEvent({
+      actorWallet: "GACTOR",
+      action: "profile.update",
+      resource: "account.profile",
+      status: "success",
+      requestId: "req-123",
+      ipHash: "hashed-ip",
+    });
+
+    expect(row).toEqual({
+      actorWallet: "GACTOR",
+      action: "profile.update",
+      resource: "account.profile",
+      status: "success",
+      requestId: "req-123",
+      ipHash: "hashed-ip",
+      createdAt: "2026-07-07T10:00:00.000Z",
+    });
+    expect(getAuditEvents()).toEqual([row]);
+  });
+
+  it("returns a copy of the append-only audit event list", async () => {
+    await appendAuditEvent({
+      actorWallet: null,
+      action: "auth.verify",
+      resource: "wallet",
+      status: "failure",
+      requestId: null,
+      ipHash: null,
+    });
+
+    const snapshot = getAuditEvents();
+    snapshot.length = 0;
+
+    expect(getAuditEvents()).toHaveLength(1);
+  });
+
+  it("writes admin audit events as JSON lines to the configured stdout sink", () => {
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    emitAuditEvent("admin.users.read", "admin-1", { page: 2 });
+
+    expect(writeSpy).toHaveBeenCalledOnce();
+    const written = writeSpy.mock.calls[0][0] as string;
+    expect(written.endsWith("\n")).toBe(true);
+    expect(JSON.parse(written)).toEqual({
+      type: "AUDIT",
+      timestamp: "2026-07-07T10:00:00.000Z",
+      action: "admin.users.read",
+      actorId: "admin-1",
+      context: { page: 2 },
+    });
+  });
+
+  it("wraps admin user read query params without adding sensitive defaults", () => {
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    auditAdminUsersRead("admin-2", { page: 1, search: "active" });
+
+    const written = writeSpy.mock.calls[0][0] as string;
+    expect(JSON.parse(written)).toMatchObject({
+      action: "admin.users.read",
+      actorId: "admin-2",
+      context: {
+        queryParams: { page: 1, search: "active" },
+      },
+    });
+    expect(written).not.toContain("token");
+    expect(written).not.toContain("password");
+  });
+});

--- a/lib/audit/logger.ts
+++ b/lib/audit/logger.ts
@@ -21,7 +21,18 @@ export function hashIp(ip?: string | null): string | null {
 }
 
 export function redactAuditPayload<T extends Record<string, unknown>>(payload: T): Partial<T> {
-  const blocked = new Set(['password', 'token', 'secret', 'transaction', 'signedEnvelopeXdr']);
+  const blocked = new Set([
+    'actorWallet',
+    'password',
+    'privateKey',
+    'publicKey',
+    'secret',
+    'seed',
+    'signedEnvelopeXdr',
+    'token',
+    'transaction',
+    'walletAddress',
+  ]);
 
   return Object.fromEntries(
     Object.entries(payload).filter(([key]) => !blocked.has(key)),
@@ -83,4 +94,4 @@ export function auditAdminUsersRead(
   queryParams: Record<string, unknown>,
 ): void {
   emitAuditEvent('admin.users.read', actorId, { queryParams });
-}
+}


### PR DESCRIPTION
## Summary
- Add unit coverage for `lib/audit/events` event shaping, filtering, missing actor fallback, metadata handling, and clear/reset behavior.
- Add unit coverage for `lib/audit/logger` IP hashing, payload redaction, append-only audit rows, admin JSON-line output, and admin user read wrappers.
- Document the current audit event catalogue and redaction expectations, and harden `redactAuditPayload()` against wallet, seed, and key material fields.

## Validation
- `npx --yes vitest@3.2.4 run --config vitest.audit.config.ts` (temporary local config for these two audit test files)
- `npx --yes prettier@3.6.2 --check lib/audit/events.test.ts lib/audit/logger.test.ts docs/audit-events.md`
- `git diff --cached --check`

Full `npm test` was not run because this local checkout does not have the full project dependency install available, and the default Vitest config requires project plugins.

Closes #677