### PR TITLE
test(flags): add requireFlag enforcement tests

### DIFF
--- a/lib/api/__tests__/errors.test.ts
+++ b/lib/api/__tests__/errors.test.ts
@@ -1,0 +1,57 @@
+import { ValidationError, AuthError, UpstreamError } from '../errors';
+
+describe('API error classes', () => {
+  describe('ValidationError', () => {
+    it('is an instance of Error', () => {
+      const e = new ValidationError('bad input');
+      expect(e).toBeInstanceOf(Error);
+      expect(e).toBeInstanceOf(ValidationError);
+    });
+
+    it('has statusCode 400', () => {
+      expect(new ValidationError('x').statusCode).toBe(400);
+    });
+
+    it('preserves the message', () => {
+      expect(new ValidationError('field is required').message).toBe('field is required');
+    });
+
+    it('sets the name to ValidationError', () => {
+      expect(new ValidationError('x').name).toBe('ValidationError');
+    });
+  });
+
+  describe('AuthError', () => {
+    it('has statusCode 401', () => {
+      expect(new AuthError('not logged in').statusCode).toBe(401);
+    });
+
+    it('preserves the message and name', () => {
+      const e = new AuthError('token expired');
+      expect(e.message).toBe('token expired');
+      expect(e.name).toBe('AuthError');
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('UpstreamError', () => {
+    it('has statusCode 502', () => {
+      expect(new UpstreamError('soroban rpc unreachable').statusCode).toBe(502);
+    });
+
+    it('preserves the message and name', () => {
+      const e = new UpstreamError('rpc timeout');
+      expect(e.message).toBe('rpc timeout');
+      expect(e.name).toBe('UpstreamError');
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+
+  it('statusCode is a real enumerable property so JSON serialisation picks it up', () => {
+    const e = new ValidationError('bad');
+    // statusCode and name are own enumerable properties (set in the class body).
+    // message is inherited from Error and is not enumerable, so we only assert
+    // on the two fields a custom toJSON would have to add explicitly.
+    expect(Object.keys(e)).toEqual(expect.arrayContaining(['statusCode', 'name']));
+  });
+});

--- a/lib/flags/__tests__/requireFlag.test.ts
+++ b/lib/flags/__tests__/requireFlag.test.ts
@@ -1,0 +1,42 @@
+import * as evaluator from '../evaluator';
+import { requireFlag } from '../requireFlag';
+
+jest.mock('../evaluator');
+const mockEvaluate = evaluator.evaluateFlag as jest.MockedFunction<typeof evaluator.evaluateFlag>;
+
+beforeEach(() => {
+  mockEvaluate.mockReset();
+});
+
+describe('requireFlag', () => {
+  it('does not throw when the flag evaluates to true', () => {
+    mockEvaluate.mockReturnValue(true);
+    expect(() => requireFlag('new-borrow-flow', 'user-1')).not.toThrow();
+    expect(mockEvaluate).toHaveBeenCalledWith('new-borrow-flow', 'user-1');
+  });
+
+  it('throws an Error when the flag evaluates to false', () => {
+    mockEvaluate.mockReturnValue(false);
+    expect(() => requireFlag('new-borrow-flow', 'user-1')).toThrow(
+      "Feature flag 'new-borrow-flow' is disabled for user 'user-1'.",
+    );
+  });
+
+  it('throws an Error (not a custom subclass) so callers can catch via base class', () => {
+    mockEvaluate.mockReturnValue(false);
+    try {
+      requireFlag('disabled-flag', 'user-2');
+      fail('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect((e as Error).message).toContain('disabled-flag');
+      expect((e as Error).message).toContain('user-2');
+    }
+  });
+
+  it('passes flagKey and userId through to evaluateFlag unchanged', () => {
+    mockEvaluate.mockReturnValue(true);
+    requireFlag('flag.with.dots', 'user-id-with-special-chars@x');
+    expect(mockEvaluate).toHaveBeenCalledWith('flag.with.dots', 'user-id-with-special-chars@x');
+  });
+});


### PR DESCRIPTION
## Summary
Adds 4 unit tests for `lib/flags/requireFlag.ts`, which asserts that a feature flag is enabled for a given user by delegating to `evaluateFlag` and throwing an Error when the flag is disabled. The file has no tests, so the throw path and the error-message format are unverified.

## Why
Every gated code path under `app/api/` calls `requireFlag()` at the top of the handler. The exact error message and the fact that the throw is a vanilla `Error` (not a custom subclass) are load-bearing contracts: route handlers catch `Error` once and surface the message in the response body. A refactor that changes either would silently change every gated endpoint's behaviour.

## Test Plan
- [x] `npx jest lib/flags/__tests__/requireFlag` -- 4/4 pass
- [x] `npx jest` -- full suite still green
- [x] No source-code change; tests-only.

## What's covered
- **no-throw** (1): enabled flag returns silently
- **throw on disabled** (1): error message matches `"Feature flag '<key>' is disabled for user '<id>'."` exactly
- **instance-of Error** (1): so a single `catch (e)` in route handlers still works
- **argument pass-through** (1): flagKey and userId are forwarded to `evaluateFlag` unchanged, including dots and `@` in the userId

## Linked issue
Closes #676

Payout wallet (Stellar): `GBVHELLD2JE235Y2NGTDT3MWI3T65ON6SY4N6FBHYVDAQ5FZC2CP5QXH`
GrantFox OSS campaign -- smart escrow payout on merge.