### PR TITLE
Fix #916: Replace any casts with proper types in lib/auth/wallet.ts

### DIFF
--- a/lib/auth/wallet.ts
+++ b/lib/auth/wallet.ts
@@ -75,7 +75,7 @@ export async function verifyWalletSignature(transactionXdr: string): Promise<str
       NETWORK_PASSPHRASE,
       HOME_DOMAIN,
       HOME_DOMAIN
-    ) as any;
+    );
 
     const signersFound = WebAuth.verifyChallengeTxSigners(
       transactionXdr,
@@ -91,7 +91,8 @@ export async function verifyWalletSignature(transactionXdr: string): Promise<str
     }
 
     return clientAccountID;
-  } catch (error: any) {
-    throw new Error(`Signature verification failed: ${error.message || "Unknown error"}`);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    throw new Error(`Signature verification failed: ${message}`);
   }
 }


### PR DESCRIPTION
Closes #916

## What

Removes two unsafe `any` usages in `lib/auth/wallet.ts`:

- Removes the unnecessary `as any` cast from the result of `WebAuth.readChallengeTx(...)`.
- Replaces `catch (error: any)` with `catch (error: unknown)` and narrows the type before accessing `.message`.

## Why

`WebAuth.readChallengeTx` from `@stellar/stellar-sdk` already returns a strongly typed object:

```ts
{
  tx: Transaction;
  clientAccountID: string;
  matchedHomeDomain: string;
  memo: string | null;
}
```

The `as any` cast discarded those existing types, preventing TypeScript from catching incorrect usage of values such as `clientAccountID`.

Likewise, `catch (error: any)` bypasses TypeScript's safer `unknown` catch type. Replacing it with `unknown` and checking `error instanceof Error` ensures `.message` is only accessed when it is safe to do so.

These changes restore type safety in the SEP-10 authentication flow used by both `context/WalletContext.tsx` and `hooks/useWalletConnection.ts`.

## Verification

Ran `npx tsc --noEmit`.

`lib/auth/wallet.ts` reports no type errors after this change.

The project still has two pre-existing TypeScript errors caused by unresolved merge conflicts in:

- `app/api/account/preferences/route.ts`
- `lib/account/preferences-repository.ts`

These issues are unrelated to this PR.