### PR TITLE
fix: add "withdraw" to StatusAnnouncer type union and render in WithdrawForm

### DIFF
--- a/components/features/lending/components/WithdrawForm.test.tsx
+++ b/components/features/lending/components/WithdrawForm.test.tsx
@@ -176,10 +176,10 @@ describe("WithdrawForm", () => {
       fireEvent.click(screen.getByText(/Review Withdrawal/i));
 
       expect(
-        await screen.findByText(
+        await screen.findAllByText(
           /Please fix the errors in the form before continuing/i,
         ),
-      ).toBeInTheDocument();
+      ).not.toHaveLength(0);
     });
   });
 
@@ -517,8 +517,62 @@ describe("WithdrawForm", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(/Withdrawal confirmed/i),
-        ).toBeInTheDocument();
+          screen.getAllByText(/Withdrawal confirmed/i).length,
+        ).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe("StatusAnnouncer — aria-live withdraw announcements", () => {
+    it("renders a sr-only aria-live region with role=status", () => {
+      render(<WithdrawForm positions={positions} onSubmit={onSubmit} />);
+      // The StatusAnnouncer always renders a sr-only div with role="status" and aria-live="polite"
+      const announcer = screen.getByTestId("status-announcer");
+      expect(announcer).toBeInTheDocument();
+      expect(announcer).toHaveAttribute("aria-live", "polite");
+      expect(announcer).toHaveAttribute("aria-atomic", "true");
+      expect(announcer).toHaveAttribute("role", "status");
+    });
+
+    it("announces an error when the form is submitted with no amount", async () => {
+      render(<WithdrawForm positions={positions} onSubmit={onSubmit} />);
+
+      fireEvent.click(screen.getByText(/Review Withdrawal/i));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("status-announcer")).toHaveTextContent(
+          /Please fix the errors in the form before continuing/i,
+        );
+      });
+    });
+
+    it("announces success after a valid withdrawal is confirmed", async () => {
+      const user = userEvent.setup();
+      render(
+        <WithdrawForm
+          positions={positions}
+          onSubmit={onSubmit}
+          initialPositionId="supply-2"
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText(/Withdrawal amount/i), {
+        target: { value: "100" },
+      });
+      fireEvent.click(screen.getByText(/Review Withdrawal/i));
+
+      const dialog = await screen.findByRole("dialog", {
+        name: /confirm withdrawal transaction/i,
+      });
+      await user.click(within(dialog).getByRole("checkbox"));
+      await user.click(
+        within(dialog).getByRole("button", { name: /confirm withdrawal/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("status-announcer")).toHaveTextContent(
+          /Withdrawal confirmed/i,
+        );
       });
     });
   });

--- a/components/features/lending/components/WithdrawForm.tsx
+++ b/components/features/lending/components/WithdrawForm.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/lending/health";
 import { cn } from "@/lib/utils/cn";
 import ConfirmModal from "./ConfirmModal";
+import StatusAnnouncer from "@/components/shared/common/StatusAnnouncer";
 
 export interface SupplyPosition extends HookSupplyPosition {}
 
@@ -81,7 +82,7 @@ export default function WithdrawForm({
   const [amount, setAmount] = useState(0);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitStatus, setSubmitStatus] = useState<
-    "idle" | "success" | "error"
+    "idle" | "submitting" | "success" | "error"
   >("idle");
   const [submitMessage, setSubmitMessage] = useState("");
   const [showConfirmModal, setShowConfirmModal] = useState(false);
@@ -277,6 +278,8 @@ export default function WithdrawForm({
           open borrows cannot be withdrawn.
         </p>
       </div>
+
+      <StatusAnnouncer status={submitStatus} type="withdraw" message={submitMessage} />
 
       {submitMessage && (
         <div

--- a/components/shared/common/StatusAnnouncer.tsx
+++ b/components/shared/common/StatusAnnouncer.tsx
@@ -7,7 +7,7 @@ export type AnnouncerStatus = "idle" | "submitting" | "success" | "error";
 interface StatusAnnouncerProps {
   status: AnnouncerStatus;
   message?: string;
-  type: "lend" | "borrow" | "repay";
+  type: "lend" | "borrow" | "repay" | "withdraw";
 }
 
 export default function StatusAnnouncer({
@@ -41,6 +41,7 @@ export default function StatusAnnouncer({
       role="status"
       aria-live="polite"
       aria-atomic="true"
+      data-testid="status-announcer"
     >
       {announcement}
     </div>


### PR DESCRIPTION
## Summary

Screen-reader users received no `aria-live` feedback when a withdrawal was submitting, succeeded, or failed — unlike every other lending action. This PR fixes that gap.

## Changes

### `components/shared/common/StatusAnnouncer.tsx`
- Added `"withdraw"` to the `type` union (`"lend" | "borrow" | "repay" | **"withdraw"**`)
- Added `data-testid="status-announcer"` for reliable test targeting when multiple `role="status"` elements exist in the tree

### `components/features/lending/components/WithdrawForm.tsx`
- Imported `StatusAnnouncer`
- Added `"submitting"` to the `submitStatus` state union for full `AnnouncerStatus` type compatibility
- Rendered `<StatusAnnouncer status={submitStatus} type="withdraw" message={submitMessage} />` in the JSX, matching the pattern used by `LendingForm`, `BorrowingForm`, and `RepayForm`

### `components/features/lending/components/WithdrawForm.test.tsx`
- Added `describe("StatusAnnouncer — aria-live withdraw announcements")` with 3 tests:
  - Verifies the sr-only `aria-live` region is rendered with correct ARIA attributes
  - Verifies it announces the error message when the form is submitted with invalid input
  - Verifies it announces success after a withdrawal is confirmed
- Fixed two pre-existing tests that broke because the submit message now correctly appears in both the visible banner and the sr-only announcer (switched to `getAllByText`)

## Testing

All 38 `WithdrawForm` tests pass.

Closes #895