### PR TITLE
Closes StellarLend/Stellarlend-frontend#880

### DIFF
--- a/context/WalletContext.test.tsx
+++ b/context/WalletContext.test.tsx
@@ -215,6 +215,30 @@ describe("WalletProvider", () => {
       expect(screen.getByTestId("address").textContent).toBe("");
     });
 
+    it("sets status to error when public key has invalid length/prefix", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false));
+      (window as any).stellar = {
+        getPublicKey: vi.fn().mockResolvedValue("not-a-valid-key"),
+        signTransaction: vi.fn(),
+      };
+
+      renderApp();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("status").textContent).toBe("disconnected");
+      });
+
+      await act(async () => {
+        screen.getByTestId("connect-btn").click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("status").textContent).toBe("error");
+      });
+      expect(screen.getByTestId("error").textContent).toBe("Invalid Stellar public key");
+      expect(screen.getByTestId("address").textContent).toBe("");
+    });
+
     it("sets status to error when no public key returned", async () => {
       vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false));
       (window as any).stellar = {

--- a/context/WalletContext.tsx
+++ b/context/WalletContext.tsx
@@ -4,21 +4,10 @@ import React, { createContext, useContext, useState, useEffect, FC, ReactNode } 
 import { useRouter } from "next/navigation";
 import config from "@/lib/config";
 import { safeRedirectPath } from "@/lib/security/safe-redirect";
-
-declare global {
-  interface Window {
-    stellar?: {
-      getPublicKey: () => Promise<string>;
-      signTransaction: (xdr: string, opts?: { network: string }) => Promise<string>;
-      // Optional: not all wallet providers expose multiple accounts.
-      // When present, used to enumerate accounts for the switcher.
-      getAccounts?: () => Promise<string[]>;
-    };
-  }
-}
+import { connectWallet, isValidStellarAddress, type StellarNetwork } from "@/lib/wallet/connectHandshake";
 
 export type WalletStatus = "disconnected" | "connecting" | "connected" | "error";
-export type StellarNetwork = "PUBLIC" | "TESTNET";
+export type { StellarNetwork };
 
 const ACCOUNTS_STORAGE_KEY = "walletAccounts";
 const ACTIVE_ACCOUNT_STORAGE_KEY = "walletActiveAccount";
@@ -36,10 +25,6 @@ export interface WalletContextType {
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
-
-function isValidStellarAddress(pubKey: string): boolean {
-  return pubKey.length === 56 && pubKey.startsWith("G");
-}
 
 function readStoredAccounts(): string[] {
   try {
@@ -142,60 +127,14 @@ export const WalletProvider: FC<{ children: ReactNode }> = ({ children }) => {
     setError(null);
 
     try {
-      const stellar = window.stellar;
-      if (!stellar) {
-        throw new Error("Stellar wallet provider (Freighter) not detected");
-      }
+      const verifiedAddress = await connectWallet(network);
 
-      // 1. Get client public key
-      const pubKey = await stellar.getPublicKey();
-      if (!pubKey) {
-        throw new Error("No public key returned from wallet");
-      }
-
-      // Validate the resolved address is a 56-char Stellar public key before persisting it
-      if (!isValidStellarAddress(pubKey)) {
-        throw new Error("Invalid Stellar public key");
-      }
-
-      // 2. Fetch SEP-10 challenge transaction
-      const challengeResponse = await fetch("/api/auth/challenge", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ walletAddress: pubKey }),
-      });
-
-      if (!challengeResponse.ok) {
-        const errData = await challengeResponse.json();
-        throw new Error(errData.error || "Failed to generate challenge");
-      }
-
-      const { transaction } = await challengeResponse.json();
-
-      // 3. Sign transaction
-      const signedTransaction = await stellar.signTransaction(transaction, {
-        network,
-      });
-
-      // 4. Verify transaction signature and establish session
-      const verifyResponse = await fetch("/api/auth/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ transaction: signedTransaction }),
-      });
-
-      if (!verifyResponse.ok) {
-        const errData = await verifyResponse.json();
-        throw new Error(errData.error || "Verification failed");
-      }
-
-      const { walletAddress: verifiedAddress } = await verifyResponse.json();
-
-      // 5. Enumerate accounts if the wallet provider supports it; otherwise
+      // Enumerate accounts if the wallet provider supports it; otherwise
       // fall back gracefully to a single-account list.
       let resolvedAccounts: string[] = [verifiedAddress];
       try {
-        if (typeof stellar.getAccounts === "function") {
+        const stellar = window.stellar;
+        if (stellar && typeof stellar.getAccounts === "function") {
           const list = await stellar.getAccounts();
           if (Array.isArray(list) && list.length > 0) {
             resolvedAccounts = list.filter(isValidStellarAddress);

--- a/hooks/useWalletConnection.test.ts
+++ b/hooks/useWalletConnection.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useWalletConnection } from "./useWalletConnection";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+const TEST_ADDRESS = "GABCDEF1234567890";
+const VALID_ADDRESS = "GBRPAME4HFAIMDOM4VES2SO24TEY246NNSUHE4WR37GBTT5CXYABXL7R";
+
+function mockResponse(ok: boolean, body: any = {}, status = ok ? 200 : 500) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function setupStellar(pubKey = VALID_ADDRESS) {
+  (window as any).stellar = {
+    getPublicKey: vi.fn().mockResolvedValue(pubKey),
+    signTransaction: vi.fn().mockResolvedValue("signed-xdr"),
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  (window as any).stellar = undefined;
+});
+
+describe("useWalletConnection", () => {
+  describe("initial state", () => {
+    it("starts disconnected with null address", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false));
+      const { result } = renderHook(() => useWalletConnection());
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.status).toBe("disconnected");
+      expect(result.current.address).toBeNull();
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("derives network from config (testnet)", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false));
+      const { result } = renderHook(() => useWalletConnection());
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.network).toBe("TESTNET");
+    });
+  });
+
+  describe("rehydration", () => {
+    it("restores from sessionStorage on mount", async () => {
+      sessionStorage.setItem("walletAddress", TEST_ADDRESS);
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false));
+
+      const { result } = renderHook(() => useWalletConnection());
+
+      await waitFor(() => {
+        expect(result.current.address).toBe(TEST_ADDRESS);
+        expect(result.current.status).toBe("connected");
+        expect(result.current.isConnected).toBe(true);
+      });
+    });
+
+    it("clears state when server has no session", async () => {
+      sessionStorage.setItem("walletAddress", TEST_ADDRESS);
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(true, { session: {} }));
+
+      const { result } = renderHook(() => useWalletConnection());
+
+      await waitFor(() => {
+        expect(result.current.address).toBeNull();
+        expect(result.current.status).toBe("disconnected");
+      });
+      expect(sessionStorage.getItem("walletAddress")).toBeNull();
+    });
+  });
+
+  describe("connect", () => {
+    it("transitions to connected on success and persists to sessionStorage", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false));
+      setupStellar();
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(mockResponse(true, { transaction: "challenge-xdr" }))
+        .mockResolvedValueOnce(mockResponse(true, { walletAddress: VALID_ADDRESS }));
+
+      const { result } = renderHook(() => useWalletConnection());
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      expect(result.current.status).toBe("connected");
+      expect(result.current.address).toBe(VALID_ADDRESS);
+      expect(result.current.isConnected).toBe(true);
+      expect(sessionStorage.getItem("walletAddress")).toBe(VALID_ADDRESS);
+    });
+
+    it("rejects a public key with an invalid length/prefix, matching WalletContext behavior", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false));
+      setupStellar("not-a-valid-key");
+
+      const { result } = renderHook(() => useWalletConnection());
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      expect(result.current.status).toBe("error");
+      expect(result.current.error).toBe("Invalid Stellar public key");
+      expect(result.current.address).toBeNull();
+      expect(result.current.isConnected).toBe(false);
+      expect(sessionStorage.getItem("walletAddress")).toBeNull();
+    });
+
+    it("sets error when Freighter is not detected", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false));
+      (window as any).stellar = undefined;
+
+      const { result } = renderHook(() => useWalletConnection());
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      expect(result.current.status).toBe("error");
+      expect(result.current.error).toBe("Stellar wallet provider (Freighter) not detected");
+    });
+  });
+
+  describe("disconnect", () => {
+    it("clears state on disconnect", async () => {
+      sessionStorage.setItem("walletAddress", TEST_ADDRESS);
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(mockResponse(false))
+        .mockResolvedValueOnce(mockResponse(true));
+
+      const { result } = renderHook(() => useWalletConnection());
+
+      await waitFor(() => expect(result.current.status).toBe("connected"));
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+
+      expect(result.current.status).toBe("disconnected");
+      expect(result.current.address).toBeNull();
+      expect(sessionStorage.getItem("walletAddress")).toBeNull();
+    });
+  });
+});

--- a/hooks/useWalletConnection.ts
+++ b/hooks/useWalletConnection.ts
@@ -1,110 +1,175 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import config from '@/lib/config';
+import { safeRedirectPath } from '@/lib/security/safe-redirect';
+
+declare global {
+  interface Window {
+    stellar?: {
+      getPublicKey: () => Promise<string>;
+      signTransaction: (xdr: string, opts?: { network: string }) => Promise<string>;
+    };
+  }
+}
+
+export type WalletStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+export type StellarNetwork = 'PUBLIC' | 'TESTNET';
 
 export const useWalletConnection = () => {
-  const [walletAddress, setWalletAddress] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [address, setAddress] = useState<string | null>(null);
+  const [status, setStatus] = useState<WalletStatus>('disconnected');
   const [error, setError] = useState<string | null>(null);
+  const [isInitializing, setIsInitializing] = useState(true);
+  const router = useRouter();
 
-  const checkSession = async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const response = await fetch('/api/auth/session');
-      if (response.ok) {
-        const data = await response.json();
-        if (data?.session?.user?.walletAddress) {
-          setWalletAddress(data.session.user.walletAddress);
-        } else {
-          setWalletAddress(null);
-        }
-      }
-    } catch (err) {
-      console.error('Failed to fetch session:', err);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const network: StellarNetwork =
+    config.stellar.network.toUpperCase() === 'MAINNET' ||
+    config.stellar.network.toUpperCase() === 'PUBLIC'
+      ? 'PUBLIC'
+      : 'TESTNET';
 
+  // Rehydrate state on mount
   useEffect(() => {
-    checkSession();
+    const rehydrate = async () => {
+      // 1. Read from sessionStorage first for immediate hydration
+      const storedAddress = sessionStorage.getItem('walletAddress');
+      if (storedAddress) {
+        setAddress(storedAddress);
+        setStatus('connected');
+      }
+
+      // 2. Fetch session from server to verify/sync
+      try {
+        const response = await fetch('/api/auth/session');
+        if (response.ok) {
+          const data = await response.json();
+          const sessionAddress = data?.session?.user?.walletAddress;
+          if (sessionAddress) {
+            setAddress(sessionAddress);
+            setStatus('connected');
+            sessionStorage.setItem('walletAddress', sessionAddress);
+          } else {
+            // Server has no session, clear client state
+            setAddress(null);
+            setStatus('disconnected');
+            sessionStorage.removeItem('walletAddress');
+          }
+        } else {
+          // If session request fails (e.g., unauthorized), clear state
+          setAddress(null);
+          setStatus('disconnected');
+          sessionStorage.removeItem('walletAddress');
+        }
+      } catch (err) {
+        console.error('Failed to fetch session during rehydration:', err);
+      } finally {
+        setIsInitializing(false);
+      }
+    };
+
+    rehydrate();
   }, []);
 
-  const connect = async () => {
-    setIsLoading(true);
+  const connect = useCallback(async () => {
+    if (status === 'connecting') return;
+    setStatus('connecting');
     setError(null);
+
     try {
       const stellar = window.stellar;
       if (!stellar) {
-        throw new Error("Stellar wallet provider (Freighter) not detected");
+        throw new Error('Stellar wallet provider (Freighter) not detected');
       }
 
+      // 1. Get client public key
       const pubKey = await stellar.getPublicKey();
       if (!pubKey) {
-        throw new Error("No public key returned from wallet");
+        throw new Error('No public key returned from wallet');
       }
 
-      const challengeResponse = await fetch("/api/auth/challenge", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      // Validate the resolved address is a 56-char Stellar public key before persisting it
+      if (pubKey.length !== 56 || !pubKey.startsWith('G')) {
+        throw new Error('Invalid Stellar public key');
+      }
+
+      // 2. Fetch SEP-10 challenge transaction
+      const challengeResponse = await fetch('/api/auth/challenge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ walletAddress: pubKey }),
       });
 
       if (!challengeResponse.ok) {
         const errData = await challengeResponse.json();
-        throw new Error(errData.error || "Failed to generate challenge");
+        throw new Error(errData.error || 'Failed to generate challenge');
       }
 
       const { transaction } = await challengeResponse.json();
+
+      // 3. Sign transaction
       const signedTransaction = await stellar.signTransaction(transaction, {
-        network: "TESTNET",
+        network,
       });
 
-      const verifyResponse = await fetch("/api/auth/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      // 4. Verify transaction signature and establish session
+      const verifyResponse = await fetch('/api/auth/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ transaction: signedTransaction }),
       });
 
       if (!verifyResponse.ok) {
         const errData = await verifyResponse.json();
-        throw new Error(errData.error || "Verification failed");
+        throw new Error(errData.error || 'Verification failed');
       }
 
       const { walletAddress: verifiedAddress } = await verifyResponse.json();
-      setWalletAddress(verifiedAddress);
-    } catch (err: any) {
-      console.error("Wallet connection failed:", err);
-      setError(err.message || "Wallet connection failed");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+      setAddress(verifiedAddress);
+      setStatus('connected');
+      sessionStorage.setItem('walletAddress', verifiedAddress);
 
-  const disconnect = async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const response = await fetch("/api/auth/session", {
-        method: "DELETE",
-      });
-      if (response.ok) {
-        setWalletAddress(null);
-      } else {
-        throw new Error("Failed to clear session");
+      const returnUrl = new URL(window.location.href).searchParams.get('returnUrl');
+      if (returnUrl) {
+        router.push(safeRedirectPath(returnUrl));
       }
     } catch (err: any) {
-      console.error("Logout failed:", err);
-      setError(err.message || "Failed to disconnect");
-    } finally {
-      setIsLoading(false);
+      console.error('Wallet connection failed:', err);
+      setError(err.message || 'Wallet connection failed');
+      setStatus('error');
+      setAddress(null);
+      sessionStorage.removeItem('walletAddress');
     }
-  };
+  }, [status, network, router]);
+
+  const disconnect = useCallback(async () => {
+    setError(null);
+    try {
+      await fetch('/api/auth/session', {
+        method: 'DELETE',
+      });
+    } catch (err: any) {
+      console.error('Logout failed during disconnect:', err);
+    } finally {
+      // Always clear local state on disconnect to ensure the user is logged out locally
+      setAddress(null);
+      setStatus('disconnected');
+      sessionStorage.removeItem('walletAddress');
+    }
+
+    const returnUrl = new URL(window.location.href).searchParams.get('returnUrl');
+    if (returnUrl) {
+      router.push(safeRedirectPath(returnUrl));
+    }
+  }, [router]);
 
   return {
-    walletAddress,
-    isConnected: !!walletAddress,
-    isLoading,
+    address,
+    walletAddress: address,
+    network,
+    status,
     error,
+    isConnected: status === 'connected',
+    isLoading: isInitializing || status === 'connecting',
     connect,
     disconnect,
   };

--- a/hooks/useWalletConnection.ts
+++ b/hooks/useWalletConnection.ts
@@ -2,18 +2,10 @@ import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import config from '@/lib/config';
 import { safeRedirectPath } from '@/lib/security/safe-redirect';
-
-declare global {
-  interface Window {
-    stellar?: {
-      getPublicKey: () => Promise<string>;
-      signTransaction: (xdr: string, opts?: { network: string }) => Promise<string>;
-    };
-  }
-}
+import { connectWallet, type StellarNetwork } from '@/lib/wallet/connectHandshake';
 
 export type WalletStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
-export type StellarNetwork = 'PUBLIC' | 'TESTNET';
+export type { StellarNetwork };
 
 export const useWalletConnection = () => {
   const [address, setAddress] = useState<string | null>(null);
@@ -76,54 +68,7 @@ export const useWalletConnection = () => {
     setError(null);
 
     try {
-      const stellar = window.stellar;
-      if (!stellar) {
-        throw new Error('Stellar wallet provider (Freighter) not detected');
-      }
-
-      // 1. Get client public key
-      const pubKey = await stellar.getPublicKey();
-      if (!pubKey) {
-        throw new Error('No public key returned from wallet');
-      }
-
-      // Validate the resolved address is a 56-char Stellar public key before persisting it
-      if (pubKey.length !== 56 || !pubKey.startsWith('G')) {
-        throw new Error('Invalid Stellar public key');
-      }
-
-      // 2. Fetch SEP-10 challenge transaction
-      const challengeResponse = await fetch('/api/auth/challenge', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ walletAddress: pubKey }),
-      });
-
-      if (!challengeResponse.ok) {
-        const errData = await challengeResponse.json();
-        throw new Error(errData.error || 'Failed to generate challenge');
-      }
-
-      const { transaction } = await challengeResponse.json();
-
-      // 3. Sign transaction
-      const signedTransaction = await stellar.signTransaction(transaction, {
-        network,
-      });
-
-      // 4. Verify transaction signature and establish session
-      const verifyResponse = await fetch('/api/auth/verify', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ transaction: signedTransaction }),
-      });
-
-      if (!verifyResponse.ok) {
-        const errData = await verifyResponse.json();
-        throw new Error(errData.error || 'Verification failed');
-      }
-
-      const { walletAddress: verifiedAddress } = await verifyResponse.json();
+      const verifiedAddress = await connectWallet(network);
       setAddress(verifiedAddress);
       setStatus('connected');
       sessionStorage.setItem('walletAddress', verifiedAddress);

--- a/lib/wallet/connectHandshake.test.ts
+++ b/lib/wallet/connectHandshake.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { connectWallet, isValidStellarAddress } from "./connectHandshake";
+
+const VALID_ADDRESS = "GBRPAME4HFAIMDOM4VES2SO24TEY246NNSUHE4WR37GBTT5CXYABXL7R";
+
+function mockResponse(ok: boolean, body: any = {}, status = ok ? 200 : 500) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  (window as any).stellar = undefined;
+});
+
+describe("isValidStellarAddress", () => {
+  it("accepts a well-formed 56-char G-prefixed address", () => {
+    expect(isValidStellarAddress(VALID_ADDRESS)).toBe(true);
+  });
+
+  it("rejects addresses of the wrong length", () => {
+    expect(isValidStellarAddress("GABCDEF1234567890")).toBe(false);
+  });
+
+  it("rejects addresses without a G prefix", () => {
+    expect(isValidStellarAddress("A".repeat(56))).toBe(false);
+  });
+});
+
+describe("connectWallet", () => {
+  it("returns the verified address on a full successful handshake", async () => {
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue(VALID_ADDRESS),
+      signTransaction: vi.fn().mockResolvedValue("signed-xdr"),
+    };
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockResponse(true, { transaction: "challenge-xdr" }))
+      .mockResolvedValueOnce(mockResponse(true, { walletAddress: VALID_ADDRESS }));
+
+    const result = await connectWallet("TESTNET");
+
+    expect(result).toBe(VALID_ADDRESS);
+  });
+
+  it("throws when Freighter is not detected", async () => {
+    (window as any).stellar = undefined;
+    await expect(connectWallet("TESTNET")).rejects.toThrow(
+      "Stellar wallet provider (Freighter) not detected",
+    );
+  });
+
+  it("throws when no public key is returned", async () => {
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue(null),
+      signTransaction: vi.fn(),
+    };
+    await expect(connectWallet("TESTNET")).rejects.toThrow(
+      "No public key returned from wallet",
+    );
+  });
+
+  it("throws when the public key has an invalid length/prefix", async () => {
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue("not-a-valid-key"),
+      signTransaction: vi.fn(),
+    };
+    await expect(connectWallet("TESTNET")).rejects.toThrow("Invalid Stellar public key");
+  });
+
+  it("throws when the challenge request fails", async () => {
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue(VALID_ADDRESS),
+      signTransaction: vi.fn(),
+    };
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse(false, { error: "Server error" }, 500));
+
+    await expect(connectWallet("TESTNET")).rejects.toThrow("Server error");
+  });
+
+  it("throws when the verify request fails", async () => {
+    (window as any).stellar = {
+      getPublicKey: vi.fn().mockResolvedValue(VALID_ADDRESS),
+      signTransaction: vi.fn().mockResolvedValue("signed-xdr"),
+    };
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockResponse(true, { transaction: "challenge-xdr" }))
+      .mockResolvedValueOnce(mockResponse(false, { error: "Invalid signature" }, 400));
+
+    await expect(connectWallet("TESTNET")).rejects.toThrow("Invalid signature");
+  });
+});

--- a/lib/wallet/connectHandshake.ts
+++ b/lib/wallet/connectHandshake.ts
@@ -1,0 +1,69 @@
+export type StellarNetwork = "PUBLIC" | "TESTNET";
+
+declare global {
+  interface Window {
+    stellar?: {
+      getPublicKey: () => Promise<string>;
+      signTransaction: (xdr: string, opts?: { network: string }) => Promise<string>;
+      // Optional: not all wallet providers expose multiple accounts.
+      getAccounts?: () => Promise<string[]>;
+    };
+  }
+}
+
+export function isValidStellarAddress(pubKey: string): boolean {
+  return pubKey.length === 56 && pubKey.startsWith("G");
+}
+
+/**
+ * Freighter -> SEP-10 challenge -> sign -> verify handshake shared by every
+ * wallet-connect entry point. Keeping this in one place is what the two
+ * previous copies (WalletContext and useWalletConnection) lacked: they had
+ * drifted apart on public key validation, so an invalid key could be
+ * accepted by one entry point and rejected by the other. Throws with a
+ * message suitable for surfacing directly to the user.
+ */
+export async function connectWallet(network: StellarNetwork): Promise<string> {
+  const stellar = window.stellar;
+  if (!stellar) {
+    throw new Error("Stellar wallet provider (Freighter) not detected");
+  }
+
+  const pubKey = await stellar.getPublicKey();
+  if (!pubKey) {
+    throw new Error("No public key returned from wallet");
+  }
+
+  if (!isValidStellarAddress(pubKey)) {
+    throw new Error("Invalid Stellar public key");
+  }
+
+  const challengeResponse = await fetch("/api/auth/challenge", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ walletAddress: pubKey }),
+  });
+
+  if (!challengeResponse.ok) {
+    const errData = await challengeResponse.json();
+    throw new Error(errData.error || "Failed to generate challenge");
+  }
+
+  const { transaction } = await challengeResponse.json();
+
+  const signedTransaction = await stellar.signTransaction(transaction, { network });
+
+  const verifyResponse = await fetch("/api/auth/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ transaction: signedTransaction }),
+  });
+
+  if (!verifyResponse.ok) {
+    const errData = await verifyResponse.json();
+    throw new Error(errData.error || "Verification failed");
+  }
+
+  const { walletAddress } = await verifyResponse.json();
+  return walletAddress;
+}


### PR DESCRIPTION
WalletContext's connect() reimplemented the Freighter -> /api/auth/challenge -> sign -> /api/auth/verify flow already present in useWalletConnection, but the two had diverged: WalletContext validated the public key shape, persisted to sessionStorage, and handled returnUrl redirects, while the hook did none of that and hardcoded TESTNET regardless of config. WalletGate (hook) and WalletConnectButton (context) therefore behaved differently for the same invalid input.

useWalletConnection is now the single implementation (validation, session persistence, config-driven network, redirect); WalletContext is a thin wrapper exposing the same WalletContextType shape for existing consumers.

## Summary

Extracts the Freighter → SEP-10 challenge → sign → verify handshake and public key validation into a single shared module (`lib/wallet/connectHandshake.ts`), and updates both `useWalletConnection` and `WalletContext` to call it instead of each maintaining their own divergent copy.

**Note on scope:** while this branch was open, `main` picked up a wallet account-switcher feature (#1018) that added a *third*, expanded copy of this same handshake directly inside `WalletContext` (to enumerate accounts after connecting). Rather than discard that work or re-fork the duplication problem, this PR rebases on top of it and pulls the handshake out from underneath both `WalletContext`'s account-switcher logic and `useWalletConnection`, leaving the switcher-specific state (`accounts`, `activeAccount`, `switchAccount`) exactly as it was.

## Changes

### New Files

- **`lib/wallet/connectHandshake.ts`** — `connectWallet(network)` and `isValidStellarAddress(pubKey)`, the single implementation of the handshake and validation both entry points now call
- **`lib/wallet/connectHandshake.test.ts`** — 9 unit tests directly on the shared handshake (valid/invalid address shapes, each failure branch of `connectWallet`)
- **`hooks/useWalletConnection.test.ts`** — 8 tests covering the hook's state machine now that it owns validation, sessionStorage persistence, and `returnUrl` redirect

### Modified Files

- **`hooks/useWalletConnection.ts`** — now derives network from `config.stellar.network` (previously hardcoded `TESTNET`), persists to sessionStorage, redirects via `safeRedirectPath` on connect/disconnect, and delegates the handshake itself to `connectWallet()`
- **`context/WalletContext.tsx`** — `connect()` now calls the shared `connectWallet()` for the handshake, then does its own account enumeration/persistence on the result; rehydrate, disconnect, and `switchAccount` are untouched
- **`context/WalletContext.test.tsx`** — added a regression test asserting an invalid public key (wrong length/prefix) is rejected with the same `"Invalid Stellar public key"` error the hook now produces

## Test Coverage

| File | Tests | What's Covered |
|---|---|---|
| `lib/wallet/connectHandshake.test.ts` | 9 | Address validation (valid/wrong-length/wrong-prefix), full successful handshake, each failure mode (no Freighter, no pubkey, invalid pubkey, challenge failure, verify failure) |
| `hooks/useWalletConnection.test.ts` | 8 | Initial state, rehydration, connect success + invalid public key + missing Freighter, disconnect |
| `context/WalletContext.test.tsx` | 24 | Initial state, rehydration (6), connect incl. invalid-key regression (7), disconnect (3), network state (3), consumer re-renders (2), hook guard |

## Verification

```bash
npx vitest run --project accessibility context/WalletContext hooks/useWalletConnection
npx vitest run --project server-unit lib/wallet/connectHandshake