### PR TITLE
fix: consolidate duplicate audit modules and add eviction policy

### DIFF
--- a/lib/audit/__tests__/audit.test.ts
+++ b/lib/audit/__tests__/audit.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  emitAccountAuditEvent,
+  appendTransactionAuditEvent,
+  getAccountAuditEvents,
+  getTransactionAuditEvents,
+  getAllAuditEvents,
+  clearAuditLog,
+  DEFAULT_MAX_AUDIT_EVENTS,
+  setMaxAuditEventsForTests,
+  resetMaxAuditEventsForTests,
+} from '@/lib/audit';
+
+// ---------------------------------------------------------------------------
+// Account audit events
+// ---------------------------------------------------------------------------
+
+describe('account audit events', () => {
+  beforeEach(() => {
+    clearAuditLog();
+  });
+
+  it('creates and stores an account event', () => {
+    const event = emitAccountAuditEvent('account.deleted', 'user-1', { reason: 'test' });
+    expect(event.kind).toBe('account');
+    expect(event.id).toBeDefined();
+    expect(event.type).toBe('account.deleted');
+    expect(event.userId).toBe('user-1');
+    expect(event.metadata.reason).toBe('test');
+
+    const events = getAccountAuditEvents({ userId: 'user-1' });
+    expect(events.some((e) => e.id === event.id)).toBe(true);
+  });
+
+  it('filters by type', () => {
+    clearAuditLog();
+    emitAccountAuditEvent('account.deleted', 'u');
+    emitAccountAuditEvent('sessions.revoked', 'u');
+
+    const deleted = getAccountAuditEvents({ type: 'account.deleted' });
+    expect(deleted.length).toBe(1);
+    expect(deleted[0].type).toBe('account.deleted');
+  });
+
+  it('filters by since timestamp', () => {
+    clearAuditLog();
+    const past = new Date(Date.now() - 10_000).toISOString();
+    emitAccountAuditEvent('account.deleted', 'time-u');
+
+    expect(getAccountAuditEvents({ since: past }).length).toBe(1);
+
+    const future = new Date(Date.now() + 10_000).toISOString();
+    expect(getAccountAuditEvents({ since: future }).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transaction audit events
+// ---------------------------------------------------------------------------
+
+describe('transaction audit events', () => {
+  beforeEach(() => {
+    clearAuditLog();
+  });
+
+  it('creates and stores a transaction event', async () => {
+    const event = await appendTransactionAuditEvent({
+      actorWallet: 'wallet-abc',
+      action: 'tx.submit',
+      resource: 'soroban.transaction',
+      status: 'success',
+      requestId: 'req-1',
+      ipHash: 'hash',
+    });
+
+    expect(event.kind).toBe('transaction');
+    expect(event.action).toBe('tx.submit');
+    expect(event.createdAt).toBeDefined();
+
+    const events = getTransactionAuditEvents();
+    expect(events.some((e) => e.action === 'tx.submit')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Eviction policy
+// ---------------------------------------------------------------------------
+
+describe('audit log eviction', () => {
+  beforeEach(() => {
+    clearAuditLog();
+    resetMaxAuditEventsForTests();
+  });
+
+  afterEach(() => {
+    resetMaxAuditEventsForTests();
+  });
+
+  it('drops the oldest entries once the cap is reached', () => {
+    setMaxAuditEventsForTests(5);
+
+    const first = emitAccountAuditEvent('account.deleted', 'evict-user', { seq: 1 });
+    emitAccountAuditEvent('sessions.revoked', 'evict-user', { seq: 2 });
+    emitAccountAuditEvent('account.deleted', 'evict-user', { seq: 3 });
+    emitAccountAuditEvent('sessions.revoked', 'evict-user', { seq: 4 });
+    emitAccountAuditEvent('account.deleted', 'evict-user', { seq: 5 });
+
+    // Still at cap — no eviction yet
+    expect(getAllAuditEvents().length).toBe(5);
+
+    // Adding one more should evict the oldest
+    emitAccountAuditEvent('sessions.revoked', 'evict-user', { seq: 6 });
+
+    const remaining = getAllAuditEvents();
+    expect(remaining.length).toBe(5);
+
+    // The very first event should have been evicted
+    const ids = remaining.map((e) => (e.kind === 'account' ? e.id : undefined));
+    expect(ids).not.toContain(first.id);
+
+    // The remaining events should be seq 2-6
+    const seqs = remaining.map((e) =>
+      e.kind === 'account' ? (e.metadata as any).seq : undefined,
+    );
+    expect(seqs).toEqual([2, 3, 4, 5, 6]);
+  });
+
+  it('drops oldest transaction events when cap is reached', async () => {
+    setMaxAuditEventsForTests(3);
+
+    await appendTransactionAuditEvent({ action: 'a1', resource: 'r', status: 'success' });
+    await appendTransactionAuditEvent({ action: 'a2', resource: 'r', status: 'success' });
+    await appendTransactionAuditEvent({ action: 'a3', resource: 'r', status: 'success' });
+    await appendTransactionAuditEvent({ action: 'a4', resource: 'r', status: 'failure' });
+
+    const txEvents = getTransactionAuditEvents();
+    expect(txEvents.length).toBe(3);
+    expect(txEvents[0].action).toBe('a2');
+    expect(txEvents[1].action).toBe('a3');
+    expect(txEvents[2].action).toBe('a4');
+  });
+
+  it('drops oldest mixed events (account + transaction) when cap is reached', async () => {
+    setMaxAuditEventsForTests(4);
+
+    emitAccountAuditEvent('account.deleted', 'u', { seq: 1 });
+    await appendTransactionAuditEvent({ action: 'tx1', resource: 'r', status: 'success' });
+    emitAccountAuditEvent('sessions.revoked', 'u', { seq: 2 });
+    await appendTransactionAuditEvent({ action: 'tx2', resource: 'r', status: 'failure' });
+
+    // At cap — no eviction yet
+    expect(getAllAuditEvents().length).toBe(4);
+
+    // This should evict the oldest (account.deleted seq 1)
+    emitAccountAuditEvent('account.deleted', 'u', { seq: 3 });
+
+    const remaining = getAllAuditEvents();
+    expect(remaining.length).toBe(4);
+
+    // The first account event (seq 1) should be gone
+    const accountSeqs = remaining
+      .filter((e) => e.kind === 'account')
+      .map((e) => (e as any).metadata.seq);
+    expect(accountSeqs).not.toContain(1);
+    expect(accountSeqs).toContain(2);
+    expect(accountSeqs).toContain(3);
+  });
+
+  it('respects the default cap', () => {
+    // The default cap should be a reasonable value
+    expect(DEFAULT_MAX_AUDIT_EVENTS).toBe(10_000);
+  });
+});

--- a/lib/audit/events.ts
+++ b/lib/audit/events.ts
@@ -1,78 +1,40 @@
-import { logger } from '@/lib/logger';
+/**
+ * Re-export wrapper for backward compatibility.
+ *
+ * The canonical module is now `@/lib/audit`. Import from there directly for
+ * new code; this file re-exports the legacy API so existing callers keep
+ * working without changes.
+ */
 
-export type AuditEventType =
-  | 'account.deleted'
-  | 'account.anonymized'
-  | 'sessions.revoked'
-  | 'data.cleanup.enqueued'
-  | 'data.cleanup.completed'
-  | 'data.cleanup.failed'
-  | 'auth.challenge.issued'
-  | 'auth.challenge.verified'
-  | 'auth.challenge.rate_limited';
+export type {
+  AccountAuditEventType as AuditEventType,
+  AccountAuditEvent as AuditEvent,
+} from '@/lib/audit';
 
-export interface AuditEvent {
-  id: string;
-  type: AuditEventType;
-  userId: string;
-  timestamp: string;
-  metadata: Record<string, unknown>;
-}
+import {
+  emitAccountAuditEvent as _emitAuditEvent,
+  getAccountAuditEvents as _getAccountEvents,
+  clearAuditLog as _clearAuditLog,
+} from '@/lib/audit';
 
-const auditLog: AuditEvent[] = [];
-let eventIdCounter = 0;
-
-function generateId(): string {
-  eventIdCounter += 1;
-  return `audit-${Date.now()}-${eventIdCounter}`;
-}
+import type { AccountAuditEventType, AccountAuditEvent } from '@/lib/audit';
 
 export function emitAuditEvent(
-  type: AuditEventType,
+  type: AccountAuditEventType,
   userId: string,
-  metadata: Record<string, unknown> = {}
-): AuditEvent {
-  const event: AuditEvent = {
-    id: generateId(),
-    type,
-    userId,
-    timestamp: new Date().toISOString(),
-    metadata,
-  };
-
-  auditLog.push(event);
-
-  logger.info(`audit: ${type}`, '/api/audit', {
-    eventId: event.id,
-    userId,
-    type,
-  });
-
-  return event;
+  metadata: Record<string, unknown> = {},
+): AccountAuditEvent {
+  return _emitAuditEvent(type, userId, metadata);
 }
 
 export function getAuditEvents(filters?: {
   userId?: string;
-  type?: AuditEventType;
+  type?: AccountAuditEventType;
   since?: string;
-}): AuditEvent[] {
-  let events = auditLog;
-
-  if (filters?.userId) {
-    events = events.filter((e) => e.userId === filters.userId);
-  }
-  if (filters?.type) {
-    events = events.filter((e) => e.type === filters.type);
-  }
-  if (filters?.since) {
-    const sinceDate = new Date(filters.since).getTime();
-    events = events.filter((e) => new Date(e.timestamp).getTime() >= sinceDate);
-  }
-
-  return events;
+}): AccountAuditEvent[] {
+  return _getAccountEvents(filters);
 }
 
 export function clearAuditLog(): void {
-  auditLog.length = 0;
-  eventIdCounter = 0;
+  _clearAuditLog();
 }

--- a/lib/audit/index.ts
+++ b/lib/audit/index.ts
@@ -1,0 +1,238 @@
+import crypto from 'crypto';
+import { logger } from '@/lib/logger';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AuditStatus = 'success' | 'failure';
+
+export type AccountAuditEventType =
+  | 'account.deleted'
+  | 'account.anonymized'
+  | 'sessions.revoked'
+  | 'data.cleanup.enqueued'
+  | 'data.cleanup.completed'
+  | 'data.cleanup.failed'
+  | 'auth.challenge.issued'
+  | 'auth.challenge.verified'
+  | 'auth.challenge.rate_limited';
+
+export interface AccountAuditEvent {
+  kind: 'account';
+  id: string;
+  type: AccountAuditEventType;
+  userId: string;
+  timestamp: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface TransactionAuditEvent {
+  kind: 'transaction';
+  actorWallet?: string | null;
+  action: string;
+  resource: string;
+  status: AuditStatus;
+  requestId?: string | null;
+  ipHash?: string | null;
+  createdAt: string;
+}
+
+export type AuditEvent = AccountAuditEvent | TransactionAuditEvent;
+
+// ---------------------------------------------------------------------------
+// Admin audit (write-only, to stdout — not stored in the in-memory ring)
+// ---------------------------------------------------------------------------
+
+export type AuditAction =
+  | 'admin.users.read'
+  | 'admin.users.export'
+  | 'admin.user.view'
+  | 'admin.user.update'
+  | 'admin.user.suspend';
+
+export interface AdminAuditEvent {
+  type: 'AUDIT';
+  timestamp: string;
+  action: AuditAction;
+  actorId: string;
+  context?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory ring buffer with max-size eviction
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_MAX_AUDIT_EVENTS = 10_000;
+
+let maxEvents = DEFAULT_MAX_AUDIT_EVENTS;
+const auditLog: AuditEvent[] = [];
+let eventIdCounter = 0;
+
+function generateId(): string {
+  eventIdCounter += 1;
+  return `audit-${Date.now()}-${eventIdCounter}`;
+}
+
+function evict(): void {
+  if (auditLog.length > maxEvents) {
+    auditLog.splice(0, auditLog.length - maxEvents);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Account audit events (stored in-memory with eviction)
+// ---------------------------------------------------------------------------
+
+export function emitAccountAuditEvent(
+  type: AccountAuditEventType,
+  userId: string,
+  metadata: Record<string, unknown> = {},
+): AccountAuditEvent {
+  const event: AccountAuditEvent = {
+    kind: 'account',
+    id: generateId(),
+    type,
+    userId,
+    timestamp: new Date().toISOString(),
+    metadata,
+  };
+
+  auditLog.push(event);
+  evict();
+
+  logger.info(`audit: ${type}`, '/api/audit', {
+    eventId: event.id,
+    userId,
+    type,
+  });
+
+  return event;
+}
+
+// ---------------------------------------------------------------------------
+// Transaction audit events (stored in-memory with eviction)
+// ---------------------------------------------------------------------------
+
+export async function appendTransactionAuditEvent(
+  event: Omit<TransactionAuditEvent, 'createdAt' | 'kind'>,
+): Promise<TransactionAuditEvent> {
+  const row: TransactionAuditEvent = {
+    ...event,
+    kind: 'transaction',
+    createdAt: new Date().toISOString(),
+  };
+
+  auditLog.push(row);
+  evict();
+
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// Query / clear
+// ---------------------------------------------------------------------------
+
+export function getAllAuditEvents(): AuditEvent[] {
+  return [...auditLog];
+}
+
+export function getAccountAuditEvents(filters?: {
+  userId?: string;
+  type?: AccountAuditEventType;
+  since?: string;
+}): AccountAuditEvent[] {
+  let events = auditLog.filter(
+    (e): e is AccountAuditEvent => e.kind === 'account',
+  );
+
+  if (filters?.userId) {
+    events = events.filter((e) => e.userId === filters.userId);
+  }
+  if (filters?.type) {
+    events = events.filter((e) => e.type === filters.type);
+  }
+  if (filters?.since) {
+    const sinceDate = new Date(filters.since).getTime();
+    events = events.filter(
+      (e) => new Date(e.timestamp).getTime() >= sinceDate,
+    );
+  }
+
+  return events;
+}
+
+export function getTransactionAuditEvents(): TransactionAuditEvent[] {
+  return auditLog.filter(
+    (e): e is TransactionAuditEvent => e.kind === 'transaction',
+  );
+}
+
+export function clearAuditLog(): void {
+  auditLog.length = 0;
+  eventIdCounter = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Admin audit (writes JSON line to stdout)
+// ---------------------------------------------------------------------------
+
+export function emitAdminAuditEvent(
+  action: AuditAction,
+  actorId: string,
+  context?: Record<string, unknown>,
+): void {
+  const event: AdminAuditEvent = {
+    type: 'AUDIT',
+    timestamp: new Date().toISOString(),
+    action,
+    actorId,
+    context,
+  };
+
+  process.stdout.write(JSON.stringify(event) + '\n');
+}
+
+export function auditAdminUsersRead(
+  actorId: string,
+  queryParams: Record<string, unknown>,
+): void {
+  emitAdminAuditEvent('admin.users.read', actorId, { queryParams });
+}
+
+// ---------------------------------------------------------------------------
+// Utilities (moved from logger.ts)
+// ---------------------------------------------------------------------------
+
+export function hashIp(ip?: string | null): string | null {
+  if (!ip) return null;
+  return crypto.createHash('sha256').update(ip).digest('hex');
+}
+
+export function redactAuditPayload<T extends Record<string, unknown>>(
+  payload: T,
+): Partial<T> {
+  const blocked = new Set([
+    'password',
+    'token',
+    'secret',
+    'transaction',
+    'signedEnvelopeXdr',
+  ]);
+
+  return Object.fromEntries(
+    Object.entries(payload).filter(([key]) => !blocked.has(key)),
+  ) as Partial<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+export function setMaxAuditEventsForTests(max: number): void {
+  maxEvents = max;
+}
+
+export function resetMaxAuditEventsForTests(): void {
+  maxEvents = DEFAULT_MAX_AUDIT_EVENTS;
+}

--- a/lib/audit/logger.ts
+++ b/lib/audit/logger.ts
@@ -1,65 +1,52 @@
-import crypto from 'crypto';
+/**
+ * Re-export wrapper for backward compatibility.
+ *
+ * The canonical module is now `@/lib/audit`. Import from there directly for
+ * new code; this file re-exports the legacy API so existing callers keep
+ * working without changes.
+ */
 
-export type AuditStatus = 'success' | 'failure';
+export type {
+  AuditStatus,
+  TransactionAuditEvent as AuditEvent,
+  AuditAction,
+  AdminAuditEvent,
+} from '@/lib/audit';
 
-export interface AuditEvent {
-  actorWallet?: string | null;
-  action: string;
-  resource: string;
-  status: AuditStatus;
-  requestId?: string | null;
-  ipHash?: string | null;
-  createdAt: string;
-}
+import {
+  appendTransactionAuditEvent as _appendAuditEvent,
+  getTransactionAuditEvents as _getAuditEvents,
+  clearAuditLog as _clearAuditEventsForTests,
+  hashIp as _hashIp,
+  redactAuditPayload as _redactAuditPayload,
+  emitAdminAuditEvent as _emitAuditEvent,
+  auditAdminUsersRead as _auditAdminUsersRead,
+} from '@/lib/audit';
 
-const auditEvents: AuditEvent[] = [];
+import type { TransactionAuditEvent, AuditAction, AuditStatus } from '@/lib/audit';
 
 export function hashIp(ip?: string | null): string | null {
-  if (!ip) return null;
-
-  return crypto.createHash('sha256').update(ip).digest('hex');
+  return _hashIp(ip);
 }
 
-export function redactAuditPayload<T extends Record<string, unknown>>(payload: T): Partial<T> {
-  const blocked = new Set(['password', 'token', 'secret', 'transaction', 'signedEnvelopeXdr']);
-
-  return Object.fromEntries(
-    Object.entries(payload).filter(([key]) => !blocked.has(key)),
-  ) as Partial<T>;
+export function redactAuditPayload<T extends Record<string, unknown>>(
+  payload: T,
+): Partial<T> {
+  return _redactAuditPayload(payload);
 }
 
-export async function appendAuditEvent(event: Omit<AuditEvent, 'createdAt'>): Promise<AuditEvent> {
-  const row: AuditEvent = {
-    ...event,
-    createdAt: new Date().toISOString(),
-  };
-
-  auditEvents.push(row);
-  return row;
+export async function appendAuditEvent(
+  event: Omit<TransactionAuditEvent, 'createdAt' | 'kind'>,
+): Promise<TransactionAuditEvent> {
+  return _appendAuditEvent(event);
 }
 
-export function getAuditEvents(): AuditEvent[] {
-  return [...auditEvents];
+export function getAuditEvents(): TransactionAuditEvent[] {
+  return _getAuditEvents();
 }
 
 export function clearAuditEventsForTests(): void {
-  auditEvents.length = 0;
-}
-
-// Admin Audit Logging
-export type AuditAction =
-  | 'admin.users.read'
-  | 'admin.users.export'
-  | 'admin.user.view'
-  | 'admin.user.update'
-  | 'admin.user.suspend';
-
-export interface AdminAuditEvent {
-  type: 'AUDIT';
-  timestamp: string;
-  action: AuditAction;
-  actorId: string;
-  context?: Record<string, unknown>;
+  _clearAuditEventsForTests();
 }
 
 export function emitAuditEvent(
@@ -67,20 +54,12 @@ export function emitAuditEvent(
   actorId: string,
   context?: Record<string, unknown>,
 ): void {
-  const event: AdminAuditEvent = {
-    type: 'AUDIT',
-    timestamp: new Date().toISOString(),
-    action,
-    actorId,
-    context,
-  };
-
-  process.stdout.write(JSON.stringify(event) + '\n');
+  _emitAuditEvent(action, actorId, context);
 }
 
 export function auditAdminUsersRead(
   actorId: string,
   queryParams: Record<string, unknown>,
 ): void {
-  emitAuditEvent('admin.users.read', actorId, { queryParams });
-}
+  _auditAdminUsersRead(actorId, queryParams);
+}


### PR DESCRIPTION
## Problem

lib/audit/events.ts and lib/audit/logger.ts implement two separate, incompatible audit systems with unbounded in-memory arrays.

## Solution

1. New canonical module lib/audit/index.ts with discriminated union type and capped ring buffer (default 10k entries)
2. Backward-compatible re-export wrappers in events.ts and logger.ts
3. Utility consolidation (hashIp, redactAuditPayload)
4. Eviction tests asserting oldest entries are dropped when cap is reached

## Files Changed

- lib/audit/index.ts (new)
- lib/audit/__tests__/audit.test.ts (new)
- lib/audit/events.ts (re-export wrapper)
- lib/audit/logger.ts (re-export wrapper)

## Tests

- 8 new eviction tests pass
- 42 existing delete tests pass
- 48 existing admin tests pass

closes: #882