### PR TITLE
fix: add per-device session store and fix vi.mock hoisting in session…

### DIFF
--- a/app/api/account/sessions/[id]/route.test.ts
+++ b/app/api/account/sessions/[id]/route.test.ts
@@ -3,10 +3,14 @@ import { NextRequest } from 'next/server';
 import { DELETE } from './route';
 
 // ── mocks ──────────────────────────────────────────────────────────────────
+// vi.mock factories are hoisted before variable declarations, so we must use
+// vi.hoisted to ensure the mock functions exist when the factories run.
 
-const mockGetSession = vi.fn();
-const mockGetStoredSession = vi.fn();
-const mockRevokeStoredSession = vi.fn();
+const { mockGetSession, mockGetStoredSession, mockRevokeStoredSession } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockGetStoredSession: vi.fn(),
+  mockRevokeStoredSession: vi.fn(),
+}));
 
 vi.mock('@/lib/auth', () => ({ getSession: mockGetSession }));
 vi.mock('@/lib/auth/session-store', () => ({

--- a/app/api/account/sessions/route.test.ts
+++ b/app/api/account/sessions/route.test.ts
@@ -3,10 +3,14 @@ import { NextRequest } from 'next/server';
 import { GET } from './route';
 
 // ── mocks ──────────────────────────────────────────────────────────────────
+// vi.mock factories are hoisted before variable declarations, so we must use
+// vi.hoisted to ensure the mock functions exist when the factories run.
 
-const mockGetSession = vi.fn();
-const mockListStoredSessions = vi.fn();
-const mockTouchStoredSession = vi.fn();
+const { mockGetSession, mockListStoredSessions, mockTouchStoredSession } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockListStoredSessions: vi.fn(),
+  mockTouchStoredSession: vi.fn(),
+}));
 
 vi.mock('@/lib/auth', () => ({ getSession: mockGetSession }));
 vi.mock('@/lib/auth/session-store', () => ({

--- a/lib/auth/session-store.ts
+++ b/lib/auth/session-store.ts
@@ -206,6 +206,96 @@ export function clearRevocations(): void {
   userRevocations.clear();
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-device session store
+//
+// Stores one record per active device session so the Active Sessions UI can
+// list, inspect, and individually revoke sessions.  The in-memory map is keyed
+// by a stable, per-device session id that callers supply (typically the value
+// held in session.user.id or a UUID minted at login time).
+//
+// In production this should be backed by Redis / the sessions DB table, but the
+// interface is intentionally kept identical so the store can be swapped without
+// touching the route layer.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface StoredSession {
+  /** Stable per-device identifier */
+  id: string;
+  /** Owning user's identifier */
+  userId: string;
+  /** User-Agent header captured at login */
+  userAgent: string;
+  /** Client IP captured at login */
+  ipAddress: string;
+  /** ISO-8601 timestamp when the session was first created */
+  createdAt: string;
+  /** ISO-8601 timestamp of the most recent activity (updated by touchStoredSession) */
+  lastSeenAt: string;
+}
+
+/** In-memory per-device session store (keyed by StoredSession.id) */
+const deviceSessionStore = new Map<string, StoredSession>();
+
+/**
+ * Add (or upsert) a per-device session record.
+ * Callers should invoke this immediately after a successful login.
+ */
+export function addStoredSession(session: StoredSession): void {
+  deviceSessionStore.set(session.id, { ...session });
+  logger.info('Stored session added', 'session-store', { sessionId: session.id, userId: session.userId });
+}
+
+/**
+ * Return the stored session with the given id, or null if it does not exist.
+ */
+export function getStoredSession(sessionId: string): StoredSession | null {
+  return deviceSessionStore.get(sessionId) ?? null;
+}
+
+/**
+ * Return all stored sessions belonging to a specific user.
+ */
+export function listStoredSessions(userId: string): StoredSession[] {
+  const results: StoredSession[] = [];
+  for (const session of deviceSessionStore.values()) {
+    if (session.userId === userId) {
+      results.push({ ...session });
+    }
+  }
+  return results;
+}
+
+/**
+ * Update lastSeenAt for the session with the given id.
+ * No-op if the session does not exist.
+ */
+export function touchStoredSession(sessionId: string): void {
+  const existing = deviceSessionStore.get(sessionId);
+  if (existing) {
+    deviceSessionStore.set(sessionId, {
+      ...existing,
+      lastSeenAt: new Date().toISOString(),
+    });
+  }
+}
+
+/**
+ * Remove (revoke) the per-device session record with the given id.
+ * No-op if the session does not exist (idempotent).
+ */
+export function revokeStoredSession(sessionId: string): void {
+  deviceSessionStore.delete(sessionId);
+  logger.info('Stored session revoked', 'session-store', { sessionId });
+}
+
+/**
+ * Remove all per-device session records (for testing only).
+ */
+export function clearStoredSessions(): void {
+  deviceSessionStore.clear();
+}
+
 /**
  * Get revocation stats for monitoring
  */


### PR DESCRIPTION
fix: add per-device session store and fix vi.mock hoisting in session tests
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Summary
  
  The DELETE /api/account/sessions/[id] route (and its companion GET /api/account/sessions) both
  imported getStoredSession, revokeStoredSession, listStoredSessions, and touchStoredSession from
  lib/auth/session-store — but none of those functions existed. The session store only contained
  a revocation-list keyed by a synthetic userId_iat token ID, with no concept of per-device
  session records. This made it impossible for users to list or revoke individual device sessions
  from the Active Sessions UI.
  
  Changes
  
  lib/auth/session-store.ts
  
  Added a dedicated per-device session store alongside the existing revocation list:
  
  - StoredSession interface — id, userId, userAgent, ipAddress, createdAt, lastSeenAt
  - addStoredSession — upserts a session record at login time
  - getStoredSession — looks up a single session by id (returns null if not found)
  - listStoredSessions — returns all sessions for a given userId
  - touchStoredSession — updates lastSeenAt to track recent activity
  - revokeStoredSession — removes the record (idempotent)
  - clearStoredSessions — test-only reset
  
  The existing revocation-list functions (revokeSession, isSessionRevoked, etc.) are untouched.
  
  app/api/account/sessions/[id]/route.test.ts and app/api/account/sessions/route.test.ts
  
  Both test files had a vi.mock hoisting bug: the factory functions closed over const mockFn =
  vi.fn() declarations, but vi.mock is hoisted to the top of the file before those consts are
  initialized, causing a ReferenceError at startup. Fixed by wrapping all mock functions in
  vi.hoisted(() => ({ ... })).
  
  Tests
  
  All 21 tests pass:
  
  - 9 tests for GET /api/account/sessions (list, auth, current-session flagging, shape)
  - 12 tests for DELETE /api/account/sessions/[id] (auth, 404, current-session confirmation
  guard, non-current revoke, audit event, idempotency)

closes #992 