### PR TITLE
Stop usePrices from refetching on every render

### DIFF
--- a/hooks/usePrices.test.ts
+++ b/hooks/usePrices.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import {
   usePrices,
   loadPrices,
@@ -198,5 +198,37 @@ describe("usePrices", () => {
     await waitFor(() => expect(result.current.hasError).toBe(true));
 
     expect(result.current.getPriceLabel("XLM")).toBe("Price unavailable");
+  });
+
+  it("does not refetch when re-rendered with a new-but-equivalent assets array", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        prices: { XLM: 0.12, USDC: 1 },
+        timestamp: new Date().toISOString(),
+        source: "test",
+      }),
+    } as Response);
+
+    // Passing a fresh array literal on every render is the exact scenario
+    // that used to defeat caching: `assets` in the effect's dependency array
+    // always differs by reference even when its contents are identical.
+    const { result, rerender } = renderHook(
+      ({ assets }: { assets: string[] }) => usePrices(assets),
+      { initialProps: { assets: ["XLM", "USDC"] } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    rerender({ assets: ["XLM", "USDC"] });
+    rerender({ assets: ["XLM", "USDC"] });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.hasError).toBe(false);
   });
 });

--- a/hooks/usePrices.ts
+++ b/hooks/usePrices.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PRICE_CACHE_CONFIG } from "@/lib/prices/constants";
 import type { PriceResponse } from "@/lib/prices/types";
 import { formatCurrency } from "@/lib/utils/format";
@@ -108,6 +108,14 @@ export function usePrices(assets: string[]): UsePricesResult {
     [assets.join(",")],
   );
 
+  // Callers typically pass a fresh array literal (e.g. usePrices(['XLM','USDC']))
+  // on every render, so `assets` itself is not a stable dependency. `symbolsKey`
+  // is the stable, memoized identity for a given set of symbols; the ref lets
+  // the effect and refresh() read the latest array contents without needing
+  // `assets` in their dependency lists.
+  const assetsRef = useRef(assets);
+  assetsRef.current = assets;
+
   const [entry, setEntry] = useState<CacheEntry | null>(
     () => sessionCache.get(symbolsKey) ?? null,
   );
@@ -126,7 +134,7 @@ export function usePrices(assets: string[]): UsePricesResult {
       setIsLoading(true);
     }
 
-    loadPrices(assets).then((result) => {
+    loadPrices(assetsRef.current).then((result) => {
       if (active) {
         setEntry(result);
         setIsLoading(false);
@@ -136,13 +144,13 @@ export function usePrices(assets: string[]): UsePricesResult {
     return () => {
       active = false;
     };
-  }, [symbolsKey, assets]);
+  }, [symbolsKey]);
 
   const refresh = useCallback(async () => {
-    const result = await loadPrices(assets);
+    const result = await loadPrices(assetsRef.current);
     setEntry(result);
     setIsLoading(false);
-  }, [assets]);
+  }, []);
 
   const getPriceLabel = useCallback(
     (symbol: string): string => {


### PR DESCRIPTION
hooks/usePrices.ts refetches on every render because its effect depends on an unstable array reference

Any consumer that calls usePrices(['XLM','USDC']) (a fresh array literal on every render) causes this effect to re-run on every single render because the array reference always changes. This defeats the hook's caching mechanism and triggers unnecessary API calls.

## Description

The effect's dependency array was `[symbolsKey, assets]`. `symbolsKey` is already a memoized, stable identity for a given set of symbols (`useMemo(() => cacheKeyForAssets(assets), [assets.join(",")])`), but including `assets` alongside it meant the effect still re-ran whenever a caller passed a new array literal with the same contents, which is the normal way this hook gets called.

Closes #896

## Changes

- **`hooks/usePrices.ts`**: added `assetsRef` (a `useRef` kept in sync with the latest `assets` on every render) and removed `assets` from the effect's dependency array, leaving only `symbolsKey`. The effect and `refresh()` now read `assetsRef.current` instead of closing over `assets` directly, so they no longer need `assets` as a dependency at all.
- **`hooks/usePrices.test.ts`**: added a test that re-renders the hook with a fresh-but-equal array on every render and asserts `fetch` was only called once.

## Verification

`pnpm vitest run hooks/usePrices.test.ts`. My new test passes, along with the other pre-existing `usePrices`/`loadPrices` tests. Three unrelated tests in this same file were already failing before my change (confirmed via `git stash`) due to a separate pre-existing bug: `formatCurrency` in `lib/utils/format.ts` references an undefined `currency` variable and throws a `ReferenceError` whenever it actually runs. I adjusted my new test to not depend on that broken path, and flagged the bug separately rather than folding an unrelated fix into this PR.

`tsc --noEmit` shows no errors for this file.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)