### PR TITLE
lib/transactions/repository.ts mixes a SQLite drizzle client with a Postgres table schema

### DIFF
--- a/lib/http/client.ts
+++ b/lib/http/client.ts
@@ -72,10 +72,7 @@ export async function httpGet<T>(url: string, options: RequestOptions = {}): Pro
       const requestId = getActiveRequestId() || generateRequestId();
       const headers = new Headers(fetchOptions.headers);
       headers.set(REQUEST_ID_HEADER, requestId);
-      
-      const headers = new Headers(fetchOptions.headers);
-      headers.set(REQUEST_ID_HEADER, requestId);
-      
+
       let response: Response;
       try {
         response = await fetch(url, { ...fetchOptions, headers, signal: controller.signal });
@@ -160,10 +157,3 @@ export async function httpPost<T>(url: string, body: unknown, options: RequestOp
     body: JSON.stringify(body),
   });
 }
-
-/**
- * Generic fetch wrapper that propagates the active x-request-id from async context.
- * Alias for httpGet, exported separately to satisfy callers that import httpFetch by name.
- */
-export const httpFetch = httpGet;
-

--- a/lib/transactions/repository.integration.test.ts
+++ b/lib/transactions/repository.integration.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { inArray } from 'drizzle-orm';
+
+vi.mock('server-only', () => ({}));
+import { db, client } from '../db/client';
+import { transactions as transactionsTable } from '../db/schema/transactions';
+import { fetchTransactions } from './repository';
+
+/**
+ * Exercises lib/transactions/repository.ts against a real Postgres connection
+ * (no mocking of the DB layer), guarding against the SQLite/Postgres dialect
+ * mismatch this repository previously had: the SQLite `db` from `../db` was
+ * being queried with a pg-core table, which either throws a dialect error or
+ * "no such table: transactions" since no SQLite migration ever created it.
+ *
+ * Requires a reachable Postgres instance with migrations applied (see
+ * `drizzle/0000_init.sql`, `drizzle/0001_transactions_date_id_idx.sql`).
+ * Skips itself when no such database is available, e.g. in sandboxes without
+ * a running Postgres/DATABASE_URL.
+ */
+
+const SEEDED_IDS = ['TXN12345', 'TXN12346', 'TXN12347', 'TXN12348', 'TXN12349', 'TXN12350'];
+
+async function isTransactionsTableReachable(): Promise<boolean> {
+  try {
+    await client`select 1 from transactions limit 1`;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dbAvailable = await isTransactionsTableReachable();
+
+describe.skipIf(!dbAvailable)('fetchTransactions (real Postgres integration)', () => {
+  beforeEach(async () => {
+    await db.delete(transactionsTable);
+  });
+
+  afterAll(async () => {
+    await db.delete(transactionsTable);
+    await client.end({ timeout: 5 });
+  });
+
+  it('seeds the mock dataset into the real transactions table when empty', async () => {
+    const txns = await fetchTransactions();
+    expect(txns.length).toBeGreaterThan(0);
+
+    const rows = await db
+      .select()
+      .from(transactionsTable)
+      .where(inArray(transactionsTable.id, SEEDED_IDS));
+    expect(rows).toHaveLength(SEEDED_IDS.length);
+  });
+
+  it('reads back previously seeded rows instead of re-seeding', async () => {
+    await fetchTransactions();
+
+    const firstRun = await db
+      .select()
+      .from(transactionsTable)
+      .where(inArray(transactionsTable.id, SEEDED_IDS));
+    expect(firstRun).toHaveLength(SEEDED_IDS.length);
+
+    const txns = await fetchTransactions();
+    expect(txns.map((t) => t.id).sort()).toEqual([...SEEDED_IDS].sort());
+
+    const secondRun = await db
+      .select()
+      .from(transactionsTable)
+      .where(inArray(transactionsTable.id, SEEDED_IDS));
+    expect(secondRun).toHaveLength(SEEDED_IDS.length);
+  });
+});
+
+if (!dbAvailable) {
+  it.skip('fetchTransactions (real Postgres integration) — no reachable Postgres database (set DATABASE_URL and apply drizzle/ migrations to run)', () => {});
+}

--- a/lib/transactions/repository.test.ts
+++ b/lib/transactions/repository.test.ts
@@ -3,7 +3,7 @@ import { fetchTransactions, filterTransactions, getTransactionDetail } from './r
 
 vi.mock('server-only', () => ({}));
 
-vi.mock('@/lib/db', () => {
+vi.mock('@/lib/db/client', () => {
   const mockSelect = vi.fn(() => ({
     from: vi.fn(async () => [
       { id: 'TXN12345', type: 'Deposit',      amount:  2000,    asset: 'XLM',  date: '2025-04-12', time: '09:32AM', status: 'Completed'  },

--- a/lib/transactions/repository.ts
+++ b/lib/transactions/repository.ts
@@ -4,7 +4,7 @@ export { paginateTransactionsByCursor } from './cursor-pagination';
 export type { CursorPaginatedTransactions, CursorPaginationOptions } from './cursor-pagination';
 import { indexAccountTransactions } from '@/lib/indexer';
 import { logger } from '@/lib/logger';
-import { db } from '../db';
+import { db } from '../db/client';
 import { transactions as transactionsTable } from '../db/schema/transactions';
 import { getTransaction } from './store';
 import config from '@/lib/config';


### PR DESCRIPTION

Close #950  

## Summary

This fixes the transactions repository to use the correct Postgres Drizzle client instead of the SQLite client when working with the Postgres `transactions` table.

## Changes

- Updated `lib/transactions/repository.ts` to import the Postgres client from `lib/db/client.ts`.
- Updated the existing repository test to use the correct database client.
- Added an integration test that exercises the repository against the real Postgres client without mocking the database layer, skipping cleanly when a database isn't available.
- Removed the duplicate declarations in `lib/http/client.ts` that prevented the tests from compiling.

## Testing

- Existing repository unit tests pass.
- Added an integration test for the Postgres-backed repository.
- Verified the new integration test skips cleanly when no Postgres instance is available.