### PR TITLE
 app/lending/page.tsx references txProgressState/setTxProgressState and PriceTicker without ever declaring or importing them

### DIFF
--- a/app/lending/page.tsx
+++ b/app/lending/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import useTxStatus from "@/lib/tx/useTxStatus";
-import { Toast } from "@/components/shared/common";
+import { PriceTicker, Toast } from "@/components/shared/common";
 import LendingForm from "@/components/features/lending/components/LendingForm";
 import { usePositions } from "@/hooks/usePositions";
 import TabSelector from "@/components/features/lending/components/TabSelector";
@@ -143,8 +143,13 @@ export default function LendingPage() {
     useState<CalculationResult | null>(null);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [txHash, setTxHash] = useState<string | null>(null);
-  const { supplyPositions, isLoading: isPositionsLoading, error: positionsError } =
-    usePositions();
+  const [txProgressState, setTxProgressState] =
+    useState<TxProgressState | null>(null);
+  const {
+    supplyPositions,
+    isLoading: isPositionsLoading,
+    error: positionsError,
+  } = usePositions();
   const [toast, setToast] = useState<{
     variant: "processing" | "success" | "error" | "info";
     title?: string;

--- a/test/e2e/lending-tx-progress.spec.ts
+++ b/test/e2e/lending-tx-progress.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Lending transaction progress", () => {
+  test("submits a lend transaction and updates the progress stepper through building, submitted, and confirmed", async ({
+    page,
+  }) => {
+    let statusPollCount = 0;
+
+    await page.route("**/api/auth/session", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session: {
+            user: {
+              walletAddress: "G".padEnd(56, "A"),
+            },
+          },
+        }),
+      });
+    });
+
+    await page.route("**/api/markets?asset=XLM", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          markets: [{ asset: "XLM", supplyApr: 8.5, borrowApr: 12 }],
+        }),
+      });
+    });
+
+    await page.route("**/api/prices**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ prices: [] }),
+      });
+    });
+
+    await page.route("**/api/quote", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          result: { dailyEarnings: 0.0233, totalEarnings: 0.7 },
+        }),
+      });
+    });
+
+    await page.route("**/api/tx/submit", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "submitted",
+          hash: "lend-progress-hash",
+        }),
+      });
+    });
+
+    await page.route("**/api/tx/status/lend-progress-hash", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      statusPollCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: statusPollCount === 1 ? "PENDING" : "SUCCESS",
+          hash: "lend-progress-hash",
+        }),
+      });
+    });
+
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem("walletAddress", "G".padEnd(56, "A"));
+    });
+
+    await page.goto("/lending");
+
+    await page.getByLabel("Amount to Lend").fill("100");
+    await page.getByRole("button", { name: "Review Lending Offer" }).click();
+
+    await expect(
+      page.getByRole("dialog", { name: "Confirm Lending Transaction" }),
+    ).toBeVisible();
+    await page.getByRole("checkbox").check();
+
+    const progress = page.getByRole("region", { name: "Transaction progress" });
+    await page.getByRole("button", { name: "Confirm Lending" }).click();
+
+    await expect(progress.locator('[data-step="building"]')).toHaveAttribute(
+      "data-state",
+      "current",
+    );
+    await expect(progress.locator('[data-step="submitted"]')).toHaveAttribute(
+      "data-state",
+      "current",
+    );
+    await expect(progress.locator('[data-step="confirmed"]')).toHaveAttribute(
+      "data-state",
+      "current",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes runtime errors in the lending page by importing the missing `PriceTicker` component and restoring the missing transaction progress state used throughout the lending flow. This PR also adds an end-to-end Playwright test to verify the transaction progress stepper transitions correctly from transaction creation through confirmation, helping prevent future regressions.

## Changes

### New Files

- **`test/e2e/lending-tx-progress.spec.ts`** — End-to-end Playwright test covering the lending transaction progress flow and stepper state transitions.

### Modified Files

- **`app/lending/page.tsx`**
  - Imported the shared `PriceTicker` component from `@/components/shared/common`.
  - Added the missing typed React state:
    ```ts
    const [txProgressState, setTxProgressState] =
      useState<TxProgressState | null>(null);
    ```
  - Restored transaction progress state handling used by `handleConfirm`, related `useEffect` hooks, and `TxProgressStepper`.

## Test Coverage

The new Playwright test verifies:

- Transaction submission initializes the progress state correctly.
- The transaction progress stepper transitions through:
  - **building**
  - **submitted**
  - **confirmed**
- Required backend endpoints are mocked, including:
  - Session
  - Market data
  - Price data
  - Quote generation
  - Transaction submission
  - Transaction status polling

## Verification

```bash
npx prettier --check app/lending/page.tsx test/e2e/lending-tx-progress.spec.ts
```

✅ Formatting checks passed.

## Notes

close #867 

- `npm run type-check` is currently blocked by pre-existing TypeScript merge conflicts and syntax errors elsewhere in the repository.
- `npx playwright test test/e2e/lending-tx-progress.spec.ts --project=chromium` could not complete because the development server exits early due to an existing parse error in `lib/server-config.ts`.
- `npm install` is currently blocked by a `403 Forbidden` response from the package registry for an existing dependency. These issues are unrelated to the changes introduced in this PR.