### PR TITLE
Close NotificationCenter panel on outside click

### DIFF
--- a/components/features/notifications/NotificationCenter.test.tsx
+++ b/components/features/notifications/NotificationCenter.test.tsx
@@ -197,6 +197,39 @@ describe("NotificationCenter", () => {
       expect(screen.queryByTestId("notification-panel")).not.toBeInTheDocument();
     });
 
+    it("closes panel when clicking outside of it", async () => {
+      render(<NotificationCenter />);
+      const trigger = await screen.findByRole("button", { name: /notification/i });
+      fireEvent.click(trigger);
+      expect(screen.getByTestId("notification-panel")).toBeInTheDocument();
+
+      fireEvent.mouseDown(document.body);
+
+      expect(screen.queryByTestId("notification-panel")).not.toBeInTheDocument();
+    });
+
+    it("does not close the panel when clicking inside it", async () => {
+      render(<NotificationCenter />);
+      const trigger = await screen.findByRole("button", { name: /notification/i });
+      fireEvent.click(trigger);
+      const panel = screen.getByTestId("notification-panel");
+
+      fireEvent.mouseDown(panel);
+
+      expect(screen.getByTestId("notification-panel")).toBeInTheDocument();
+    });
+
+    it("does not close the panel when clicking the trigger itself (toggle owns that)", async () => {
+      render(<NotificationCenter />);
+      const trigger = await screen.findByRole("button", { name: /notification/i });
+      fireEvent.click(trigger);
+      expect(screen.getByTestId("notification-panel")).toBeInTheDocument();
+
+      fireEvent.mouseDown(trigger);
+
+      expect(screen.getByTestId("notification-panel")).toBeInTheDocument();
+    });
+
     it("closes panel on Escape key", async () => {
       render(<NotificationCenter />);
       const trigger = await screen.findByRole("button", { name: /notification/i });

--- a/components/features/notifications/NotificationCenter.tsx
+++ b/components/features/notifications/NotificationCenter.tsx
@@ -85,6 +85,20 @@ const NotificationCenter = () => {
   );
 
   useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  useEffect(() => {
     if (isOpen && panelRef.current) {
       const first = panelRef.current.querySelector<HTMLElement>(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
             "components/shared/ui/**/*.test.tsx",
             "components/features/dashboard/**/*.test.tsx",
             "components/features/account/**/*.test.tsx",
+            "components/features/notifications/**/*.test.tsx",
             "lib/utils/clipboard.test.ts",
             "lib/search/**/*.test.ts",
             "components/features/lending/**/*.test.tsx",


### PR DESCRIPTION
NotificationCenter dropdown panel doesn't close when clicking outside of it

The panel only closes when users press Escape or click the bell button again. The component is missing a document-level click listener to dismiss the panel when users click outside of it - a pattern already implemented in similar dropdowns like AccountMenu.tsx.

## Description

`components/features/notifications/NotificationCenter.tsx` already declared `triggerRef` and `panelRef` (used for the Escape-key handler), but nothing wired them up to a click-outside dismissal. `AccountMenu.tsx` already has the exact pattern for its own dropdown, so this brings the notification panel in line with it.

Closes #890

## Changes

- **`components/features/notifications/NotificationCenter.tsx`**: added a `mousedown` listener, attached only while the panel is open, that closes the panel unless the click target is inside `triggerRef` or `panelRef` - mirroring `AccountMenu.tsx`'s existing implementation.
- **`components/features/notifications/NotificationCenter.test.tsx`**: added tests for closing on outside click, not closing on a click inside the panel, and not closing on a click on the trigger itself (that's the toggle's job).
- **`vitest.config.ts`**: added `components/features/notifications/**/*.test.tsx` to the `accessibility` project's include list. This test file existed already but wasn't included in any vitest project, so neither its existing 25 tests nor this fix's new coverage were ever actually running in CI.

## Verification

`npx vitest run components/features/notifications/NotificationCenter.test.tsx` - 28 of 28 pass (25 pre-existing + 3 new).

`tsc --noEmit` shows no errors in the touched file.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)