### PR TITLE
fix(WalletGate): surface wallet connection error to user

### DIFF
--- a/components/shared/ui/WalletGate.test.tsx
+++ b/components/shared/ui/WalletGate.test.tsx
@@ -43,6 +43,24 @@ describe('WalletGate', () => {
     expect(connectMock).toHaveBeenCalled();
   });
 
+  it('renders error message when wallet connection fails', () => {
+    const connectMock = vi.fn();
+    (useWalletConnection as any).mockReturnValue({
+      isConnected: false,
+      isLoading: false,
+      connect: connectMock,
+      error: 'Freighter not detected',
+    });
+
+    render(
+      <WalletGate>
+        <div>Content</div>
+      </WalletGate>
+    );
+
+    expect(screen.getByTestId('wallet-error')).toHaveTextContent('Freighter not detected');
+  });
+
   it('renders loading state', () => {
     (useWalletConnection as any).mockReturnValue({
       isConnected: false,
@@ -57,7 +75,6 @@ describe('WalletGate', () => {
     );
     
     expect(screen.queryByText('Content')).not.toBeInTheDocument();
-    // Check for pulse animation class or something that indicates loading
-    expect(screen.getByRole('button', { name: /Connect/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Connect/i })).not.toBeInTheDocument();
   });
 });

--- a/components/shared/ui/WalletGate.tsx
+++ b/components/shared/ui/WalletGate.tsx
@@ -7,7 +7,7 @@ interface WalletGateProps {
 }
 
 export const WalletGate = ({ children, fallbackText = "Connect wallet to continue" }: WalletGateProps) => {
-  const { isConnected, isLoading, connect } = useWalletConnection();
+  const { isConnected, isLoading, connect, error } = useWalletConnection();
 
   if (isLoading) {
     return <div className="animate-pulse h-12 w-full bg-slate-200 rounded-md" />;
@@ -15,12 +15,22 @@ export const WalletGate = ({ children, fallbackText = "Connect wallet to continu
 
   if (!isConnected) {
     return (
-      <button
-        onClick={connect}
-        className="w-full flex items-center justify-center gap-2 rounded-xl bg-green-600 px-6 py-4 font-semibold text-white shadow-sm transition-all hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
-      >
-        {fallbackText}
-      </button>
+      <div className="w-full">
+        <button
+          onClick={connect}
+          className="w-full flex items-center justify-center gap-2 rounded-xl bg-green-600 px-6 py-4 font-semibold text-white shadow-sm transition-all hover:bg-green-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
+        >
+          {fallbackText}
+        </button>
+        {error && (
+          <span
+            data-testid="wallet-error"
+            className="mt-2 block text-xs text-red-200 bg-red-900/90 border border-red-700/50 px-2 py-0.5 rounded shadow-lg"
+          >
+            {error}
+          </span>
+        )}
+      </div>
     );
   }
 


### PR DESCRIPTION
## Overview

This PR surfaces the wallet connection error from `useWalletConnection()` to the user inside `WalletGate.tsx`. Previously, when a connection failed (e.g. missing Freighter provider or SEP-10 challenge/verify flow), the error was silently swallowed � the button simply returned to its default label with no explanation.

## Related Issue

Closes #879

## Changes

- **[FIX]** `components/shared/ui/WalletGate.tsx`
  - Destructure `error` from `useWalletConnection()` (was previously ignored)
  - Render a visible `data-testid="wallet-error"` error message beneath the connect button when `error` is set, matching the pattern used in `WalletConnectButton.tsx`
- **[TEST]** `components/shared/ui/WalletGate.test.tsx`
  - Add test case simulating a failed `connect()` call, asserting the error message is displayed
  - Fix pre-existing bug in loading test: `getByRole` ? `queryByRole` to avoid throwing when element is absent

## Verification Results

```
npx vitest run components/shared/ui/WalletGate.test.tsx
? 4/4 passed (3 existing + 1 new)
```

Acceptance Criteria | Status
-- | --
Error from `useWalletConnection` is surfaced to the user | ? Error rendered as `data-testid="wallet-error"` span below button
Error appears when `connect()` fails | ? Tested with mocked failed connection
