### PR TITLE
test: add tx build route integration coverage

### DIFF
--- a/app/api/tx/build/route.integration.test.ts
+++ b/app/api/tx/build/route.integration.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import simulateSuccessFixture from '@/lib/soroban/__fixtures__/simulate-success.json';
+
+vi.mock('@/lib/config', () => ({
+  default: {
+    stellar: {
+      network: 'testnet',
+      sorobanContractId: 'GCONTRACTTESTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      sorobanRpcUrl: 'https://private-rpc.test',
+    },
+    rateLimit: {
+      account: {
+        limit: 2,
+        windowMs: 60000,
+        burst: 2,
+      },
+    },
+  },
+}));
+
+vi.mock('@/lib/server-config', () => ({
+  default: {
+    stellar: {
+      sorobanRpcUrl: 'https://private-rpc.test',
+    },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@/lib/http/client', () => ({
+  httpPost: vi.fn(),
+}));
+
+import { getSession } from '@/lib/auth';
+import { httpPost } from '@/lib/http/client';
+import { clearAccountBucketCache } from '@/lib/rate-limit/account-bucket';
+import { POST } from './route';
+
+const validSourceAccount = `G${'A'.repeat(55)}`;
+
+const validLendBody = {
+  type: 'lend',
+  sourceAccount: validSourceAccount,
+  data: {
+    asset: 'XLM',
+    amount: 1000,
+    interestRate: 5,
+    duration: 30,
+  },
+};
+
+const validBorrowBody = {
+  type: 'borrow',
+  sourceAccount: validSourceAccount,
+  data: {
+    asset: 'USDC',
+    amount: 250,
+    interestRate: 7.5,
+    duration: 90,
+    collateral: 'XLM',
+    collateralAmount: 1000,
+  },
+};
+
+const normalizedSimulation = {
+  transactionDataXdr: 'AAAAAgAAAAE=',
+  minResourceFee: '3210',
+  footprint: {
+    readOnly: ['AAAAAQ=='],
+    readWrite: ['AAAAAg=='],
+  },
+  auth: ['AAAAAw==', 'AAAABA=='],
+};
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/tx/build', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('POST /api/tx/build integration', () => {
+  const httpPostMock = vi.mocked(httpPost);
+  const getSessionMock = vi.mocked(getSession);
+
+  beforeEach(() => {
+    clearAccountBucketCache();
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue(null);
+  });
+
+  it('rejects malformed JSON with the standard invalid-input envelope', async () => {
+    const response = await POST(makeRequest('{'));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'Invalid request body.',
+      },
+    });
+    expect(httpPostMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects structurally invalid tx build requests before calling Soroban RPC', async () => {
+    const response = await POST(
+      makeRequest({
+        type: 'lend',
+        sourceAccount: validSourceAccount,
+        data: {
+          asset: '',
+          amount: '1000',
+          interestRate: 5,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'Invalid request body.',
+      },
+    });
+    expect(httpPostMock).not.toHaveBeenCalled();
+  });
+
+  it('assembles a lend build request and returns the unsigned envelope plus simulation', async () => {
+    httpPostMock
+      .mockResolvedValueOnce({ result: { transaction: 'unsigned-lend-xdr' } })
+      .mockResolvedValueOnce(simulateSuccessFixture);
+
+    const response = await POST(makeRequest(validLendBody));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      unsignedXdr: 'unsigned-lend-xdr',
+      simulation: normalizedSimulation,
+    });
+
+    expect(httpPostMock).toHaveBeenNthCalledWith(
+      1,
+      'https://private-rpc.test',
+      {
+        jsonrpc: '2.0',
+        id: 'build_soroban_transaction',
+        method: 'build_soroban_transaction',
+        params: [
+          {
+            source: validSourceAccount,
+            network_passphrase: 'Test SDF Network ; September 2015',
+            fee: 100,
+            instructions: [
+              {
+                type: 'invoke_host_function',
+                function: 'lend',
+                contract_id: 'GCONTRACTTESTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+                args: [
+                  { type: 'string', value: 'XLM' },
+                  { type: 'u64', value: '1000' },
+                  { type: 'string', value: '5' },
+                ],
+                footprint: {
+                  read_only: [],
+                  read_write: [],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      { timeoutMs: 10000 },
+    );
+    expect(httpPostMock).toHaveBeenNthCalledWith(
+      2,
+      'https://private-rpc.test',
+      {
+        jsonrpc: '2.0',
+        id: 'simulate_transaction',
+        method: 'simulateTransaction',
+        params: [{ transaction: 'unsigned-lend-xdr' }],
+      },
+      { timeoutMs: 10000 },
+    );
+  });
+
+  it('assembles borrow-specific instruction arguments before simulation', async () => {
+    httpPostMock
+      .mockResolvedValueOnce({
+        result: { transaction_xdr: 'unsigned-borrow-xdr' },
+      })
+      .mockResolvedValueOnce(simulateSuccessFixture);
+
+    const response = await POST(makeRequest(validBorrowBody));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      unsignedXdr: 'unsigned-borrow-xdr',
+      simulation: normalizedSimulation,
+    });
+
+    expect(httpPostMock.mock.calls[0][1]).toMatchObject({
+      params: [
+        {
+          instructions: [
+            {
+              function: 'borrow',
+              args: [
+                { type: 'string', value: 'USDC' },
+                { type: 'u64', value: '250' },
+                { type: 'string', value: '7.5' },
+                { type: 'u32', value: '90' },
+                { type: 'string', value: 'XLM' },
+                { type: 'u64', value: '1000' },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('maps Soroban build RPC errors to the route error envelope', async () => {
+    httpPostMock.mockResolvedValueOnce({
+      error: {
+        code: -32602,
+        message: 'invalid transaction build request',
+        data: { reason: 'bad params' },
+      },
+    });
+
+    const response = await POST(makeRequest(validLendBody));
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: -32602,
+        message: 'invalid transaction build request',
+        data: { reason: 'bad params' },
+      },
+    });
+    expect(httpPostMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a safe RPC error when the build response has no unsigned envelope', async () => {
+    httpPostMock.mockResolvedValueOnce({ result: { status: 'missing_xdr' } });
+
+    const response = await POST(makeRequest(validLendBody));
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'RPC_ERROR',
+        message: 'Failed to build Soroban transaction with upstream RPC.',
+      },
+    });
+    expect(httpPostMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps simulation failures after a successful build without hiding the route status', async () => {
+    httpPostMock
+      .mockResolvedValueOnce({ result: { transaction: 'unsigned-lend-xdr' } })
+      .mockResolvedValueOnce({
+        error: {
+          code: -32000,
+          message: 'restore required before simulation can continue',
+          data: { restorePreamble: 'restore-xdr' },
+        },
+      });
+
+    const response = await POST(makeRequest(validLendBody));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'RESTORE_REQUIRED',
+        message:
+          'This transaction requires a restore before it can be submitted.',
+        data: {
+          restoreRequired: true,
+          restorePreamble: 'restore-xdr',
+        },
+      },
+    });
+    expect(httpPostMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/api/tx/build/route.test.ts
+++ b/app/api/tx/build/route.test.ts
@@ -93,7 +93,18 @@ describe('POST /api/tx/build', () => {
 
     expect(response.status).toBe(200);
     const json = await response.json();
-    expect(json).toEqual({ unsignedXdr: 'unsigned-xdr' });
+    expect(json).toEqual({
+      unsignedXdr: 'unsigned-xdr',
+      simulation: {
+        transactionDataXdr: 'AAAAAgAAAAE=',
+        minResourceFee: '3210',
+        footprint: {
+          readOnly: ['AAAAAQ=='],
+          readWrite: ['AAAAAg=='],
+        },
+        auth: ['AAAAAw==', 'AAAABA=='],
+      },
+    });
     expect(mockFetch).toHaveBeenCalledWith(
       'https://private-rpc.test',
       expect.objectContaining({ method: 'POST' }),

--- a/docs/tx-build-route.md
+++ b/docs/tx-build-route.md
@@ -1,0 +1,83 @@
+# Transaction Build Route
+
+`POST /api/tx/build` builds an unsigned Soroban transaction envelope for lending
+and borrowing flows, then simulates the unsigned envelope before returning it to
+the client. The route is server-only and proxies calls to the configured Soroban
+RPC endpoint.
+
+## Request
+
+The request body must be a JSON object with:
+
+| Field                   | Type                   | Notes                                                                    |
+| ----------------------- | ---------------------- | ------------------------------------------------------------------------ |
+| `type`                  | `"lend"` or `"borrow"` | Selects the Soroban contract function.                                   |
+| `sourceAccount`         | Stellar public key     | Must be a non-empty `G...` account id.                                   |
+| `data.asset`            | string                 | Asset code sent as the first contract argument.                          |
+| `data.amount`           | number                 | Converted to a `u64` string argument.                                    |
+| `data.interestRate`     | number                 | Converted to a string argument.                                          |
+| `data.duration`         | number                 | Required by borrow requests; defaults to `0` in the builder when absent. |
+| `data.collateral`       | string                 | Borrow-only collateral asset, defaulting to an empty string when absent. |
+| `data.collateralAmount` | number                 | Borrow-only collateral amount, defaulting to `0` when absent.            |
+
+Malformed JSON, unsupported `type`, invalid `sourceAccount`, missing `data`, and
+incorrect field types return:
+
+```json
+{
+  "error": {
+    "code": "INVALID_INPUT",
+    "message": "Invalid request body."
+  }
+}
+```
+
+with HTTP status `400`.
+
+## Build Flow
+
+For valid input the route sends a `build_soroban_transaction` JSON-RPC request
+to the private Soroban RPC URL using the configured contract id and network
+passphrase. A lend request produces a single `invoke_host_function` instruction
+with `asset`, `amount`, and `interestRate` arguments. A borrow request includes
+the same base arguments plus `duration`, `collateral`, and `collateralAmount`.
+
+If the build response includes `result.transaction` or `result.transaction_xdr`,
+the route sends a second `simulateTransaction` RPC call with that unsigned XDR.
+
+## Success Response
+
+Successful responses return HTTP `200`:
+
+```json
+{
+  "unsignedXdr": "AAAA...",
+  "simulation": {
+    "transactionDataXdr": "AAAA...",
+    "minResourceFee": "3210",
+    "footprint": {
+      "readOnly": [],
+      "readWrite": []
+    },
+    "auth": []
+  }
+}
+```
+
+The simulation object is normalized by `lib/soroban/simulate.ts` so callers can
+consume camelCase fields even when the upstream RPC uses snake_case fields.
+
+## Error Responses
+
+| Status | Code                                   | Cause                                                             |
+| ------ | -------------------------------------- | ----------------------------------------------------------------- |
+| `400`  | `INVALID_INPUT`                        | Request body cannot be parsed or does not match the build schema. |
+| `429`  | `RATE_LIMIT_EXCEEDED`                  | Authenticated wallet exceeded the account bucket limit.           |
+| `500`  | `CONFIGURATION_ERROR`                  | The server has no configured Soroban contract id.                 |
+| `502`  | upstream code or `RPC_ERROR`           | The build RPC failed or returned no unsigned envelope.            |
+| `409`  | `RESTORE_REQUIRED`                     | Simulation indicates archived ledger entries must be restored.    |
+| `422`  | `AUTH_REQUIRED` or `SIMULATION_FAILED` | Simulation needs extra authorization or rejected the transaction. |
+| `502`  | `SIMULATION_UNAVAILABLE`               | Simulation transport failed or timed out.                         |
+
+The route does not submit or sign transactions. Clients must sign the returned
+`unsignedXdr` and submit it through the transaction submission flow.

--- a/lib/http/client.ts
+++ b/lib/http/client.ts
@@ -67,15 +67,12 @@ export async function httpGet<T>(url: string, options: RequestOptions = {}): Pro
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
       const { timeoutMs: _t, retries: _r, backoffMs: _b, retryOnPost: _rp, retryAfterUpperBoundMs: _rao, ...fetchOptions } = options;
-      
+
       // Inject the request ID into headers
       const requestId = getActiveRequestId() || generateRequestId();
       const headers = new Headers(fetchOptions.headers);
       headers.set(REQUEST_ID_HEADER, requestId);
-      
-      const headers = new Headers(fetchOptions.headers);
-      headers.set(REQUEST_ID_HEADER, requestId);
-      
+
       let response: Response;
       try {
         response = await fetch(url, { ...fetchOptions, headers, signal: controller.signal });
@@ -160,10 +157,3 @@ export async function httpPost<T>(url: string, body: unknown, options: RequestOp
     body: JSON.stringify(body),
   });
 }
-
-/**
- * Generic fetch wrapper that propagates the active x-request-id from async context.
- * Alias for httpGet, exported separately to satisfy callers that import httpFetch by name.
- */
-export const httpFetch = httpGet;
-


### PR DESCRIPTION
Closes #679

## Summary
- add a dedicated `app/api/tx/build/route.integration.test.ts` that exercises the exported route handler with realistic lend/borrow requests
- cover malformed JSON, invalid body shape, lend and borrow envelope assembly, build RPC errors, missing unsigned XDR, and restore-required simulation failures
- document the route request, response, build/simulation flow, and error contract in `docs/tx-build-route.md`
- remove duplicate declarations in `lib/http/client.ts` that prevented the tx build route tests from compiling, and update the existing route test to assert the current `simulation` response payload

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm vitest run --project server app/api/tx/build/route.test.ts app/api/tx/build/route.integration.test.ts` -> 12 tests passed
- `git diff --check`

## Notes
- `corepack pnpm exec tsc --noEmit --pretty false` is currently blocked by pre-existing repository syntax issues outside this PR, including merge conflict markers in `app/api/account/preferences/route.ts` and `lib/account/preferences-repository.ts`, plus JSX syntax errors in `components/shared/common/Transaction.tsx` and `components/features/dashboard/components/MetricsCards.tsx`.