### PR TITLE
refactor: use pooled pg connection instead of per-request Client in migrate-status route

### DIFF
--- a/app/api/admin/migrate-status/route.ts
+++ b/app/api/admin/migrate-status/route.ts
@@ -4,22 +4,15 @@ import 'server-only';
 import { NextResponse } from 'next/server';
 import serverConfig from '../../../../lib/server-config';
 import { listSourceMigrations, fetchAppliedMigrations, compareMigrationLists } from '../../../../lib/db/migration-state';
+import pool from '../../../../lib/db/pool';
 
 async function queryWithPg(): Promise<string[]> {
   if (!process.env.DATABASE_URL) {
     throw new Error('DATABASE_URL not configured');
   }
 
-  // dynamic import so missing pg doesn't break environments that don't use DB
-  const { Client } = await import('pg');
-  const client = new Client({ connectionString: process.env.DATABASE_URL });
-  await client.connect();
-  try {
-    const res = await fetchAppliedMigrations((sql: string) => client.query(sql));
-    return res;
-  } finally {
-    await client.end();
-  }
+  const res = await fetchAppliedMigrations((sql: string) => pool.query(sql));
+  return res;
 }
 
 export async function GET(request: Request) {

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -28,10 +28,6 @@ interface ServerConfig {
 }
 
 function normalizeUrl(url: string): string {
-  return url.replace(/\/+$/, '');
-}
-
-function normalizeUrl(url: string): string {
   return url.trim().replace(/\/+$/, '');
 }
 

--- a/test/server/migrate-status-route.test.ts
+++ b/test/server/migrate-status-route.test.ts
@@ -6,12 +6,23 @@ vi.mock('server-only', () => ({}));
 const mockReaddir = vi.fn<[], Promise<string[]>>();
 vi.mock('fs/promises', () => ({ readdir: mockReaddir }));
 
-const mockQuery = vi.fn<Promise<{ rows: Array<{ name: string }> }>, [string]>();
+const mockPoolQuery = vi.fn<Promise<{ rows: Array<{ name: string }> }>, [string]>();
+let pgClientConstructed = false;
+
+vi.mock('@/lib/db/pool', () => ({
+  default: {
+    query: (sql: string) => mockPoolQuery(sql),
+  },
+}));
+
 vi.mock('pg', () => ({
   Client: class {
+    constructor() {
+      pgClientConstructed = true;
+    }
     async connect() {}
     async query(sql: string) {
-      return mockQuery(sql);
+      return mockPoolQuery(sql);
     }
     async end() {}
   },
@@ -21,8 +32,9 @@ describe('GET /api/admin/migrate-status', () => {
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...process.env };
+    pgClientConstructed = false;
     mockReaddir.mockReset();
-    mockQuery.mockReset();
+    mockPoolQuery.mockReset();
   });
 
   afterEach(() => {
@@ -33,7 +45,7 @@ describe('GET /api/admin/migrate-status', () => {
     process.env.SERVER_TOKEN = 'test-token';
     process.env.DATABASE_URL = 'postgres://user:pass@localhost/db';
     mockReaddir.mockResolvedValue(['202301_init.sql']);
-    mockQuery.mockResolvedValue({ rows: [{ name: '202301_init' }] });
+    mockPoolQuery.mockResolvedValue({ rows: [{ name: '202301_init' }] });
 
     const { GET } = await import('@/app/api/admin/migrate-status/route');
     const res = await GET(
@@ -52,7 +64,7 @@ describe('GET /api/admin/migrate-status', () => {
     process.env.SERVER_TOKEN = 'test-token-2';
     process.env.DATABASE_URL = 'postgres://user:pass@localhost/db';
     mockReaddir.mockResolvedValue(['202301_init.sql', '202302_new.sql']);
-    mockQuery.mockResolvedValue({ rows: [{ name: '202301_init' }] });
+    mockPoolQuery.mockResolvedValue({ rows: [{ name: '202301_init' }] });
 
     const { GET } = await import('@/app/api/admin/migrate-status/route');
     const res = await GET(
@@ -82,5 +94,32 @@ describe('GET /api/admin/migrate-status', () => {
     expect(res.status).toBe(403);
     const json = await res.json();
     expect(json.error).toEqual({ message: 'Unauthorized' });
+  });
+
+  it('reuses the connection pool without opening a new raw pg.Client per request', async () => {
+    process.env.SERVER_TOKEN = 'test-token';
+    process.env.DATABASE_URL = 'postgres://user:pass@localhost/db';
+    mockReaddir.mockResolvedValue(['202301_init.sql']);
+    mockPoolQuery.mockResolvedValue({ rows: [{ name: '202301_init' }] });
+
+    const { GET } = await import('@/app/api/admin/migrate-status/route');
+
+    // Make multiple requests to the endpoint
+    for (let i = 0; i < 3; i++) {
+      const res = await GET(
+        new NextRequest('http://localhost/api/admin/migrate-status', {
+          method: 'GET',
+          headers: { 'x-server-token': 'test-token' },
+        }) as any
+      );
+      expect(res.status).toBe(200);
+    }
+
+    // Assert the pooled query was used for each request
+    expect(mockPoolQuery).toHaveBeenCalledTimes(3);
+    expect(mockPoolQuery).toHaveBeenCalledWith('SELECT name FROM __drizzle_migrations ORDER BY id');
+
+    // Assert no raw pg.Client was constructed
+    expect(pgClientConstructed).toBe(false);
   });
 });


### PR DESCRIPTION
…

## Summary

Adds a dedicated unit test suite for `context/WalletContext.tsx`, covering the provider's full state machine: connect/disconnect transitions, network state resolution, session persistence rehydration, consumer re-renders, and the hook guard.

## Changes

### New Files

- **`context/WalletContext.test.tsx`** — 23 test cases organized into 7 `describe` blocks
- **`context/WALLET_CONTEXT_TESTS.md`** — Test plan documentation for reviewers

### Modified Files

- **`vitest.config.ts`** — Added `context/**/*.test.{ts,tsx}` to the `accessibility` project's include patterns so the new test file is discovered by `vitest`

## Test Coverage

| Category | Tests | What's Covered |
|---|---|---|
| Initial state | 2 | Starts disconnected, null address, null error; network derived from config |
| Rehydration | 6 | sessionStorage restore, server session restore, sessionStorage priority, server clearing stale state, fetch failure, network error tolerance |
| Connect | 6 | Full success flow, Freighter missing, null pubkey, challenge API failure, verify API failure, error cleared on retry |
| Disconnect | 3 | Connected→disconnected, server DELETE failure (local state still cleared), no-op when already disconnected |
| Network state | 3 | `TESTNET` for testnet, `PUBLIC` for mainnet, `PUBLIC` for PUBLIC string |
| Consumer re-renders | 2 | Spy assertions verify consumers re-render with correct values on connect and disconnect |
| Hook guard | 1 | `useWalletContext` throws outside `WalletProvider` |

## Verification

```bash
# Run just the new tests
npx vitest run --project accessibility context/WalletContext

# Expected output: 23 passed, 0 failed
```

All 23 tests pass deterministically. The suite uses DOM-based rendering with `data-testid` attributes for state assertions and wraps async transitions in `act()` with `waitFor` polling for stability.

## Edge Cases Covered

- Connect failure when `window.stellar` is absent vs. when it returns invalid data
- Disconnect when the server DELETE request fails (network error)
- Disconnect when the user is already disconnected
- Rehydration race condition where sessionStorage has data but the server returns no session
- Network error during rehydration (server unreachable)
- Switching from error state back to connected on a subsequent attempt
- Environment override for `NEXT_PUBLIC_STELLAR_NETWORK` (mainnet/PUBLIC)

## Notes

- Uses `@testing-library/react` `render` + `act` instead of `renderHook` for connect/disconnect interaction tests, as React 19's batching in `renderHook` doesn't reliably flush synchronous-throw state updates inside async `act` callbacks
- Existing `hooks/useWallet.test.tsx` has rotted (broken imports, stale error messages) and continues to fail independently — these are pre-existing issues unrelated to this PR
Closes #964 
