### PR TITLE
docs: add database schema and migration workflow guide

### DIFF
--- a/__tests__/config/database-schema-doc.test.ts
+++ b/__tests__/config/database-schema-doc.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// vitest may run with a different cwd than the test file location, so
+// resolve the test file's own directory and walk up from there.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = resolve(__filename, '..');
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const DOC_PATH = resolve(REPO_ROOT, 'docs', 'database-schema.md');
+const SCHEMA_DIR = resolve(REPO_ROOT, 'lib', 'db', 'schema');
+const DRIZZLE_DIR = resolve(REPO_ROOT, 'drizzle');
+const DRIZZLE_CONFIG = resolve(REPO_ROOT, 'drizzle.config.ts');
+const MIGRATE_RUNNER = resolve(REPO_ROOT, 'lib', 'db', 'migrate.ts');
+const MIGRATE_WORKFLOW = resolve(REPO_ROOT, '.github', 'workflows', 'migrate.yml');
+
+function readDoc(): string {
+  expect(existsSync(DOC_PATH)).toBe(true);
+  return readFileSync(DOC_PATH, 'utf8');
+}
+
+function listSchemaFiles(): string[] {
+  return readdirSync(SCHEMA_DIR)
+    .filter((name) => name.endsWith('.ts') && name !== 'index.ts')
+    .filter((name) => statSync(resolve(SCHEMA_DIR, name)).isFile())
+    .map((name) => basename(name, '.ts'))
+    .sort();
+}
+
+function listMigrationFiles(): string[] {
+  return readdirSync(DRIZZLE_DIR)
+    .filter((name) => name.endsWith('.sql'))
+    .map((name) => basename(name, '.sql'))
+    .sort();
+}
+
+describe('docs/database-schema.md', () => {
+  it('exists and is non-empty', () => {
+    const doc = readDoc();
+    expect(doc.length).toBeGreaterThan(200);
+  });
+
+  it('lists every table file in lib/db/schema/ (no missing-table drift)', () => {
+    const doc = readDoc();
+    const tables = listSchemaFiles();
+
+    // Every schema file (minus .ts extension) must be referenced in the doc.
+    // This is the canary: a contributor who adds a new table without
+    // updating the doc will fail this test.
+    expect(tables.length).toBeGreaterThan(0);
+    for (const table of tables) {
+      expect(doc, `doc missing table "${table}"`).toContain(table);
+      expect(doc, `doc missing schema file path for "${table}"`).toContain(`lib/db/schema/${table}.ts`);
+    }
+  });
+
+  it('references the drizzle migrations directory and the runner', () => {
+    const doc = readDoc();
+    expect(doc).toMatch(/drizzle\//);
+    expect(doc).toContain('lib/db/migrate.ts');
+  });
+
+  it('points at the actual drizzle.config.ts and CI workflow', () => {
+    const doc = readDoc();
+    expect(doc).toContain('drizzle.config.ts');
+    expect(doc).toContain('.github/workflows/migrate.yml');
+
+    // Sanity: those files should still exist on disk.
+    expect(existsSync(DRIZZLE_CONFIG)).toBe(true);
+    expect(existsSync(MIGRATE_RUNNER)).toBe(true);
+    expect(existsSync(MIGRATE_WORKFLOW)).toBe(true);
+  });
+
+  it('lists the existing SQL migrations present in drizzle/', () => {
+    const doc = readDoc();
+    const migrations = listMigrationFiles();
+
+    // Documenting the initial migration by number is enough to keep the
+    // first commit anchored; new migrations are tracked in the
+    // "Generating a new migration" workflow section.
+    if (migrations.length > 0) {
+      const first = migrations[0];
+      const number = first.split('_')[0];
+      // Migration filenames look like "0000_init.sql" — `\b` won't match
+      // between a digit and `_`, so use a non-word-boundary lookahead
+      // that allows for either `_` or end-of-string after the number.
+      expect(doc).toMatch(new RegExp(`drizzle/${number}(?=_|\\b|\\d|$)`));
+    }
+  });
+
+  it('documents the transactions composite index actually present in the schema', () => {
+    const doc = readDoc();
+    const transactions = readFileSync(
+      resolve(SCHEMA_DIR, 'transactions.ts'),
+      'utf8',
+    );
+
+    // Pull the index name out of the source.
+    const match = transactions.match(/index\('([^']+)'\)/);
+    expect(match).not.toBeNull();
+    const indexName = match![1];
+
+    expect(doc).toContain(indexName);
+  });
+
+  it('enumerates the notification type union in source', () => {
+    const doc = readDoc();
+    const notifications = readFileSync(
+      resolve(SCHEMA_DIR, 'notifications.ts'),
+      'utf8',
+    );
+
+    // The `type` column has an inline union comment in the schema. The
+    // doc must list every value so it stays accurate.
+    const match = notifications.match(/\/\/\s*'([^']+)'/);
+    expect(match).not.toBeNull();
+    const types = match![1]
+      .split('|')
+      .map((t) => t.trim().replace(/['\s]/g, ''))
+      .filter(Boolean);
+
+    for (const t of types) {
+      expect(doc, `doc missing notification type "${t}"`).toContain(t);
+    }
+  });
+});

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,199 @@
+# Database Schema and Migration Workflow
+
+This document describes the persistent data layer for the frontend, the
+Drizzle migration workflow that ships schema changes to staging and
+production, and the relationship between the schema source files and the
+generated SQL. If you change a column, add a table, or alter an index,
+update this guide in the same PR.
+
+The schemas live in `lib/db/schema/`, the generated migrations live in
+`drizzle/`, and the runner is `lib/db/migrate.ts`. The Drizzle Kit
+configuration is at `drizzle.config.ts`; the GitHub Actions workflow that
+invokes the runner in CI is at `.github/workflows/migrate.yml`. The
+initial migration in this repo is `drizzle/0000_init.sql` (followed by
+`drizzle/0001_transactions_date_id_idx.sql` for the composite index); the
+Drizzle journal lives at `drizzle/meta/_journal.json` and the schema
+snapshots at `drizzle/meta/`.
+
+## Tables at a glance
+
+| Table | Source | Purpose |
+|---|---|---|
+| `accounts` | `lib/db/schema/accounts.ts` | Per-user profile data (display name, bio, website, timezone). |
+| `sessions` | `lib/db/schema/sessions.ts` | Server-side session records keyed by `id`, with an `expires_at` and `user_id` foreign reference. |
+| `notifications` | `lib/db/schema/notifications.ts` | Per-user notification feed (title, message, read flag, type). |
+| `transactions` | `lib/db/schema/transactions.ts` | Transaction history rows (id, type, amount, asset, date, time, status) with a composite `(date, id)` index for ordered listing. |
+| `audit_events` | `lib/db/schema/audit_events.ts` | Append-only audit log of actor, action, target entity, and a free-form `details` JSON payload. |
+
+The Drizzle schema entry point is `drizzle.config.ts` which currently
+points to `./lib/db/schema.ts`. The actual definitions are split per-table
+under `lib/db/schema/<name>.ts` and re-exported through `lib/db/schema.ts`
+when the entry point is updated. Until the entry point is consolidated,
+treat the per-table files as the source of truth.
+
+## Relationship overview
+
+```text
+accounts (user_id PK)
+  ▲
+  │ user_id (FK by convention; no DB-level constraint)
+  ├── sessions          (1 account → N sessions)
+  ├── notifications     (1 account → N notifications)
+  └── audit_events      (1 account → N events; user_id is nullable for anonymous actor)
+
+transactions          (standalone — no account FK; rows are identified by
+                       the supplied `id` text and ordered via the
+                       `transactions_date_id_idx` composite index)
+```
+
+Foreign keys are **not** declared in DDL today; referential integrity is
+maintained in the application layer. If you need a join, do it in code
+(`SELECT … WHERE user_id = ?`). The composite index on `transactions` is
+the only index in the schema:
+
+```text
+CREATE INDEX IF NOT EXISTS transactions_date_id_idx
+  ON transactions (date, id);
+```
+
+This supports the listing page's "newest first" query plan. Any new
+transaction query that filters or sorts by a non-`id` column should be
+accompanied by a matching index in the same PR.
+
+## Per-table column reference
+
+### `accounts` — `lib/db/schema/accounts.ts`
+
+| Column | Type | Notes |
+|---|---|---|
+| `user_id` | `text` PK | Matches the authenticated subject. |
+| `display_name` | `text` | Public display name. |
+| `bio` | `text` | Defaults to `''`. |
+| `website` | `text` | Defaults to `''`. |
+| `timezone` | `text` | Defaults to `'UTC'`. |
+| `updated_at` | `timestamp` | Auto-updated by the application on every write; not a Drizzle `$onUpdate`. |
+
+### `sessions` — `lib/db/schema/sessions.ts`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `text` PK | Opaque session token. |
+| `user_id` | `text` | Owning account; not a DB FK. |
+| `expires_at` | `timestamp` | Hard expiry; the auth layer rejects expired rows. |
+| `created_at` | `timestamp` | Defaults to `now()`. |
+
+### `notifications` — `lib/db/schema/notifications.ts`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `text` PK | |
+| `user_id` | `text` | Owning account. |
+| `title` | `text` | |
+| `message` | `text` | |
+| `read` | `boolean` | Defaults to `false`. |
+| `created_at` | `timestamp` | Defaults to `now()`. |
+| `type` | `text` | One of `'info' | 'success' | 'warning' | 'error'`. Defaults to `'info'`. |
+
+### `transactions` — `lib/db/schema/transactions.ts`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `text` PK | External transaction id (hash). |
+| `type` | `text` | Free-form operation type. |
+| `amount` | `double precision` | Decimal amount. |
+| `asset` | `text` | Asset code or symbol. |
+| `date` | `text` | ISO date string (used for ordering). |
+| `time` | `text` | ISO time string. |
+| `status` | `text` | Free-form status. |
+
+Index: `transactions_date_id_idx (date, id)`.
+
+### `audit_events` — `lib/db/schema/audit_events.ts`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `text` PK | |
+| `user_id` | `text` | Nullable — anonymous events are allowed. |
+| `action` | `text` | Stable action identifier (e.g. `tx.submit`). |
+| `entity_type` | `text` | Resource type (e.g. `soroban.transaction`). |
+| `entity_id` | `text` | Optional specific entity id. |
+| `details` | `jsonb` | Free-form payload; never log raw secrets. |
+| `created_at` | `timestamp` | Defaults to `now()`. |
+
+## Migration workflow
+
+### Generating a new migration
+
+1. Edit the relevant file under `lib/db/schema/`.
+2. Run `npx drizzle-kit generate` to write a new SQL file into `drizzle/`.
+   The filename pattern is `NNNN_<description>.sql` and a corresponding
+   entry is added to `drizzle/meta/_journal.json` plus a snapshot in
+   `drizzle/meta/`. Commit all of these files together — the snapshot and
+   journal are how Drizzle detects drift in CI.
+3. Open the generated SQL and read it. Drizzle Kit does not understand
+   Postgres-only types or destructive renames; you may need to hand-edit
+   the SQL (e.g. add `IF EXISTS` guards, change a column type, drop and
+   recreate an index). Whatever ends up in the SQL file is what ships, so
+   review it line by line.
+4. Update the per-table column reference in this document.
+
+### Applying migrations locally
+
+`lib/db/migrate.ts` is the canonical runner. It opens the connection
+defined in `lib/db/index.ts`, calls `migrate(db, { migrationsFolder: 'drizzle' })`,
+and exits non-zero on failure. Run it with:
+
+```bash
+npm run db:migrate
+# or, directly:
+npx tsx lib/db/migrate.ts
+```
+
+The `drizzle/` folder is the source of truth at runtime — never edit the
+database schema by hand; always regenerate and check in the SQL.
+
+### Applying migrations in CI
+
+`.github/workflows/migrate.yml` runs on every push to `main` and via
+`workflow_dispatch` for ad-hoc staging/production runs. The workflow
+targets the `staging` environment by default and can be dispatched against
+`production` from the Actions UI. It exports `DATABASE_URL` from
+`secrets.DATABASE_URL` and posts the outcome to Slack via
+`secrets.SLACK_WEBHOOK_URL`.
+
+The current workflow is a stub that prints success without invoking
+`lib/db/migrate.ts`. Until that is wired up, migrations must be applied
+manually using the runner from the previous section.
+
+## Drift detection
+
+`codex/openapi-drift-gate` (PR #269 on `Creditra/Creditra-Backend`) is
+the model we want to copy here: a CI job that runs `drizzle-kit check`
+and fails the build if the checked-in schema source and the snapshot in
+`drizzle/meta/` disagree. Until that lands, reviewers should manually
+verify that any new schema edit is accompanied by a fresh generated
+migration in the same commit.
+
+## Adding a new table
+
+1. Create `lib/db/schema/<name>.ts` using the same imports and `$inferSelect`/
+   `$inferInsert` exports as the existing tables.
+2. Re-export it from `lib/db/schema.ts` and update `drizzle.config.ts` if
+   you want the global schema entry to pick it up.
+3. Run `npx drizzle-kit generate` and review the SQL.
+4. Add a row to the **Tables at a glance** table and a **per-table
+   column reference** section in this document.
+5. Add a test in `__tests__/config/database-schema-doc.test.ts` (the
+   sync test added alongside this doc) that asserts the table name and
+   file path appear in the doc.
+6. If the new table has a foreign reference to an existing account, note
+   it in the **Relationship overview** diagram.
+
+## Related
+
+- `docs/rate-limiting.md` — request-layer concerns (auth, throttling).
+- `docs/observability.md` — how `audit_events` and metrics flow into the
+  observability stack.
+- `drizzle.config.ts` — Drizzle Kit configuration.
+- `lib/db/migrate.ts` — local migration runner.
+- `.github/workflows/migrate.yml` — CI migration workflow.


### PR DESCRIPTION
## Summary
- Adds `docs/database-schema.md` covering the five Drizzle tables (`accounts`, `sessions`, `notifications`, `transactions`, `audit_events`) with a per-table column reference, a relationship overview, the `transactions_date_id_idx` composite index, the migration generation/apply workflow, and a how-to for adding a new table.
- Adds `__tests__/config/database-schema-doc.test.ts` — a 7-test sync test that fails the build if the doc falls out of sync with the source: every schema file must be referenced, the doc must point at the drizzle config/migration runner/CI workflow, the doc must list the actual transactions index name, every `notifications.type` value must be documented, and the initial migration must be referenced by number.

## Why
New contributors had to reverse-engineer the data layer from `lib/db/schema/`, `drizzle/`, `drizzle.config.ts`, `lib/db/migrate.ts`, and `.github/workflows/migrate.yml`. This doc + sync test makes the schema self-documenting and prevents drift.

## Test Plan
- [x] `npx vitest run --project server-unit __tests__/config/database-schema-doc.test.ts` — 7/7 pass
- [x] `npx tsc --noEmit` — no new errors introduced in the new files

## Closes
Closes #684