### PR TITLE
feat: add wallet account switcher

### DIFF
--- a/context/WalletContext.test.tsx
+++ b/context/WalletContext.test.tsx
@@ -3,11 +3,22 @@ import { renderHook, act, waitFor, render, screen } from "@testing-library/react
 import { WalletProvider, useWalletContext } from "./WalletContext";
 import { FC, ReactNode, createElement } from "react";
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
 function wrapper({ children }: { children: ReactNode }) {
   return createElement(WalletProvider, null, children);
 }
 
-const TEST_ADDRESS = "GABCDEF1234567890";
+const TEST_ADDRESS = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
 
 function mockResponse(ok: boolean, body: any = {}, status = ok ? 200 : 500) {
   return {

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -10,6 +10,9 @@ declare global {
     stellar?: {
       getPublicKey: () => Promise<string>;
       signTransaction: (xdr: string, opts?: { network: string }) => Promise<string>;
+      // Optional: not all wallet providers expose multiple accounts.
+      // When present, used to enumerate accounts for the switcher.
+      getAccounts?: () => Promise<string[]>;
     };
   }
 }
@@ -17,19 +20,42 @@ declare global {
 export type WalletStatus = "disconnected" | "connecting" | "connected" | "error";
 export type StellarNetwork = "PUBLIC" | "TESTNET";
 
+const ACCOUNTS_STORAGE_KEY = "walletAccounts";
+const ACTIVE_ACCOUNT_STORAGE_KEY = "walletActiveAccount";
+
 export interface WalletContextType {
   address: string | null;
+  accounts: string[];
+  activeAccount: string | null;
   network: StellarNetwork;
   status: WalletStatus;
   error: string | null;
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
+  switchAccount: (address: string) => Promise<void>;
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
+function isValidStellarAddress(pubKey: string): boolean {
+  return pubKey.length === 56 && pubKey.startsWith("G");
+}
+
+function readStoredAccounts(): string[] {
+  try {
+    const raw = sessionStorage.getItem(ACCOUNTS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((a) => typeof a === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
 export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [address, setAddress] = useState<string | null>(null);
+  const [accounts, setAccounts] = useState<string[]>([]);
+  const [activeAccount, setActiveAccount] = useState<string | null>(null);
   const [status, setStatus] = useState<WalletStatus>("disconnected");
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
@@ -49,6 +75,14 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
       if (storedAddress) {
         setAddress(storedAddress);
         setStatus("connected");
+
+        const storedAccounts = readStoredAccounts();
+        const storedActive = sessionStorage.getItem(ACTIVE_ACCOUNT_STORAGE_KEY);
+        const resolvedAccounts = storedAccounts.length > 0 ? storedAccounts : [storedAddress];
+        setAccounts(resolvedAccounts);
+        setActiveAccount(
+          storedActive && resolvedAccounts.includes(storedActive) ? storedActive : storedAddress,
+        );
       }
 
       // 2. Fetch session from server to verify/sync
@@ -61,17 +95,38 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
             setAddress(sessionAddress);
             setStatus("connected");
             sessionStorage.setItem("walletAddress", sessionAddress);
+
+            const storedAccounts = readStoredAccounts();
+            const resolvedAccounts = storedAccounts.includes(sessionAddress)
+              ? storedAccounts
+              : [sessionAddress];
+            setAccounts(resolvedAccounts);
+            sessionStorage.setItem(ACCOUNTS_STORAGE_KEY, JSON.stringify(resolvedAccounts));
+
+            const storedActive = sessionStorage.getItem(ACTIVE_ACCOUNT_STORAGE_KEY);
+            const nextActive =
+              storedActive && resolvedAccounts.includes(storedActive) ? storedActive : sessionAddress;
+            setActiveAccount(nextActive);
+            sessionStorage.setItem(ACTIVE_ACCOUNT_STORAGE_KEY, nextActive);
           } else {
             // Server has no session, clear client state
             setAddress(null);
             setStatus("disconnected");
+            setAccounts([]);
+            setActiveAccount(null);
             sessionStorage.removeItem("walletAddress");
+            sessionStorage.removeItem(ACCOUNTS_STORAGE_KEY);
+            sessionStorage.removeItem(ACTIVE_ACCOUNT_STORAGE_KEY);
           }
         } else {
           // If session request fails (e.g., unauthorized), clear state
           setAddress(null);
           setStatus("disconnected");
+          setAccounts([]);
+          setActiveAccount(null);
           sessionStorage.removeItem("walletAddress");
+          sessionStorage.removeItem(ACCOUNTS_STORAGE_KEY);
+          sessionStorage.removeItem(ACTIVE_ACCOUNT_STORAGE_KEY);
         }
       } catch (err) {
         console.error("Failed to fetch session during rehydration:", err);
@@ -99,7 +154,7 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
       }
 
       // Validate the resolved address is a 56-char Stellar public key before persisting it
-      if (pubKey.length !== 56 || !pubKey.startsWith("G")) {
+      if (!isValidStellarAddress(pubKey)) {
         throw new Error("Invalid Stellar public key");
       }
 
@@ -135,9 +190,32 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
       }
 
       const { walletAddress: verifiedAddress } = await verifyResponse.json();
+
+      // 5. Enumerate accounts if the wallet provider supports it; otherwise
+      // fall back gracefully to a single-account list.
+      let resolvedAccounts: string[] = [verifiedAddress];
+      try {
+        if (typeof stellar.getAccounts === "function") {
+          const list = await stellar.getAccounts();
+          if (Array.isArray(list) && list.length > 0) {
+            resolvedAccounts = list.filter(isValidStellarAddress);
+            if (!resolvedAccounts.includes(verifiedAddress)) {
+              resolvedAccounts = [verifiedAddress, ...resolvedAccounts];
+            }
+          }
+        }
+      } catch (accountsErr) {
+        console.error("Failed to enumerate wallet accounts:", accountsErr);
+        resolvedAccounts = [verifiedAddress];
+      }
+
       setAddress(verifiedAddress);
+      setAccounts(resolvedAccounts);
+      setActiveAccount(verifiedAddress);
       setStatus("connected");
       sessionStorage.setItem("walletAddress", verifiedAddress);
+      sessionStorage.setItem(ACCOUNTS_STORAGE_KEY, JSON.stringify(resolvedAccounts));
+      sessionStorage.setItem(ACTIVE_ACCOUNT_STORAGE_KEY, verifiedAddress);
 
       const returnUrl = new URL(window.location.href).searchParams.get("returnUrl");
       if (returnUrl) {
@@ -148,7 +226,11 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
       setError(err.message || "Wallet connection failed");
       setStatus("error");
       setAddress(null);
+      setAccounts([]);
+      setActiveAccount(null);
       sessionStorage.removeItem("walletAddress");
+      sessionStorage.removeItem(ACCOUNTS_STORAGE_KEY);
+      sessionStorage.removeItem(ACTIVE_ACCOUNT_STORAGE_KEY);
     }
   };
 
@@ -163,8 +245,12 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
     } finally {
       // Always clear local state on disconnect to ensure the user is logged out locally
       setAddress(null);
+      setAccounts([]);
+      setActiveAccount(null);
       setStatus("disconnected");
       sessionStorage.removeItem("walletAddress");
+      sessionStorage.removeItem(ACCOUNTS_STORAGE_KEY);
+      sessionStorage.removeItem(ACTIVE_ACCOUNT_STORAGE_KEY);
     }
 
     const returnUrl = new URL(window.location.href).searchParams.get("returnUrl");
@@ -173,15 +259,38 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
     }
   };
 
+  // Switch the active account among already-known accounts.
+  // Triggers downstream data refresh (positions, balances) by updating
+  // `address`, since existing consumers key their fetch effects off it.
+  const switchAccount = async (nextAddress: string) => {
+    if (!nextAddress || !accounts.includes(nextAddress)) {
+      setError("Unknown account: cannot switch to an address not exposed by the wallet");
+      return;
+    }
+
+    if (nextAddress === activeAccount) {
+      return;
+    }
+
+    setError(null);
+    setActiveAccount(nextAddress);
+    setAddress(nextAddress);
+    sessionStorage.setItem(ACTIVE_ACCOUNT_STORAGE_KEY, nextAddress);
+    sessionStorage.setItem("walletAddress", nextAddress);
+  };
+
   return (
     <WalletContext.Provider
       value={{
         address,
+        accounts,
+        activeAccount,
         network,
         status,
         error,
         connect,
         disconnect,
+        switchAccount,
       }}
     >
       {children}

--- a/hooks/useWallet.ts
+++ b/hooks/useWallet.ts
@@ -1,13 +1,26 @@
 import { useWalletContext } from "@/context/WalletContext";
 
 export const useWallet = () => {
-  const { address, network, status, error, connect, disconnect } = useWalletContext();
-  return {
+  const {
     address,
+    accounts,
+    activeAccount,
     network,
     status,
     error,
     connect,
     disconnect,
+    switchAccount,
+  } = useWalletContext();
+  return {
+    address,
+    accounts,
+    activeAccount,
+    network,
+    status,
+    error,
+    connect,
+    disconnect,
+    switchAccount,
   };
 };


### PR DESCRIPTION
## Summary
- add support for multiple wallet accounts in WalletContext
- expose activeAccount and accounts
- add switchAccount functionality
- update tests for WalletContext
fixes #608
Closes #608