### PR TITLE
fix(hooks): resolve undeclared vars and signature mismatch in usePositions

### DIFF
--- a/hooks/usePositions.retry.test.ts
+++ b/hooks/usePositions.retry.test.ts
@@ -1,57 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { usePositions } from "./usePositions";
 
 describe("usePositions retry logic", () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
-    jest.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn());
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
-    jest.useRealTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("retries failed fetches with backoff and stops at max attempts", async () => {
-    (global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+    vi.mocked(global.fetch).mockRejectedValue(new Error("Network error"));
 
     const { result } = renderHook(() => usePositions());
 
     expect(result.current.isLoading).toBe(true);
-    
-    // Attempt 0
+
+    // Flush the initial (attempt 0) fetch rejection so the first retry gets scheduled.
     await act(async () => {
       await Promise.resolve();
     });
 
-    // We should be stale now
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+
+    // Drive the recursive setTimeout retry chain to completion.
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.isOffline).toBe(false);
+    expect(global.fetch).toHaveBeenCalledTimes(6); // 1 initial attempt + 5 retries
+  });
+
+  it("recovers and clears stale state once a retry succeeds", async () => {
+    vi.mocked(global.fetch)
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ positions: [] }),
+      } as Response);
+
+    const { result } = renderHook(() => usePositions());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     expect(result.current.isStale).toBe(true);
 
-    // Fast-forward through 5 retries
-    for (let i = 0; i < 5; i++) {
-      await act(async () => {
-        jest.runAllTimers();
-        await Promise.resolve();
-      });
-    }
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
-    // It should stop retrying and finally set error
-    expect(result.current.error).toBeTruthy();
-    expect(global.fetch).toHaveBeenCalledTimes(6); // 1 initial + 5 retries
+    expect(result.current.isStale).toBe(false);
+    expect(result.current.isOffline).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
   it("aborts in-flight requests on unmount", () => {
-    const abortMock = jest.fn();
-    global.AbortController = jest.fn().mockImplementation(() => ({
-      abort: abortMock,
-      signal: {}
-    }));
-    
-    (global.fetch as jest.Mock).mockImplementation(() => new Promise(() => {}));
+    const abortMock = vi.fn();
+    vi.stubGlobal(
+      "AbortController",
+      vi.fn().mockImplementation(() => ({
+        abort: abortMock,
+        signal: {},
+      })),
+    );
+
+    vi.mocked(global.fetch).mockImplementation(() => new Promise(() => {}));
 
     const { unmount } = renderHook(() => usePositions());
     unmount();
-    
+
     expect(abortMock).toHaveBeenCalled();
+  });
+});
+
+describe("usePositions offline detection", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reports isOffline and does not retry while the browser is offline", async () => {
+    const onLineSpy = vi.spyOn(window.navigator, "onLine", "get").mockReturnValue(false);
+    const mockError = new Error("Network error");
+    vi.mocked(global.fetch).mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => usePositions());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isOffline).toBe(true);
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.error).toEqual(mockError);
+    expect(result.current.isLoading).toBe(false);
+    expect(global.fetch).toHaveBeenCalledTimes(1); // no retries scheduled while offline
+
+    onLineSpy.mockRestore();
+  });
+
+  it("clears isOffline once a fetch succeeds again", async () => {
+    const onLineSpy = vi.spyOn(window.navigator, "onLine", "get").mockReturnValue(false);
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    const { result, rerender } = renderHook(() => usePositions());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isOffline).toBe(true);
+
+    onLineSpy.mockReturnValue(true);
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ positions: [] }),
+    } as Response);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+    rerender();
+
+    expect(result.current.isOffline).toBe(false);
+    expect(result.current.isStale).toBe(false);
+
+    onLineSpy.mockRestore();
   });
 });

--- a/hooks/usePositions.test.ts
+++ b/hooks/usePositions.test.ts
@@ -131,12 +131,18 @@ describe("usePositions Hook", () => {
       nextDue: "$250.00 in 4 days",
     });
     expect(result.current.error).toBeNull();
+    expect(result.current.isStale).toBe(false);
+    expect(result.current.isOffline).toBe(false);
   });
 
   it("should handle fetch failure and call onError callback", async () => {
     const mockError = new Error("Network error");
     vi.mocked(global.fetch).mockRejectedValueOnce(mockError);
     const mockOnError = vi.fn();
+
+    // Force offline so the hook reports the failure immediately instead of
+    // entering its retry/backoff loop (covered separately in usePositions.retry.test.ts).
+    const onLineSpy = vi.spyOn(window.navigator, "onLine", "get").mockReturnValue(false);
 
     const { result } = renderHook(() => usePositions(mockOnError));
 
@@ -146,7 +152,11 @@ describe("usePositions Hook", () => {
 
     expect(result.current.positions).toEqual([]);
     expect(result.current.error).toEqual(mockError);
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.isOffline).toBe(true);
     expect(mockOnError).toHaveBeenCalledWith(mockError);
+
+    onLineSpy.mockRestore();
   });
 
   it("should return empty array for only-lend positions", async () => {

--- a/hooks/usePositions.ts
+++ b/hooks/usePositions.ts
@@ -55,6 +55,8 @@ export interface UsePositionsResult {
   positions: BorrowPosition[];
   supplyPositions: SupplyPosition[];
   isLoading: boolean;
+  isStale: boolean;
+  isOffline: boolean;
   error: Error | null;
   refetch: () => Promise<void>;
 }
@@ -241,16 +243,18 @@ export function usePositions(onError?: (error: Error) => void): UsePositionsResu
   const [positions, setPositions] = useState<BorrowPosition[]>([]);
   const [supplyPositions, setSupplyPositions] = useState<SupplyPosition[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isStale, setIsStale] = useState<boolean>(false);
+  const [isOffline, setIsOffline] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
   const hasLoadedOnceRef = useRef(false);
 
-  const fetchPositions = useCallback(async () => {
+  const fetchPositions = useCallback(async (signal: AbortSignal, attempts = 0) => {
     if (!hasLoadedOnceRef.current) {
       setIsLoading(true);
     }
     setError(null);
     try {
-      const response = await fetch("/api/positions", { signal: abortSignal });
+      const response = await fetch("/api/positions", { signal });
       if (!response.ok) {
         throw new Error(`Failed to fetch positions: ${response.statusText}`);
       }
@@ -259,6 +263,8 @@ export function usePositions(onError?: (error: Error) => void): UsePositionsResu
       const mappedSupply = mapSupplyPositionsResponse(data);
       setPositions(mapped);
       setSupplyPositions(mappedSupply);
+      setIsStale(false);
+      setIsOffline(false);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {
         return; // Aborted
@@ -266,18 +272,16 @@ export function usePositions(onError?: (error: Error) => void): UsePositionsResu
 
       setIsStale(true);
       const errorObj = err instanceof Error ? err : new Error(String(err));
-      
-      if (!navigator.onLine) {
-        setIsOffline(true);
-      }
+      const offline = typeof navigator !== "undefined" && !navigator.onLine;
+      setIsOffline(offline);
 
       const maxAttempts = 5;
-      if (attempts < maxAttempts && navigator.onLine) {
+      if (attempts < maxAttempts && !offline) {
         const backoff = Math.min(1000 * (2 ** attempts), 10000);
         const jitter = Math.random() * 500;
         setTimeout(() => {
-          if (abortSignal && abortSignal.aborted) return;
-          fetchPositions(abortSignal, attempts + 1);
+          if (signal.aborted) return;
+          fetchPositions(signal, attempts + 1);
         }, backoff + jitter);
       } else {
         setError(errorObj);
@@ -297,14 +301,19 @@ export function usePositions(onError?: (error: Error) => void): UsePositionsResu
     return () => controller.abort();
   }, [fetchPositions]);
 
+  const refetch = useCallback(() => {
+    const controller = new AbortController();
+    return fetchPositions(controller.signal);
+  }, [fetchPositions]);
+
   return {
     positions,
     supplyPositions,
     isLoading,
-    error,
-    refetch: () => fetchPositions(),
     isStale,
-    isOffline
+    isOffline,
+    error,
+    refetch,
   };
 }
 


### PR DESCRIPTION
Closes #868

## Summary

`hooks/usePositions.ts` declared `fetchPositions` as a zero-argument `useCallback`, but its body referenced `abortSignal` and `attempts` as if they were parameters, and its catch block called `setIsStale`/`setIsOffline` (and read `isStale`/`isOffline` in the return value) even though neither was ever created with `useState`. The hook was invoked inconsistently — `fetchPositions(controller.signal)` on mount, `fetchPositions()` from `refetch`, and recursively as `fetchPositions(abortSignal, attempts + 1)` for retries — none of which matched the zero-arg declaration.

Since `usePositions` backs `NextPaymentDue`, `PositionSummary`, `WithdrawForm`, and the dashboard, this meant:
- The hook threw `ReferenceError: isStale is not defined` on **every** render (the reference is in the return statement, not just the error path), so the hook was completely broken, even on a successful fetch.
- Any fetch failure would have thrown `ReferenceError: abortSignal is not defined` instead of retrying.
- The `isStale`/`isOffline` flags returned by the hook were undefined.

## Changes

### Modified files
- `hooks/usePositions.ts`
  - Added `const [isStale, setIsStale] = useState<boolean>(false);` and `const [isOffline, setIsOffline] = useState<boolean>(false);`.
  - Added `isStale: boolean` and `isOffline: boolean` to the `UsePositionsResult` interface.
  - Gave `fetchPositions` the signature `(signal: AbortSignal, attempts = 0)`, replacing all `abortSignal` references with the `signal` parameter.
  - On a successful fetch, `isStale` and `isOffline` are reset to `false` (self-healing once data loads again).
  - On failure, `isOffline` is now derived and set from `navigator.onLine` (`typeof navigator !== "undefined" && !navigator.onLine`) instead of referencing an undeclared setter.
  - The retry/backoff loop now correctly gates on `attempts < maxAttempts && !offline`, and the recursive retry call passes `signal` and `attempts + 1`, matching the new signature. The `signal.aborted` check before retrying is preserved so an unmounted component doesn't keep retrying.
  - `refetch` now creates its own `AbortController` and calls `fetchPositions(controller.signal)`, matching the new required-`signal` signature (previously `refetch: () => fetchPositions()` called the hook with no arguments at all).

### Test files
- `hooks/usePositions.retry.test.ts` — this file previously used Jest globals (`jest.fn()`, `jest.useFakeTimers()`) while the project's `npm test` runs everything through Vitest, so the file threw `ReferenceError: jest is not defined` and never actually executed. Rewrote it with Vitest syntax (`vi.fn()`, `vi.useFakeTimers()`, `vi.stubGlobal`, `vi.runAllTimersAsync()`) and expanded coverage:
  - `retries failed fetches with backoff and stops at max attempts` — asserts `isStale` becomes `true` after the first failure, and after the retry chain runs to completion, `fetch` was called 6 times (1 initial + 5 retries) and `error` is set.
  - `recovers and clears stale state once a retry succeeds` — first attempt rejects, second (retried) attempt resolves; asserts `isStale`/`isOffline` reset to `false` and `error` is `null`.
  - `aborts in-flight requests on unmount` — asserts the `AbortController`'s `abort()` is called when the component unmounts.
  - `reports isOffline and does not retry while the browser is offline` — stubs `navigator.onLine` to `false`, asserts `isOffline` becomes `true`, `error` is set immediately, and `fetch` is only called once (no retry loop while offline).
  - `clears isOffline once a fetch succeeds again` — simulates coming back online and calling `refetch()`, asserts `isOffline`/`isStale` clear.
- `hooks/usePositions.test.ts` — updated `should handle fetch failure and call onError callback` to stub `navigator.onLine` to `false` (so the assertion isn't racing the new retry/backoff timers) and added assertions that `isStale`/`isOffline` are `true`. Added `isStale`/`isOffline` assertions (`false`) to the existing success-path test.

## Implementation details

- `attempts` defaults to `0` (`attempts = 0` in the signature), so the initial call from the mount `useEffect` (`fetchPositions(controller.signal)`) and any manual `refetch()` call behave the same as attempt 0 of the retry loop.
- `isLoading` semantics are unchanged: it's only forced `true` before the very first successful load (`hasLoadedOnceRef.current` gate), so background retries after the initial load don't flip the loading spinner back on — `isStale` is the signal for "we have data (or are still trying) but the latest refresh failed."
- No changes to `mapPositionsResponse`, `mapSupplyPositionsResponse`, `deriveCollateralShares`, or any consumer component — this is a pure bug fix to the hook's internal wiring and return shape (additive fields only, so existing consumers destructuring `positions`, `supplyPositions`, `isLoading`, `error`, `refetch` are unaffected).

## How to test

1. `npm install`
2. `npx vitest run hooks/usePositions.test.ts hooks/usePositions.retry.test.ts` — all 14 tests should pass.
3. Manually: render any component using `usePositions()` (e.g. the dashboard, `NextPaymentDue`, `PositionSummary`, `WithdrawForm`) — it should no longer throw `ReferenceError: isStale is not defined` and should load positions on mount as before.
4. Manually: simulate a failing `/api/positions` response (e.g. via devtools network throttling/blocking) and observe the hook retrying with increasing backoff instead of crashing, eventually setting `error` after 5 retries if the failure persists.
5. Manually: go offline in devtools while `/api/positions` is failing — the hook should stop retrying and immediately reflect `isOffline: true` instead of looping.
