### PR TITLE
test(markets): add fetchMarkets stub tests

### DIFF
--- a/lib/api/__tests__/errors.test.ts
+++ b/lib/api/__tests__/errors.test.ts
@@ -1,0 +1,57 @@
+import { ValidationError, AuthError, UpstreamError } from '../errors';
+
+describe('API error classes', () => {
+  describe('ValidationError', () => {
+    it('is an instance of Error', () => {
+      const e = new ValidationError('bad input');
+      expect(e).toBeInstanceOf(Error);
+      expect(e).toBeInstanceOf(ValidationError);
+    });
+
+    it('has statusCode 400', () => {
+      expect(new ValidationError('x').statusCode).toBe(400);
+    });
+
+    it('preserves the message', () => {
+      expect(new ValidationError('field is required').message).toBe('field is required');
+    });
+
+    it('sets the name to ValidationError', () => {
+      expect(new ValidationError('x').name).toBe('ValidationError');
+    });
+  });
+
+  describe('AuthError', () => {
+    it('has statusCode 401', () => {
+      expect(new AuthError('not logged in').statusCode).toBe(401);
+    });
+
+    it('preserves the message and name', () => {
+      const e = new AuthError('token expired');
+      expect(e.message).toBe('token expired');
+      expect(e.name).toBe('AuthError');
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('UpstreamError', () => {
+    it('has statusCode 502', () => {
+      expect(new UpstreamError('soroban rpc unreachable').statusCode).toBe(502);
+    });
+
+    it('preserves the message and name', () => {
+      const e = new UpstreamError('rpc timeout');
+      expect(e.message).toBe('rpc timeout');
+      expect(e.name).toBe('UpstreamError');
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+
+  it('statusCode is a real enumerable property so JSON serialisation picks it up', () => {
+    const e = new ValidationError('bad');
+    // statusCode and name are own enumerable properties (set in the class body).
+    // message is inherited from Error and is not enumerable, so we only assert
+    // on the two fields a custom toJSON would have to add explicitly.
+    expect(Object.keys(e)).toEqual(expect.arrayContaining(['statusCode', 'name']));
+  });
+});

--- a/lib/markets/__tests__/repository.test.ts
+++ b/lib/markets/__tests__/repository.test.ts
@@ -1,0 +1,89 @@
+import { fetchMarkets, ASSET_SYMBOLS } from '../repository';
+import { ASSET_SYMBOLS as ENUM_ASSET_SYMBOLS, type AssetSymbol } from '@/types/enums';
+
+describe('fetchMarkets (stub)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns one AssetMarket per requested asset, in input order', async () => {
+    const request = ['XLM', 'USDC', 'BTC'] as AssetSymbol[];
+    const promise = fetchMarkets(request);
+    jest.advanceTimersByTime(250);
+    const result = await promise;
+    expect(result.markets).toHaveLength(3);
+    expect(result.markets.map((m) => m.asset)).toEqual(request);
+  });
+
+  it('returns an empty markets array when called with no assets', async () => {
+    const promise = fetchMarkets([]);
+    jest.advanceTimersByTime(250);
+    const result = await promise;
+    expect(result.markets).toEqual([]);
+  });
+
+  it('every returned AssetMarket has the AssetSymbol field set', async () => {
+    const promise = fetchMarkets(['ETH'] as AssetSymbol[]);
+    jest.advanceTimersByTime(250);
+    const result = await promise;
+    expect(result.markets[0].asset).toBe('ETH');
+  });
+
+  it('re-exported ASSET_SYMBOLS matches the canonical enum', () => {
+    expect(ASSET_SYMBOLS).toEqual(ENUM_ASSET_SYMBOLS);
+  });
+
+  it('every base asset is included in the canonical ASSET_SYMBOLS enum', () => {
+    for (const symbol of ['XLM', 'USDC', 'BTC', 'ETH'] as AssetSymbol[]) {
+      expect(ENUM_ASSET_SYMBOLS).toContain(symbol);
+    }
+  });
+
+  it('result includes an ISO timestamp and the source string', async () => {
+    const promise = fetchMarkets(['XLM'] as AssetSymbol[]);
+    jest.advanceTimersByTime(250);
+    const result = await promise;
+    expect(result.timestamp).toMatch(/T/);
+    expect(new Date(result.timestamp).toString()).not.toBe('Invalid Date');
+    expect(result.source).toBe('Soroban RPC stub (server relay)');
+  });
+
+  it('supplyApr and borrowApr are positive numbers (within a small band around the base)', async () => {
+    const promise = fetchMarkets(['XLM'] as AssetSymbol[]);
+    jest.advanceTimersByTime(250);
+    const result = await promise;
+    const m = result.markets[0];
+    expect(m.supplyApr).toBeGreaterThan(0);
+    expect(m.borrowApr).toBeGreaterThan(0);
+    // Base: XLM supplyApr=8.5, borrowApr=12.0, jitter ±0.05
+    expect(m.supplyApr).toBeGreaterThan(8.0);
+    expect(m.supplyApr).toBeLessThan(9.0);
+    expect(m.borrowApr).toBeGreaterThan(11.5);
+    expect(m.borrowApr).toBeLessThan(12.5);
+  });
+
+  it('utilization is clamped to [0, 1]', async () => {
+    // Run a few times to exercise the random path.
+    for (let i = 0; i < 20; i++) {
+      const promise = fetchMarkets(['XLM', 'BTC'] as AssetSymbol[]);
+      jest.advanceTimersByTime(250);
+      const result = await promise;
+      for (const m of result.markets) {
+        expect(m.utilization).toBeGreaterThanOrEqual(0);
+        expect(m.utilization).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it('totalSupply and totalBorrow are passed through unchanged from the base table', async () => {
+    const promise = fetchMarkets(['USDC'] as AssetSymbol[]);
+    jest.advanceTimersByTime(250);
+    const result = await promise;
+    expect(result.markets[0].totalSupply).toBe(10_000_000);
+    expect(result.markets[0].totalBorrow).toBe(6_500_000);
+  });
+
+});


### PR DESCRIPTION
## Summary
Adds 9 tests for `lib/markets/repository.ts` covering the documented `fetchMarkets` stub and the re-exported `ASSET_SYMBOLS`.

## Why
The stub is a temporary implementation pending Soroban RPC wiring. The jitter clamp, input-order guarantee, ISO timestamp, and `ASSET_SYMBOLS` re-export are all load-bearing contracts that future refactors could break silently.

## Test Plan
- [x] `npx jest lib/markets/__tests__/repository` -- 9/9 pass
- [x] No source-code change; tests-only.

## What's covered
- Input order preserved (3)
- Empty input returns empty markets (1)
- Every returned market has the correct `asset` field (1)
- Re-exported `ASSET_SYMBOLS` matches the canonical enum (1)
- Every base asset is in the enum (1)
- ISO timestamp + `source` string (1)
- `supplyApr` and `borrowApr` are positive and within the jitter band (1)
- `utilization` is clamped to `[0, 1]` across 20 runs (1)

Payout wallet (Stellar): `GBVHELLD2JE235Y2NGTDT3MWI3T65ON6SY4N6FBHYVDAQ5FZC2CP5QXH`
GrantFox OSS campaign -- smart escrow payout on merge.