### PR TITLE
Harden transactions webhook payload guards

### DIFF
--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -45,7 +45,20 @@ WEBHOOK_SECRET=your-secret-key-here
 | Header | Required | Description |
 |---|---|---|
 | `Content-Type` | Yes | Must be `application/json` |
+| `Content-Length` | Recommended | If present, must be no larger than 64 KiB. Oversized requests are rejected before signature verification. |
 | `x-webhook-signature` | Yes | `sha256=<hex-digest>` HMAC signature |
+
+### Request Limits
+
+Transaction webhooks are capped at **64 KiB**. Requests with a declared
+`Content-Length` above that limit are rejected before the body is read. Requests
+without `Content-Length` are checked immediately after the raw body is read and
+before signature verification, so oversized or streamed payloads cannot scale the
+HMAC verification work.
+
+Only `application/json` requests are accepted. Parameters such as
+`application/json; charset=utf-8` are allowed, but other content types are
+rejected before signature verification.
 
 ### Body
 
@@ -88,6 +101,8 @@ Two mechanisms prevent replay attacks:
 | `403` | Forbidden | Timestamp outside ±5 minute tolerance window |
 | `404` | Not Found | `transaction_id` does not exist |
 | `409` | Conflict | Duplicate `nonce` (event already processed) |
+| `413` | Payload Too Large | Body exceeds the 64 KiB webhook payload limit |
+| `415` | Unsupported Media Type | `Content-Type` is not `application/json` |
 | `500` | Internal Server Error | `WEBHOOK_SECRET` environment variable not configured |
 
 ### Success Response
@@ -173,6 +188,9 @@ npx vitest run --project unit --coverage
 
 - **No new dependencies** — uses Node.js built-in `crypto` module.
 - **Signing secret is server-only** — never exposed to the browser (no `NEXT_PUBLIC_` prefix).
+- **Pre-verification guards** — the handler rejects unsupported content types
+  and oversized bodies before signature verification so invalid traffic is
+  discarded cheaply.
 - **Constant-time verification** — signature comparison uses `crypto.timingSafeEqual` with buffer padding to prevent timing side-channel attacks. All signature verification paths (missing, wrong-length, wrong-value) return 401 with indistinguishable timing.
 - **In-memory nonce store** — nonces are stored in a `Set` with automatic pruning. For multi-instance deployments, consider using a shared store (e.g. Redis).
 

--- a/app/api/webhooks/transactions/route.test.ts
+++ b/app/api/webhooks/transactions/route.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { NextRequest } from "next/server";
-import { POST } from "@/app/api/webhooks/transactions/route";
+import {
+  POST,
+  TRANSACTION_WEBHOOK_MAX_BYTES,
+} from "@/app/api/webhooks/transactions/route";
 import { signPayload } from "@/lib/webhooks/verify";
 import { SIGNATURE_HEADER } from "@/lib/webhooks/types";
 import { resetStore, getTransaction } from "@/lib/transactions/store";
@@ -45,6 +48,33 @@ function makeSignedRequest(
   const body = JSON.stringify(payload);
   const signature = signPayload(body, secret);
   return makeWebhookRequest(body, { [SIGNATURE_HEADER]: signature });
+}
+
+function getByteLength(value: string) {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function makeSizedSignedRequest(
+  targetBytes: number,
+  payload: Record<string, unknown> = makePayload(),
+) {
+  let paddingLength = Math.max(0, targetBytes - getByteLength(JSON.stringify(payload)));
+  let body = "";
+
+  while (paddingLength >= 0) {
+    body = JSON.stringify({ ...payload, padding: "x".repeat(paddingLength) });
+    const bodyBytes = getByteLength(body);
+    if (bodyBytes === targetBytes) {
+      const signature = signPayload(body, TEST_SECRET);
+      return makeWebhookRequest(body, {
+        [SIGNATURE_HEADER]: signature,
+        "content-length": String(bodyBytes),
+      });
+    }
+    paddingLength += targetBytes - bodyBytes;
+  }
+
+  throw new Error(`Unable to create ${targetBytes}-byte webhook payload`);
 }
 
 // ---------------------------------------------------------------------------
@@ -229,6 +259,50 @@ describe("POST /api/webhooks/transactions – replay protection", () => {
 // Payload validation errors (400)
 // ---------------------------------------------------------------------------
 
+describe("POST /api/webhooks/transactions – pre-verification guards", () => {
+  it("returns 415 for non-JSON content before signature verification", async () => {
+    const req = makeWebhookRequest("not-json", {
+      "Content-Type": "text/plain",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(415);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/content type/i);
+  });
+
+  it("returns 413 when declared content-length exceeds the webhook limit", async () => {
+    const req = makeWebhookRequest("{}", {
+      "content-length": String(TRANSACTION_WEBHOOK_MAX_BYTES + 1),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+
+    const body = await res.json();
+    expect(body.error).toMatch(/maximum allowed size/i);
+  });
+
+  it("returns 413 when the actual body exceeds the webhook limit without content-length", async () => {
+    const rawBody = "x".repeat(TRANSACTION_WEBHOOK_MAX_BYTES + 1);
+    const req = makeWebhookRequest(rawBody, {
+      [SIGNATURE_HEADER]: "sha256=not-checked-for-oversized-body",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+  });
+
+  it("accepts a signed JSON webhook exactly at the payload-size limit", async () => {
+    const req = makeSizedSignedRequest(
+      TRANSACTION_WEBHOOK_MAX_BYTES,
+      makePayload({
+        data: { transaction_id: "TXN12346", status: "Completed" },
+      }),
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("POST /api/webhooks/transactions – payload validation", () => {
   it("returns 400 for malformed JSON", async () => {
     const body = "not-json{{{";
@@ -325,6 +399,9 @@ describe("POST /api/webhooks/transactions – body read error", () => {
   it("returns 400 when reading request body fails", async () => {
     const req = new NextRequest("http://localhost/api/webhooks/transactions", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
     });
     vi.spyOn(req, "text").mockRejectedValue(new Error("Simulated stream read error"));
     const res = await POST(req);

--- a/app/api/webhooks/transactions/route.ts
+++ b/app/api/webhooks/transactions/route.ts
@@ -7,13 +7,45 @@ import {
 } from "@/lib/webhooks/verify";
 import { SIGNATURE_HEADER } from "@/lib/webhooks/types";
 import type { WebhookPayload } from "@/lib/webhooks/types";
-import { updateTransactionStatus } from "@/lib/transactions/store";
+import {
+  getTransaction,
+  updateTransactionStatus,
+} from "@/lib/transactions/store";
 import { enqueueNotificationInBackground } from "@/lib/notifications/repository";
+import {
+  isStrictModeEnabled,
+  resolveAccountByMemo,
+  validateMemo,
+  type MemoType,
+} from "@/lib/stellar/memo";
 
 export const runtime = "nodejs";
+export const TRANSACTION_WEBHOOK_MAX_BYTES = 64 * 1024;
 
 /** Module-level nonce store for replay protection. */
 const nonceStore = new NonceStore();
+
+function isJsonContentType(contentType: string | null): boolean {
+  return contentType?.toLowerCase().split(";")[0]?.trim() === "application/json";
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function rejectUnsupportedContentType() {
+  return NextResponse.json(
+    { error: "Unsupported content type" },
+    { status: 415 },
+  );
+}
+
+function rejectPayloadTooLarge() {
+  return NextResponse.json(
+    { error: "Webhook payload exceeds the maximum allowed size" },
+    { status: 413 },
+  );
+}
 
 /**
  * POST /api/webhooks/transactions
@@ -36,7 +68,24 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // ── 2. Read raw body (required for HMAC verification) ───────────────────
+  // ── 2. Reject unexpected content before reading/verifying the body ──────
+  if (!isJsonContentType(req.headers.get("content-type"))) {
+    return rejectUnsupportedContentType();
+  }
+
+  const contentLength = req.headers.get("content-length");
+  if (contentLength) {
+    const declaredLength = Number(contentLength);
+    if (
+      !Number.isFinite(declaredLength) ||
+      declaredLength < 0 ||
+      declaredLength > TRANSACTION_WEBHOOK_MAX_BYTES
+    ) {
+      return rejectPayloadTooLarge();
+    }
+  }
+
+  // ── 3. Read raw body (required for HMAC verification) ───────────────────
   let rawBody: string;
   try {
     rawBody = await req.text();
@@ -47,7 +96,11 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // ── 3. Verify signature ─────────────────────────────────────────────────
+  if (byteLength(rawBody) > TRANSACTION_WEBHOOK_MAX_BYTES) {
+    return rejectPayloadTooLarge();
+  }
+
+  // ── 4. Verify signature ─────────────────────────────────────────────────
   const signature = req.headers.get(SIGNATURE_HEADER) || "";
   if (!verifyWebhookSignature(rawBody, signature, secret)) {
     return NextResponse.json(
@@ -56,7 +109,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // ── 4. Parse & validate payload ─────────────────────────────────────────
+  // ── 5. Parse & validate payload ─────────────────────────────────────────
   let payload: WebhookPayload;
   try {
     payload = JSON.parse(rawBody);
@@ -92,7 +145,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // ── 5. Validate timestamp ───────────────────────────────────────────────
+  // ── 6. Validate timestamp ───────────────────────────────────────────────
   if (!validateTimestamp(payload.timestamp)) {
     return NextResponse.json(
       { error: "Timestamp outside tolerance window" },
@@ -100,7 +153,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // ── 6. Check nonce for replay ───────────────────────────────────────────
+  // ── 7. Check nonce for replay ───────────────────────────────────────────
   if (nonceStore.has(payload.nonce)) {
     return NextResponse.json(
       { error: "Event already processed" },
@@ -109,7 +162,7 @@ export async function POST(req: NextRequest) {
   }
   nonceStore.add(payload.nonce, payload.timestamp);
 
-  // ── 7. Validate status ──────────────────────────────────────────────────
+  // ── 8. Validate status ──────────────────────────────────────────────────
   if (!isTransactionStatus(payload.data.status)) {
     return NextResponse.json(
       {
@@ -125,7 +178,7 @@ export async function POST(req: NextRequest) {
   const memoType = rawData.memo_type;
 
   if (memo || memoType) {
-    const type = (memoType || 'MEMO_TEXT') as any;
+    const type = (memoType || 'MEMO_TEXT') as MemoType;
     const value = memo || '';
 
     // Validate format
@@ -155,7 +208,7 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // ── 8. Update transaction ───────────────────────────────────────────────
+  // ── 9. Update transaction ───────────────────────────────────────────────
   const updated = await updateTransactionStatus(
     payload.data.transaction_id,
     payload.data.status,


### PR DESCRIPTION
## Summary
- reject non-JSON transaction webhooks before body parsing or signature verification
- enforce a 64 KiB payload limit using both `Content-Length` and the raw body byte length
- add regression coverage for unsupported content type, oversized declared/actual bodies, and the exact-size boundary
- document the new request limits and 413/415 responses in `WEBHOOKS.md`

Fixes #683

## Tests
- `git diff --check`

## Notes
I could not complete the target Vitest run locally because the repository had no installed test runner and dependency installation did not finish in this environment. The attempted install also warned that this workspace is running Node 18 while several project dependencies require Node 20+.
