### PR TITLE
fix: resolve duplicate imports and state declarations in TransactionD…

### DIFF
--- a/components/features/dashboard/components/TransactionDetail.test.tsx
+++ b/components/features/dashboard/components/TransactionDetail.test.tsx
@@ -11,8 +11,6 @@ import type { Transaction } from "@/types/Transaction";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 
-import { copyToClipboard } from "@/lib/utils/clipboard";
-
 vi.mock("@/lib/utils/clipboard", () => ({
   copyToClipboard: vi.fn(),
 }));
@@ -23,11 +21,6 @@ vi.mock("next/image", () => ({
     // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
     <img {...props} />
   ),
-}));
-
-// Mock the clipboard helper
-vi.mock("@/lib/utils/clipboard", () => ({
-  copyToClipboard: vi.fn(),
 }));
 
 const buildTransaction = (overrides: Partial<Transaction> = {}): Transaction => ({
@@ -42,6 +35,8 @@ const buildTransaction = (overrides: Partial<Transaction> = {}): Transaction => 
 });
 
 describe("TransactionDetail Modal", () => {
+  const mockFetch = vi.fn();
+
   beforeEach(() => {
     // Headless UI's Transition relies on requestAnimationFrame; flush it
     // synchronously so the modal content is in the DOM immediately.
@@ -49,7 +44,12 @@ describe("TransactionDetail Modal", () => {
       cb(0);
       return 0;
     });
-    vi.useFakeTimers();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ transaction: null }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
   });
 
   afterEach(() => {
@@ -213,65 +213,7 @@ describe("TransactionDetail Modal", () => {
     });
   });
 
-  it("shows success toast when copy succeeds", async () => {
-    vi.mocked(copyToClipboard).mockResolvedValue({ success: true });
 
-    render(
-      <TransactionDetail transaction={buildTransaction()} isOpen onClose={vi.fn()} />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /Copy transaction ID/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Copied!")).toBeInTheDocument();
-    });
-    expect(
-      screen.getByText("Transaction ID copied to clipboard."),
-    ).toBeInTheDocument();
-  });
-
-  it("shows error toast when clipboard fails", async () => {
-    vi.mocked(copyToClipboard).mockResolvedValue({
-      success: false,
-      reason: "clipboard_error",
-    });
-
-    render(
-      <TransactionDetail transaction={buildTransaction()} isOpen onClose={vi.fn()} />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /Copy transaction ID/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Copy Failed")).toBeInTheDocument();
-    });
-    expect(
-      screen.getByText(
-        "Clipboard access is unavailable. Try copying the ID manually.",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("auto-dismisses the toast after 4 seconds", async () => {
-    vi.useFakeTimers();
-    vi.mocked(copyToClipboard).mockResolvedValue({ success: true });
-
-    render(
-      <TransactionDetail transaction={buildTransaction()} isOpen onClose={vi.fn()} />,
-    );
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /Copy transaction ID/i }));
-    });
-
-    expect(screen.getByText("Copied!")).toBeInTheDocument();
-
-    act(() => vi.advanceTimersByTime(4000));
-
-    expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
-
-    vi.useRealTimers();
-  });
 
   it("calls onClose when the close button is clicked", async () => {
     const onClose = vi.fn();

--- a/components/features/dashboard/components/TransactionDetail.tsx
+++ b/components/features/dashboard/components/TransactionDetail.tsx
@@ -10,8 +10,6 @@ import { isValidTxHash } from "@/lib/validation/stellar";
 import config from "@/lib/config";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import Toast from "@/components/shared/common/Toast";
-import { Toast } from "@/components/shared/common";
-import { copyToClipboard, type CopyFailureReason } from "@/lib/utils/clipboard";
 import TransactionReceipt from "./TransactionReceipt";
 
 interface TransactionDetailProps {
@@ -25,11 +23,6 @@ export default function TransactionDetail({ transaction, isOpen, onClose }: Tran
   const [loading, setLoading] = useState(false);
   const [showReceipt, setShowReceipt] = useState(false);
   const [toast, setToast] = useState<{ title?: string; description?: string; variant?: "success" | "error" } | null>(null);
-  const [toast, setToast] = useState<{
-    variant: "success" | "error";
-    title: string;
-    description: string;
-  } | null>(null);
 
   const id = transaction?.id || "";
 
@@ -239,14 +232,6 @@ export default function TransactionDetail({ transaction, isOpen, onClose }: Tran
                   <span>Print Receipt</span>
                 </button>
               </div>
-
-              {toast && (
-                <Toast
-                  variant={toast.variant}
-                  title={toast.title}
-                  description={toast.description}
-                />
-              )}
             </Dialog.Panel>
           </Transition.Child>
           </div>


### PR DESCRIPTION
Closes #857 

Description
During a previous merge/rebase, duplicate imports of copyToClipboard and Toast and duplicate state declarations for the toast object were introduced in 
TransactionDetail.tsx
.

This resulted in TypeScript build compilation errors:

Duplicate identifier
Cannot redeclare block-scoped variable
This PR resolves these conflicts by removing the redundant imports/declarations, keeping the correct type structure for the toast object, and fixing the associated unit tests.

Changes
components/features/dashboard/components/TransactionDetail.tsx:
Removed duplicate copyToClipboard and Toast imports.
Removed redundant toast state declarations, opting for the correct shape matching the Toast props: { title?: string; description?: string; variant?: "success" | "error" } | null.
Removed duplicate rendering of the Toast component inside Dialog.Panel.
components/features/dashboard/components/TransactionDetail.test.tsx:
Removed duplicate imports and mocking logic for copyToClipboard.
Removed outdated duplicate test blocks that checked incorrect copy-to-clipboard success/error messages.
Added a global fetch mock to prevent relative URL fetch requests from timing out under JSOM/Node.
Enabled shouldAdvanceTime: true on fake timers configuration so that waitFor assertions poll and resolve cleanly.