### PR TITLE
fix: wire ProfileForm handleSubmit to POST /api/account/profile

### DIFF
--- a/components/features/account/components/ProfileForm.test.tsx
+++ b/components/features/account/components/ProfileForm.test.tsx
@@ -1,12 +1,55 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from "@/test/test-utils";
+import { render, screen, fireEvent, waitFor, act } from "@/test/test-utils";
 import ProfileForm from "./ProfileForm";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// The test-utils wrapper includes CurrencyProvider which fetches /api/account/preferences on mount.
+// We provide a default fetch mock that handles both that request and the profile submission.
+function makeFetchMock(profileOverride?: Partial<{ ok: boolean; status: number; body: unknown }>) {
+  return vi.fn((url: string) => {
+    if (url === "/api/account/preferences") {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ currency: "USD" }),
+      } as Response);
+    }
+    const { ok = true, status = 200, body = { profile: {} } } = profileOverride ?? {};
+    return Promise.resolve({
+      ok,
+      status,
+      json: async () => body,
+    } as Response);
+  });
+}
+
+// Helper: fill all required fields with valid data
+async function fillValidForm() {
+  await act(async () => {
+    fireEvent.change(screen.getByLabelText(/First Name/i), { target: { value: "John" } });
+    fireEvent.change(screen.getByLabelText(/Last Name/i), { target: { value: "Doe" } });
+    fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: "john@example.com" } });
+    fireEvent.change(screen.getByLabelText(/Phone Number/i), { target: { value: "+1234567890" } });
+    fireEvent.change(screen.getByLabelText(/ID Number/i), { target: { value: "ID123" } });
+    fireEvent.change(screen.getByLabelText(/Tax Verification Number/i), { target: { value: "12-3456789" } });
+    fireEvent.change(screen.getByLabelText(/Identification Country/i), { target: { value: "USA" } });
+    fireEvent.change(screen.getByLabelText(/Address/i), { target: { value: "123 Main St" } });
+    fireEvent.click(screen.getByLabelText(/^male$/i));
+  });
+}
 
 describe("ProfileForm Component", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", makeFetchMock());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders all form fields", () => {
     render(<ProfileForm />);
-    
+
     expect(screen.getByLabelText(/First Name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Last Name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
@@ -15,49 +58,96 @@ describe("ProfileForm Component", () => {
 
   it("shows validation errors on empty submit", async () => {
     render(<ProfileForm />);
-    
-    const saveButton = screen.getByText(/Save Changes/i);
-    fireEvent.click(saveButton);
-    
-    expect(await screen.findByText(/First Name is required/i)).toBeInTheDocument();
-    expect(screen.getByText(/Email is required/i)).toBeInTheDocument();
-    expect(screen.getByText(/Gender is required/i)).toBeInTheDocument();
+
+    const form = screen.getByRole("button", { name: /Save Changes/i }).closest("form")!;
+    await act(async () => { fireEvent.submit(form); });
+
+    await waitFor(() => {
+      expect(screen.getByText(/First name is required/i)).toBeInTheDocument();
+      expect(screen.getByText(/Email is required/i)).toBeInTheDocument();
+      expect(screen.getByText(/Gender is required/i)).toBeInTheDocument();
+    });
   });
 
   it("shows error for invalid email", async () => {
     render(<ProfileForm />);
-    
-    const emailInput = screen.getByLabelText(/Email/i);
-    fireEvent.change(emailInput, { target: { value: "invalid-email" } });
-    
-    const saveButton = screen.getByText(/Save Changes/i);
-    fireEvent.click(saveButton);
-    
-    expect(await screen.findByText(/Invalid email format/i)).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: "invalid-email" } });
+    });
+
+    const form = screen.getByRole("button", { name: /Save Changes/i }).closest("form")!;
+    await act(async () => { fireEvent.submit(form); });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Please enter a valid email address/i)).toBeInTheDocument();
+    });
   });
 
-  it("successfully submits when form is valid", async () => {
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
+  it("calls POST /api/account/profile with form data on successful submit", async () => {
+    const fetchMock = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
     render(<ProfileForm />);
-    
-    fireEvent.change(screen.getByLabelText(/First Name/i), { target: { value: "John" } });
-    fireEvent.change(screen.getByLabelText(/Last Name/i), { target: { value: "Doe" } });
-    fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: "john@example.com" } });
-    fireEvent.change(screen.getByLabelText(/Phone Number/i), { target: { value: "1234567890" } });
-    fireEvent.change(screen.getByLabelText(/ID/i), { target: { value: "ID123" } });
-    fireEvent.change(screen.getByLabelText(/Identification Country/i), { target: { value: "USA" } });
-    fireEvent.change(screen.getByLabelText(/Address/i), { target: { value: "123 Main St" } });
-    
-    const maleRadio = screen.getByLabelText(/male/i);
-    fireEvent.click(maleRadio);
-    
-    const saveButton = screen.getByText(/Save Changes/i);
-    fireEvent.click(saveButton);
-    
+    await fillValidForm();
+
+    const form = screen.getByRole("button", { name: /Save Changes/i }).closest("form")!;
+    await act(async () => { fireEvent.submit(form); });
+
     await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith("Profile updated successfully!");
-    }, { timeout: 2000 });
-    
-    alertMock.mockRestore();
+      const profileCalls = fetchMock.mock.calls.filter(
+        ([url]) => url === "/api/account/profile"
+      );
+      expect(profileCalls).toHaveLength(1);
+    });
+
+    const profileCall = fetchMock.mock.calls.find(
+      ([url]) => url === "/api/account/profile"
+    )!;
+    const [url, options] = profileCall as [string, RequestInit];
+
+    expect(url).toBe("/api/account/profile");
+    expect(options.method).toBe("POST");
+    expect(options.headers).toMatchObject({ "Content-Type": "application/json" });
+
+    const body = JSON.parse(options.body as string);
+    expect(body).toMatchObject({
+      firstName: "John",
+      lastName: "Doe",
+      email: "john@example.com",
+      phone: "+1234567890",
+      id: "ID123",
+      taxId: "12-3456789",
+      country: "USA",
+      address: "123 Main St",
+      gender: "male",
+    });
+  });
+
+  it("shows success toast after a successful submit", async () => {
+    render(<ProfileForm />);
+    await fillValidForm();
+
+    const form = screen.getByRole("button", { name: /Save Changes/i }).closest("form")!;
+    await act(async () => { fireEvent.submit(form); });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Profile saved/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error toast when the API returns a server error", async () => {
+    const fetchMock = makeFetchMock({ ok: false, status: 500, body: { error: "Internal Server Error" } });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProfileForm />);
+    await fillValidForm();
+
+    const form = screen.getByRole("button", { name: /Save Changes/i }).closest("form")!;
+    await act(async () => { fireEvent.submit(form); });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Save failed/i)).toBeInTheDocument();
+    });
   });
 });

--- a/components/features/account/components/ProfileForm.tsx
+++ b/components/features/account/components/ProfileForm.tsx
@@ -1,8 +1,13 @@
-import React, { useMemo, useState, ChangeEvent, MouseEvent } from "react";
+"use client";
+
+import React, { useCallback, useMemo, useState, ChangeEvent } from "react";
 import Image, { StaticImageData } from "next/image";
+import { Save } from "lucide-react";
 import profile from "@/public/images/p-Picture.jpg";
-import Camera from "@/public/camera-ai-fill.svg"; 
-import { EmptyState } from "@/components/shared/common/EmptyState";
+import Camera from "@/public/camera-ai-fill.svg";
+import Toast from "@/components/shared/common/Toast";
+import type { ToastVariant } from "@/components/shared/common/Toast";
+import { Button } from "@/components/shared/ui";
 
 const formFields = [
   { id: "firstName", label: "First Name", placeholder: "e.g. John", type: "text", group: "personal", helpText: "Please enter your legal first name." },
@@ -28,10 +33,22 @@ const initialFormData: Record<string, string> = {
 const ProfileForm: React.FC = () => {
   const [avatar, setAvatar] = useState<string | StaticImageData>(profile);
   const [gender, setGender] = useState<"male" | "female" | "">("");
-  const [formData, setFormData] = useState<Record<string, string>>({
-    address: ""
-  });
+  const [formData, setFormData] = useState<Record<string, string>>(initialFormData);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<{
+    variant: ToastVariant;
+    title: string;
+    description?: string;
+  } | null>(null);
+
+  const showToast = useCallback(
+    (variant: ToastVariant, title: string, description?: string) => {
+      setToast({ variant, title, description });
+      setTimeout(() => setToast(null), 5000);
+    },
+    []
+  );
 
   // fn to handle profile image manipulations
   const handleAvatarUpload = (e: ChangeEvent<HTMLInputElement>) => {
@@ -59,38 +76,63 @@ const ProfileForm: React.FC = () => {
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};
-    
+
     if (!formData.firstName?.trim()) newErrors.firstName = "First name is required.";
     if (!formData.lastName?.trim()) newErrors.lastName = "Last name is required.";
-    
+
     if (!formData.email?.trim()) {
       newErrors.email = "Email is required.";
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
       newErrors.email = "Please enter a valid email address.";
     }
-    
+
     if (!formData.phone?.trim()) {
       newErrors.phone = "Phone number is required.";
     } else if (!/^\+?[\d\s\-()]{7,}$/.test(formData.phone)) {
       newErrors.phone = "Please enter a valid phone number.";
     }
-    
+
     if (!formData.id?.trim()) newErrors.id = "ID number is required.";
     if (!formData.taxId?.trim()) newErrors.taxId = "Tax verification number is required.";
     if (!formData.country?.trim()) newErrors.country = "Identification country is required.";
     if (!formData.address?.trim()) newErrors.address = "Address is required.";
-    
+
     if (!gender) newErrors.gender = "Gender is required.";
-    
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
-  // fn to submit form data 
-  const handleSubmit = (e: MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    if (validateForm()) {
-      console.log({ avatar, gender, ...formData });
+  // fn to submit form data to the profile API
+  const handleSubmit = async () => {
+    if (!validateForm()) return;
+
+    setSaving(true);
+    setErrors({});
+
+    try {
+      const res = await fetch("/api/account/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ gender, ...formData }),
+      });
+
+      if (res.status === 422 || res.status === 400) {
+        const body = await res.json();
+        if (body.errors) setErrors(body.errors);
+        showToast("error", "Validation failed", "Please fix the highlighted fields.");
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error("Failed to update profile");
+      }
+
+      showToast("success", "Profile saved", "Your profile has been updated successfully.");
+    } catch {
+      showToast("error", "Save failed", "An error occurred while saving your profile.");
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -175,15 +217,15 @@ const ProfileForm: React.FC = () => {
       </div>
 
       {/* Input Fields organized by section */}
-      <form className="space-y-8">
+      <form className="space-y-8" onSubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
         {/* Section 1: Personal Info */}
         <div className="bg-white border border-gray-100 rounded-lg p-4 sm:p-6 shadow-sm">
           <h3 className="text-base font-semibold text-gray-900 mb-1">Personal Information</h3>
           <p className="text-xs text-gray-500 mb-6">Enter your basic identification details.</p>
-          
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
             {formFields.filter(f => f.group === 'personal').map(renderInputField)}
-            
+
             {/* Gender */}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -192,8 +234,8 @@ const ProfileForm: React.FC = () => {
               <div className="flex items-center gap-4 mt-2">
                 {["male", "female"].map((g) => (
                   <label key={g} className={`flex items-center gap-3 border px-4 py-2.5 rounded-lg cursor-pointer transition-all duration-200 flex-1 sm:flex-initial ${
-                    gender === g 
-                      ? 'border-[#2600FF] bg-[#2600FF]/5 text-[#2600FF]' 
+                    gender === g
+                      ? 'border-[#2600FF] bg-[#2600FF]/5 text-[#2600FF]'
                       : 'border-gray-200 hover:border-gray-300 text-gray-700'
                   }`}>
                     <input
@@ -223,9 +265,6 @@ const ProfileForm: React.FC = () => {
                 <p className="mt-1 text-xs text-gray-400" id="gender-help">Select your gender.</p>
               )}
             </div>
-            {errors.gender && (
-              <p className="text-xs text-red-500 mt-1.5">{errors.gender}</p>
-            )}
           </div>
         </div>
 
@@ -233,12 +272,12 @@ const ProfileForm: React.FC = () => {
         <div className="bg-white border border-gray-100 rounded-lg p-4 sm:p-6 shadow-sm">
           <h3 className="text-base font-semibold text-gray-900 mb-1">Contact Details</h3>
           <p className="text-xs text-gray-500 mb-6">How we can reach you.</p>
-          
+
           <div className="space-y-6">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
               {formFields.filter(f => f.group === 'contact').map(renderInputField)}
             </div>
-            
+
             {/* Address */}
             <div>
               <label htmlFor="address" className="block text-sm font-medium text-gray-700 mb-1">
@@ -267,7 +306,7 @@ const ProfileForm: React.FC = () => {
         <div className="bg-white border border-gray-100 rounded-lg p-4 sm:p-6 shadow-sm">
           <h3 className="text-base font-semibold text-gray-900 mb-1">Identity Verification</h3>
           <p className="text-xs text-gray-500 mb-6">Financial and legal identification information.</p>
-          
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
             {formFields.filter(f => f.group === 'verification').map(renderInputField)}
           </div>
@@ -275,13 +314,15 @@ const ProfileForm: React.FC = () => {
 
         {/* Buttons */}
         <div className="flex flex-col sm:flex-row gap-3 pt-4">
-          <button
-            onClick={handleSubmit}
-            type="button"
-            className="sm:px-12 py-2.5 text-sm cursor-pointer bg-[#2600FF] hover:bg-[#1a00cc] text-white rounded-md font-medium shadow-md transition-colors duration-200 text-center order-1 sm:order-none"
+          <Button
+            type="submit"
+            isLoading={saving}
+            leftIcon={<Save className="w-4 h-4" aria-hidden="true" />}
+            className="sm:px-12 py-2.5 text-sm bg-[#2600FF] hover:bg-[#1a00cc] text-white rounded-md font-medium shadow-md transition-colors duration-200"
+            data-testid="save-profile-btn"
           >
             Save Changes
-          </button>
+          </Button>
 
           <button
             type="button"
@@ -291,9 +332,16 @@ const ProfileForm: React.FC = () => {
           </button>
         </div>
       </form>
+
+      {toast && (
+        <Toast
+          title={toast.title}
+          description={toast.description}
+          variant={toast.variant}
+        />
+      )}
     </div>
   );
 };
 
 export default ProfileForm;
-


### PR DESCRIPTION
## Summary

Fixes #894

`ProfileForm.tsx`'s `handleSubmit` only `console.log`'d the form data and never called the profile API. This PR wires the submit to `POST /api/account/profile` and adds pending/success/error UI state.

## Changes

### `ProfileForm.tsx`
- Add `"use client"` directive (required for client-side hooks)
- Initialise `formData` with all field defaults (was missing most keys)
- Replace `console.log` stub with `fetch("/api/account/profile", { method: "POST" })`
- Add `saving`/`setSaving` state — `Button` `isLoading` prop shows a spinner during submission
- Add `Toast` success/error feedback following the `PreferencesForm.tsx` pattern
- Handle `422`/`400` validation error responses from the API (field-level errors)
- Remove duplicate gender error display
- Convert submit button to `type="submit"` inside an `onSubmit` form handler

### `ProfileForm.test.tsx`
- Remove broken `window.alert` assertion test
- Add `makeFetchMock` helper that handles the `CurrencyProvider`'s `/api/account/preferences` fetch
- Add test asserting `POST /api/account/profile` is called with all form fields
- Add test asserting success toast appears after a `200` response
- Add test asserting error toast appears after a `500` response

## Testing

```
npx vitest run components/features/account/components/ProfileForm.test.tsx
# 6/6 tests pass
```

ESLint: no warnings or errors.