### PR TITLE
fix(dashboard): resolve missing react imports and add error fallback …

### DIFF
--- a/app/dashboard/page.a11y.test.tsx
+++ b/app/dashboard/page.a11y.test.tsx
@@ -3,6 +3,24 @@ import axe from "axe-core";
 import { render, screen, waitFor } from "@/test/test-utils";
 import DashboardPage from "./page";
 
+// Mock DashboardLayout to avoid loading TopNav, SideNav, and their providers
+vi.mock("@/components", () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="mock-dashboard-layout">
+      {children}
+    </div>
+  ),
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 describe("DashboardPage A11y", () => {
   const fetchMock = vi.fn();
 
@@ -30,13 +48,19 @@ describe("DashboardPage A11y", () => {
       if (url.includes("/api/transactions")) {
         return Promise.resolve({
           ok: true,
-          json: async () => ([]),
+          json: async () => ({ transactions: [], total: 0 }),
         });
       }
       if (url.includes("/api/notifications")) {
         return Promise.resolve({
           ok: true,
           json: async () => ([]),
+        });
+      }
+      if (url.includes("/api/liquidations")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ positions: [] }),
         });
       }
       // default mock
@@ -82,9 +106,21 @@ describe("DashboardPage A11y", () => {
           }),
         });
       }
+      if (url.includes("/api/liquidations")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ positions: [] }),
+        });
+      }
+      if (url.includes("/api/transactions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ transactions: [], total: 0 }),
+        });
+      }
       return Promise.resolve({
         ok: true,
-        json: async () => ([]),
+        json: async () => ({}),
       });
     });
 
@@ -94,6 +130,86 @@ describe("DashboardPage A11y", () => {
     
     const alert = await screen.findByText(/Immediate action required|Collateral is critically weak/i);
     expect(alert).toBeInTheDocument();
+
+    const results = await axe.run(document.body);
+    const seriousOrCritical = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical"
+    );
+    expect(seriousOrCritical).toEqual([]);
+  });
+
+  it("handles fetch failure gracefully and renders a user-visible error banner", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/positions")) {
+        return Promise.reject(new Error("Network error"));
+      }
+      if (url.includes("/api/liquidations")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ positions: [] }),
+        });
+      }
+      if (url.includes("/api/transactions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ transactions: [], total: 0 }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({}),
+      });
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/positions"));
+
+    const errorAlert = await screen.findByText(/Failed to load positions data/i);
+    expect(errorAlert).toBeInTheDocument();
+    expect(screen.getAllByText("Error").length).toBeGreaterThan(0);
+
+    const results = await axe.run(document.body);
+    const seriousOrCritical = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical"
+    );
+    expect(seriousOrCritical).toEqual([]);
+  });
+
+  it("handles fetch response not ok gracefully and renders a user-visible error banner", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/api/positions")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+        });
+      }
+      if (url.includes("/api/liquidations")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ positions: [] }),
+        });
+      }
+      if (url.includes("/api/transactions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ transactions: [], total: 0 }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({}),
+      });
+    });
+
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/positions"));
+
+    const errorAlert = await screen.findByText(/Failed to load positions data/i);
+    expect(errorAlert).toBeInTheDocument();
+    expect(screen.getAllByText("Error").length).toBeGreaterThan(0);
 
     const results = await axe.run(document.body);
     const seriousOrCritical = results.violations.filter(

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 
 import MetricsCards from "@/components/features/dashboard/components/MetricsCards";
@@ -106,10 +107,16 @@ const getDashboardAlertData = (position: PositionMetrics): DashboardAlertData | 
 
 export default function Dashboard() {
   const [alertData, setAlertData] = useState<DashboardAlertData | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/positions")
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to fetch positions");
+        }
+        return response.json();
+      })
       .then((data) => {
         const alert = getDashboardAlertData({
           nextDue: data.nextDue,
@@ -118,7 +125,10 @@ export default function Dashboard() {
 
         setAlertData(alert);
       })
-      .catch(console.error);
+      .catch((err) => {
+        console.error(err);
+        setError("Failed to load positions data. Please try again later.");
+      });
   }, []);
 
   return (
@@ -153,16 +163,24 @@ export default function Dashboard() {
             }
           />
 
-{alertData ? (
-             <div className="mb-6">
-               <AlertBanner
-                 title={alertData.title}
-                 message={alertData.message}
-                 severity={alertData.severity}
-                 dismissKey={alertData.dismissKey}
-               />
-             </div>
-           ) : null}
+          {error ? (
+            <div className="mb-6">
+              <AlertBanner
+                title="Error"
+                message={error}
+                severity="error"
+              />
+            </div>
+          ) : alertData ? (
+            <div className="mb-6">
+              <AlertBanner
+                title={alertData.title}
+                message={alertData.message}
+                severity={alertData.severity}
+                dismissKey={alertData.dismissKey}
+              />
+            </div>
+          ) : null}
 
            <NetWorthTrend />
            <MetricsCards />


### PR DESCRIPTION
Closes #865 

Description
This PR resolves a runtime ReferenceError on the main dashboard route by importing the missing React hooks, and addresses swallowed fetch failures by introducing a user-visible fallback error banner.

Fixes:
Missing React Hook Imports: Added { useState, useEffect } imports to app/dashboard/page.tsx, fixing the ReferenceError: useState is not defined thrown on render.
Fetch Failure Handling: Previously, fetch errors on /api/positions were swallowed silently with a console.error. Added an error state to track failures, validated response.ok, and rendered a prominent, user-visible <AlertBanner severity="error" /> when the endpoint fails.
Regression Tests: Added regression tests targeting /api/positions fetch failures (both network rejection and non-ok status codes) to ensure the fallback error UI is properly displayed and passes accessibility (axe) checks.
Test Isolation: Mocked the DashboardLayout in the test suite to execute the dashboard component tests in isolation, avoiding extraneous context provider requirements (wallet/sidebar) from other modules.
Proposed Changes
app/dashboard/page.tsx
Imported useState and useEffect from "react".
Added const [error, setError] = useState<string | null>(null); state.
Throw an error if !response.ok is true in the fetch chain.
Caught errors in the .catch block to set a user-friendly error message.
Rendered the error banner if the state is set, otherwise falling back to normal alert data.
app/dashboard/page.a11y.test.tsx
Mocked the DashboardLayout component and next/navigation hooks.
Mocked /api/liquidations and /api/transactions return types to avoid runtime component errors under mock testing.
Added test: "handles fetch failure gracefully and renders a user-visible error banner"
Added test: "handles fetch response not ok gracefully and renders a user-visible error banner"