### PR TITLE
Add requireFlag enforcement tests

### DIFF
--- a/docs/require-flag.md
+++ b/docs/require-flag.md
@@ -1,0 +1,38 @@
+# Feature Flag Enforcement Contract
+
+`lib/flags/requireFlag.ts` is the narrow guard used by server-side code that
+must stop when a feature flag is unavailable for a caller.
+
+## Contract
+
+- The guard delegates all flag decisions to `evaluateFlag(flagKey, userId)`.
+- A `true` evaluator result allows the caller to continue.
+- A `false` evaluator result throws a deterministic error that includes the
+  flag key and user id.
+- Unknown flags remain safe because the evaluator returns `false` for missing
+  configuration.
+- Bucketed and percentage rollout behavior stays inside the evaluator; the
+  guard must not duplicate rollout math.
+- Evaluator failures propagate rather than silently enabling the feature.
+
+## Tested Cases
+
+Run:
+
+```bash
+npm test -- lib/flags/requireFlag.test.ts
+```
+
+The test suite covers:
+
+- enabled flag pass-through
+- disabled flag rejection
+- unknown flag closed-state behavior
+- bucketed rollout decisions delegated to the evaluator
+- evaluator errors remaining closed by propagation
+
+## Out Of Scope
+
+The guard does not load configuration, hash users into buckets, or evaluate all
+flags. Those behaviors belong to `lib/flags/evaluator.ts` and are documented in
+`lib/flags/EVALUATOR_TESTS.md`.

--- a/lib/flags/requireFlag.test.ts
+++ b/lib/flags/requireFlag.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEvaluateFlag = vi.hoisted(() => vi.fn());
+
+vi.mock('./evaluator', () => ({
+  evaluateFlag: mockEvaluateFlag,
+}));
+
+async function importRequireFlag() {
+  vi.resetModules();
+  return import('./requireFlag');
+}
+
+describe('requireFlag', () => {
+  beforeEach(() => {
+    mockEvaluateFlag.mockReset();
+  });
+
+  it('allows execution when the evaluated flag is enabled for the user', async () => {
+    mockEvaluateFlag.mockReturnValue(true);
+    const { requireFlag } = await importRequireFlag();
+
+    expect(() => requireFlag('borrow-flow', 'user-123')).not.toThrow();
+    expect(mockEvaluateFlag).toHaveBeenCalledWith('borrow-flow', 'user-123');
+  });
+
+  it('blocks execution when the evaluated flag is disabled for the user', async () => {
+    mockEvaluateFlag.mockReturnValue(false);
+    const { requireFlag } = await importRequireFlag();
+
+    expect(() => requireFlag('borrow-flow', 'user-123')).toThrow(
+      "Feature flag 'borrow-flow' is disabled for user 'user-123'.",
+    );
+    expect(mockEvaluateFlag).toHaveBeenCalledWith('borrow-flow', 'user-123');
+  });
+
+  it('treats unknown flags as closed when the evaluator returns false', async () => {
+    mockEvaluateFlag.mockReturnValue(false);
+    const { requireFlag } = await importRequireFlag();
+
+    expect(() => requireFlag('unknown-flag', 'user-123')).toThrow(
+      "Feature flag 'unknown-flag' is disabled for user 'user-123'.",
+    );
+  });
+
+  it('passes bucketed rollout decisions through without re-evaluating locally', async () => {
+    mockEvaluateFlag.mockReturnValue(true);
+    const { requireFlag } = await importRequireFlag();
+
+    requireFlag('bucketed-market-preview', 'stable-user-id');
+
+    expect(mockEvaluateFlag).toHaveBeenCalledTimes(1);
+    expect(mockEvaluateFlag).toHaveBeenCalledWith('bucketed-market-preview', 'stable-user-id');
+  });
+
+  it('propagates evaluator failures instead of defaulting open', async () => {
+    mockEvaluateFlag.mockImplementation(() => {
+      throw new Error('feature flag config unreadable');
+    });
+    const { requireFlag } = await importRequireFlag();
+
+    expect(() => requireFlag('borrow-flow', 'user-123')).toThrow(
+      'feature flag config unreadable',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated Vitest coverage for `lib/flags/requireFlag`
- cover enabled, disabled, unknown, bucketed, and evaluator-error paths
- document the feature-flag enforcement contract in `docs/require-flag.md`

Fixes #676

## Tests
- `git diff --check HEAD~1..HEAD`

## Notes
I could not complete the target Vitest run in this environment because the project dependencies were not installed and dependency installation repeatedly stalled. This PR changes only tests and documentation; no production behavior changed.
