### PR TITLE
Wire up the dead terms and conditions link in ConfirmModal

### DIFF
--- a/components/features/lending/components/ConfirmModal.test.tsx
+++ b/components/features/lending/components/ConfirmModal.test.tsx
@@ -107,6 +107,60 @@ describe("ConfirmModal accessibility", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it("has a properly-typed terms and conditions button that opens terms content", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmModalHarness />);
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm lending transaction/i });
+    const termsButton = within(dialog).getByRole("button", { name: /terms and conditions/i });
+
+    expect(termsButton).toHaveAttribute("type", "button");
+    expect(screen.queryByRole("dialog", { name: /terms and conditions/i })).not.toBeInTheDocument();
+
+    await user.click(termsButton);
+
+    const termsDialog = screen.getByRole("dialog", { name: /terms and conditions/i });
+    expect(termsDialog).toBeInTheDocument();
+    expect(within(termsDialog).getByRole("button", { name: /close terms and conditions/i })).toHaveFocus();
+  });
+
+  it("opens the terms and conditions content via the keyboard", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmModalHarness />);
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm lending transaction/i });
+    const termsButton = within(dialog).getByRole("button", { name: /terms and conditions/i });
+
+    termsButton.focus();
+    expect(termsButton).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("dialog", { name: /terms and conditions/i })).toBeInTheDocument();
+  });
+
+  it("closes the terms modal on Escape without closing the underlying confirmation modal", async () => {
+    const user = userEvent.setup();
+    render(<ConfirmModalHarness />);
+
+    await user.click(screen.getByRole("button", { name: /open confirmation/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm lending transaction/i });
+    const termsButton = within(dialog).getByRole("button", { name: /terms and conditions/i });
+
+    await user.click(termsButton);
+    expect(screen.getByRole("dialog", { name: /terms and conditions/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: /terms and conditions/i })).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("dialog", { name: /confirm lending transaction/i })).toBeInTheDocument();
+    expect(termsButton).toHaveFocus();
+  });
+
   it("closes from the close button, cancel button, and backdrop", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/components/features/lending/components/ConfirmModal.tsx
+++ b/components/features/lending/components/ConfirmModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { LendingData, CalculationResult } from "@/app/lending/page";
 import type { LendingActionType } from "@/lib/lending/types";
 import { cn } from "@/lib/utils/cn";
+import TermsModal from "./TermsModal";
 
 interface ConfirmModalProps {
   isOpen: boolean;
@@ -24,6 +25,7 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   const [isConfirming, setIsConfirming] = useState(false);
   const [hasAgreed, setHasAgreed] = useState(false);
+  const [isTermsOpen, setIsTermsOpen] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<
     "idle" | "success" | "error"
   >("idle");
@@ -37,6 +39,7 @@ export default function ConfirmModal({
       setSubmitStatus("idle");
       setSubmitMessage("");
       setHasAgreed(false);
+      setIsTermsOpen(false);
     }
   }, [isOpen]);
 
@@ -139,6 +142,7 @@ export default function ConfirmModal({
   };
 
   return (
+    <>
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
         {/* Background overlay */}
@@ -420,7 +424,11 @@ export default function ConfirmModal({
               />
               <span className="text-sm text-gray-700">
                 I understand and agree to the{" "}
-                <button className="text-green-600 hover:text-green-700 underline">
+                <button
+                  type="button"
+                  onClick={() => setIsTermsOpen(true)}
+                  className="text-green-600 hover:text-green-700 underline"
+                >
                   terms and conditions
                 </button>
                 {type === "borrow" && (
@@ -509,5 +517,7 @@ export default function ConfirmModal({
         </div>
       </div>
     </div>
+    <TermsModal isOpen={isTermsOpen} onClose={() => setIsTermsOpen(false)} />
+    </>
   );
 }

--- a/components/features/lending/components/TermsModal.tsx
+++ b/components/features/lending/components/TermsModal.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface TermsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function TermsModal({ isOpen, onClose }: TermsModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previouslyFocusedElementRef.current = document.activeElement as HTMLElement;
+    closeButtonRef.current?.focus();
+
+    const focusableSelector = [
+      "button:not([disabled])",
+      "a[href]",
+      "[tabindex]:not([tabindex='-1'])",
+    ].join(", ");
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableElements = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ?? [],
+      ).filter((element) => !element.hasAttribute("disabled"));
+
+      if (!focusableElements.length) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    // Capture phase so this modal's Escape handling runs, and is stopped,
+    // before the underlying ConfirmModal's own document-level Escape
+    // listener (attached in bubble phase) can see the event and close too.
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+      previouslyFocusedElementRef.current?.focus();
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+        <div
+          className="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75"
+          onClick={onClose}
+        />
+
+        <div
+          ref={dialogRef}
+          className="inline-block w-full max-w-lg p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="terms-modal-title"
+        >
+          <div className="flex items-center justify-between mb-4">
+            <h3
+              id="terms-modal-title"
+              className="text-lg font-semibold text-gray-900"
+            >
+              Terms and Conditions
+            </h3>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 transition-colors p-1 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50"
+              aria-label="Close terms and conditions"
+            >
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+
+          <div className="space-y-3 text-sm text-gray-700 max-h-[60vh] overflow-y-auto">
+            <p>
+              By using StellarLend&apos;s lending, borrowing, repayment, and
+              withdrawal features, you acknowledge and agree to the following:
+            </p>
+            <ul className="list-disc pl-5 space-y-2">
+              <li>
+                All transactions are executed on the Stellar blockchain and are
+                irreversible once confirmed.
+              </li>
+              <li>
+                Borrowing positions are secured by collateral, which may be
+                liquidated if your health factor falls below the required
+                threshold.
+              </li>
+              <li>
+                Interest rates, health factors, and other figures shown before
+                confirming are estimates and may change before your
+                transaction settles on-chain.
+              </li>
+              <li>
+                You are solely responsible for safeguarding your wallet and
+                verifying transaction details before confirming.
+              </li>
+              <li>
+                StellarLend provides this interface as-is, without warranty of
+                any kind, and is not responsible for losses resulting from
+                market volatility, network conditions, or user error.
+              </li>
+            </ul>
+          </div>
+
+          <div className="mt-6 flex justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-white bg-green-500 hover:bg-green-600 rounded-lg font-medium transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
ConfirmModal.tsx's "terms and conditions" link is dead — no href, no onClick, no type attribute

The button rendering "terms and conditions" text had no onClick handler, no navigation capability, and no explicit type attribute. Users encounter a checkbox requesting agreement to terms before transactions (lend/borrow/repay/withdraw), yet cannot access the actual terms content by clicking the linked text.

## Description

Wired the button up to open an accessible terms modal instead of leaving it decorative.

Closes #891

## Changes

- **`components/features/lending/components/TermsModal.tsx`** (new): a self-contained accessible dialog showing the terms content, with focus trap, Escape-to-close, and focus restoration to whatever triggered it. Follows the same hand-rolled dialog pattern `ConfirmModal` already uses, since this codebase doesn't have a shared `Modal`/`Dialog` component yet.
- **`components/features/lending/components/ConfirmModal.tsx`**: the terms button now has `type="button"` (defensive against form submission) and an `onClick` that opens `TermsModal`. `isTermsOpen` resets alongside the other confirm-modal state whenever the parent modal reopens. `TermsModal`'s Escape handler runs in the capture phase and calls `stopPropagation()`, so pressing Escape while it's open closes only the terms modal, not the confirmation modal behind it.
- **`components/features/lending/components/ConfirmModal.test.tsx`**: added tests confirming the button has `type="button"`, that clicking it opens the terms dialog with proper focus, that it's keyboard-activatable (focus + Enter), and that Escape closes only the terms modal while returning focus to the trigger.

## Verification

`npx vitest run components/features/lending/components/ConfirmModal.test.tsx` — 14 of 15 pass, including all 3 new tests. The one pre-existing failure ("renders withdraw-specific labels and details") is unrelated — confirmed via `git stash` that it fails identically on `main` before this change (a duplicate "1.48" text match) — flagged separately.

`tsc --noEmit` shows no errors in either touched file.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)