### PR TITLE
fix(hooks): resolve undefined skip reference in useInfiniteTransactions

### DIFF
--- a/hooks/useInfiniteTransactions.test.ts
+++ b/hooks/useInfiniteTransactions.test.ts
@@ -159,6 +159,17 @@ describe("useInfiniteTransactions", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
+  it("starts with isLoading false and does not fetch when enabled is false", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useInfiniteTransactions({ enabled: false }));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.transactions).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("stops at final cursor and does not fetch again", async () => {
     const fetchMock = vi.fn().mockImplementation((url: string) => {
       if (url.includes("cursor=cursor-page-2")) {

--- a/hooks/useInfiniteTransactions.ts
+++ b/hooks/useInfiniteTransactions.ts
@@ -31,7 +31,7 @@ export function useInfiniteTransactions(
 
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(!skip);
+  const [isLoading, setIsLoading] = useState(enabled);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isError, setIsError] = useState(false);
   const [error, setError] = useState<Error | null>(null);


### PR DESCRIPTION
Closes #869

## Summary

`useInfiniteTransactions` called `useState(!skip)` to seed its `isLoading` state, but `skip` was never declared, destructured, or imported anywhere in the file — the hook's options only destructure `limit` and `enabled`. This threw `ReferenceError: skip is not defined` on the first render of any component using the hook, breaking infinite-scroll transaction history everywhere it's used.

The fix replaces the stray `skip` reference with the existing `enabled` option, matching the surrounding enabled-flag semantics used later in the hook (the `useEffect` already gates the initial fetch on `enabled`).

## Changes

### Modified files
- `hooks/useInfiniteTransactions.ts` — changed `const [isLoading, setIsLoading] = useState(!skip);` to `const [isLoading, setIsLoading] = useState(enabled);` so `isLoading` starts `true` only when fetching is enabled, and no longer throws a `ReferenceError`.

### Test files
- `hooks/useInfiniteTransactions.test.ts` — added a new test, `"starts with isLoading false and does not fetch when enabled is false"`, which renders the hook with `{ enabled: false }` and asserts:
  - `isLoading` is `false` immediately (no async wait needed, since no fetch is triggered)
  - `transactions` stays empty
  - the mocked `fetch` is never called

## Implementation details

- `enabled` defaults to `true` (`const { limit = 6, enabled = true, ...filters } = options;`), so the default behavior (no options passed, or `enabled: true`) is unchanged: `isLoading` still starts `true` and the initial page fetch still fires on mount via the existing `useEffect`.
- When `enabled: false` is passed, `isLoading` now correctly starts `false` instead of throwing, and the `useEffect`'s existing `if (!enabled) return;` guard prevents the initial fetch, so the two behaviors are now consistent instead of the hook crashing before that guard is ever reached.
- No other logic in the hook changed — `loadMore`, `reset`, pagination, and error handling are untouched.

## How to test

1. `npm install`
2. `npx vitest run hooks/useInfiniteTransactions.test.ts` — all 8 tests should pass, including the new one.
3. Manually: render any component using `useInfiniteTransactions()` (e.g. the transaction history / dashboard views) — it should no longer throw `ReferenceError: skip is not defined` and should load the first page of transactions on mount as before.
4. Manually: render a component with `useInfiniteTransactions({ enabled: false })` — `isLoading` should be `false` immediately and no network request should fire until `enabled` becomes `true` or `loadMore`/fetch is triggered elsewhere.
