### PR TITLE
fix: resolve duplicate onerror and undefined identifiers in useNotificationStream

### DIFF
--- a/hooks/useNotificationStream.test.ts
+++ b/hooks/useNotificationStream.test.ts
@@ -386,4 +386,38 @@ describe("useNotificationStream", () => {
 
     expect(MockEventSource.instances).toHaveLength(2);
   });
+
+  it("simulates an onerror event and asserts the hook reconnects with backoff", () => {
+    renderHook(() => useNotificationStream());
+
+    // First error: should reconnect after 1000ms
+    act(() => {
+      MockEventSource.instances[0].triggerError();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    // Second error: should reconnect with backoff after 2000ms (1000 * 2)
+    act(() => {
+      MockEventSource.instances[1].triggerError();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1999);
+    });
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(MockEventSource.instances).toHaveLength(3);
+  });
 });

--- a/hooks/useNotificationStream.ts
+++ b/hooks/useNotificationStream.ts
@@ -38,6 +38,12 @@ function parseEventData(event: MessageEvent): unknown {
  * and provides the current unread notification count plus a debounced
  * connection state for the live notification feed.
  */
+export type NotificationStreamConnectionState = "connected" | "reconnecting" | "offline";
+
+const RECONNECTING_DEBOUNCE_MS = 1500;
+const OFFLINE_DELAY_MS = 5000;
+const MAX_RECONNECT_DELAY_MS = 30000;
+
 export const useNotificationStream = (
   options: UseNotificationStreamOptions = {},
 ) => {
@@ -46,8 +52,21 @@ export const useNotificationStream = (
     useState<NotificationStreamConnectionState>("reconnecting");
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectingStateTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const offlineStateTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const backoff = useRef<number>(1000); // start at 1s
   const onNotificationRef = useRef(options.onNotification);
+
+  const clearStateTimers = () => {
+    if (reconnectingStateTimeout.current) {
+      clearTimeout(reconnectingStateTimeout.current);
+      reconnectingStateTimeout.current = null;
+    }
+    if (offlineStateTimeout.current) {
+      clearTimeout(offlineStateTimeout.current);
+      offlineStateTimeout.current = null;
+    }
+  };
 
   useEffect(() => {
     onNotificationRef.current = options.onNotification;
@@ -100,6 +119,12 @@ export const useNotificationStream = (
         }
       };
 
+      source.onopen = () => {
+        setConnectionState("connected");
+        backoff.current = 1000;
+        clearStateTimers();
+      };
+
       source.onmessage = handleUnreadCount;
       source.addEventListener?.(
         "unreadCount",
@@ -109,15 +134,6 @@ export const useNotificationStream = (
         "notification",
         handleNotification as EventListener,
       );
-
-      source.onerror = () => {
-        cleanup();
-        // exponential backoff up to 30s
-        reconnectTimeout.current = setTimeout(() => {
-          backoff.current = Math.min(backoff.current * 2, 30000);
-          connect();
-        }, backoff.current);
-      };
 
       source.onerror = () => {
         if (reconnectTimeout.current) {


### PR DESCRIPTION
Closes #866
## Description
This PR resolves issue #866 by fixing runtime errors and connection recovery failures in `useNotificationStream.ts`.

## Changes
* **Removed Duplicate onerror Assignment**: Removed the dead first assignment to `source.onerror` which was overwriting the backoff handler.
* **Declared Missing References**: Declared missing constants (`RECONNECTING_DEBOUNCE_MS = 1500`, `OFFLINE_DELAY_MS = 5000`, `MAX_RECONNECT_DELAY_MS = 30000`) and missing timeout state refs (`reconnectingStateTimeout`, `offlineStateTimeout`).
* **Added Helper**: Created `clearStateTimers` to prevent leaks by clearing timeout callbacks.
* **Added onopen Listener**: Configured `source.onopen` to transition `connectionState` to `"connected"`, clear pending disconnect timers, and reset reconnect backoff.
* **Added Unit Test**: Created a new test inside `useNotificationStream.test.ts` to simulate `onerror` events and verify reconnect exponential backoff behavior.

---

