### PR TITLE
fix: remove any from sanitiseRecord generic constraint and index assignment

### DIFF
--- a/lib/security/input-sanitizer.test.ts
+++ b/lib/security/input-sanitizer.test.ts
@@ -1,22 +1,62 @@
-// lib/security/input-sanitizer.test.ts
-import { expect, test } from "vitest";
-import { sanitizeInput } from "@/lib/security/input-sanitizer";
+import { describe, expect, test } from "vitest";
+import { sanitiseRecord, sanitiseString } from "./input-sanitizer";
 import fc from "fast-check";
 
-// Helper regexes matching characters that should be stripped
 const CONTROL_REGEX = /[\u0000-\u001F\u007F-\u009F]/;
 const BIDI_REGEX = /[\u202A-\u202E\u2066-\u2069]/;
 
-test("sanitizeInput strips control and bidi characters and normalizes NFC", () => {
+test("sanitiseString strips control/bidi characters and normalizes NFC", () => {
   fc.assert(
-    fc.property(fc.unicodeString(), (raw) => {
-      const sanitized = sanitizeInput(raw);
-      // Ensure no control chars remain
+    fc.property(fc.string(), (raw) => {
+      const sanitized = sanitiseString(raw);
       expect(CONTROL_REGEX.test(sanitized)).toBe(false);
-      // Ensure no bidi chars remain
       expect(BIDI_REGEX.test(sanitized)).toBe(false);
-      // NFC normalization: string should be equal to its NFC form
       expect(sanitized).toBe(sanitized.normalize("NFC"));
-    })
+    }),
   );
+});
+
+describe("sanitiseRecord", () => {
+  it("sanitises string values and leaves non-strings untouched", () => {
+    const input = {
+      name: "hello\u0000world",
+      age: 30,
+      active: true,
+      tags: ["a", "b"],
+      meta: { key: "val" },
+    };
+    const result = sanitiseRecord(input);
+    expect(result.name).toBe("helloworld");
+    expect(result.age).toBe(30);
+    expect(result.active).toBe(true);
+    expect(result.tags).toEqual(["a", "b"]);
+    expect(result.meta).toEqual({ key: "val" });
+  });
+
+  it("handles a record with only string values", () => {
+    const input = { a: "foo\u0000", b: "bar\u200B" };
+    const result = sanitiseRecord(input);
+    expect(result.a).toBe("foo");
+    expect(result.b).toBe("bar");
+  });
+
+  it("handles an empty record", () => {
+    const result = sanitiseRecord({});
+    expect(result).toEqual({});
+  });
+
+  it("preserves null and undefined values", () => {
+    const input = { a: null, b: undefined, c: "text\u0000" };
+    const result = sanitiseRecord(input);
+    expect(result.a).toBeNull();
+    expect(result.b).toBeUndefined();
+    expect(result.c).toBe("text");
+  });
+
+  it("strips control characters from nested string values (shallow only)", () => {
+    const input = { outer: "ok\u0000", inner: { nested: "bad\u0000" } };
+    const result = sanitiseRecord(input);
+    expect(result.outer).toBe("ok");
+    expect(result.inner).toEqual({ nested: "bad\u0000" });
+  });
 });

--- a/lib/security/input-sanitizer.ts
+++ b/lib/security/input-sanitizer.ts
@@ -21,13 +21,11 @@ export function sanitiseString(input: string): string {
  * Only string values are processed; other types are left untouched.
  * This is used for profile data after Zod validation.
  */
-export function sanitiseRecord<T extends Record<string, any>>(record: T): T {
-  const result = { ...record } as T;
-  for (const key of Object.keys(result)) {
-    const value = result[key];
-    if (typeof value === 'string') {
-      result[key] = sanitiseString(value) as any;
-    }
-  }
-  return result;
+export function sanitiseRecord<T extends Record<string, unknown>>(record: T): T {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      typeof value === 'string' ? sanitiseString(value) : value,
+    ]),
+  ) as T;
 }


### PR DESCRIPTION
## Summary

Closes #878

Removes two `any` escape hatches from `sanitiseRecord` that were masking a real generic-indexing type error:

1. **Generic constraint**: `T extends Record<string, any>` → `T extends Record<string, unknown>`
2. **Index assignment**: `result[key] = sanitiseString(value) as any` → replaced entirely

## How

Rewrote the function body from a mutable spread + indexed-write pattern to a pure `Object.fromEntries`/`Object.entries` pipeline. This avoids the generic-indexed write (TS2862) altogether since the new object is constructed from a typed entry array rather than mutating a variable of type `T`.

The only remaining cast is `as T` on the return value, which narrows `Record<string, unknown>` → `T` — safe because all non-string values pass through unchanged.

## Test changes

- Fixed broken import in the existing test (`sanitizeInput` → `sanitiseString`) and fast-check API (`unicodeString` → `string`)
- Added 5 `sanitiseRecord` unit tests covering:
  - Mixed string/number/boolean/array/object fields
  - All-string record with control characters
  - Empty record (`{}`)
  - `null` and `undefined` value preservation
  - Shallow-only sanitisation (nested objects left untouched)

## Verification

- 6/6 tests pass (`vitest run lib/security/input-sanitizer.test.ts`)
- No new TypeScript errors in the changed files
