### PR TITLE
fix: re-sync TransactionFilters local state when searchParams change externally

### DIFF
--- a/components/features/dashboard/components/TransactionFilters.test.tsx
+++ b/components/features/dashboard/components/TransactionFilters.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import TransactionFilters from './TransactionFilters';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
@@ -131,6 +131,33 @@ describe('TransactionFilters', () => {
     
     // page param should be removed
     expect(mockReplace).toHaveBeenCalledWith('/dashboard/transactions?asset=XLM&type=repay', { scroll: false });
+  });
+
+  it('re-syncs filter state from URL on external navigation (e.g., browser back button)', async () => {
+    // Start with asset=BTC in the URL
+    (useSearchParams as any).mockReturnValue(new URLSearchParams('?asset=BTC'));
+    const { rerender } = render(<TransactionFilters totalCount={10} />);
+
+    // Verify initial state matches URL
+    expect(screen.getByLabelText(/Asset/i)).toHaveValue('BTC');
+
+    // User changes asset to XLM
+    fireEvent.change(screen.getByLabelText(/Asset/i), { target: { value: 'XLM' } });
+
+    // Verify URL was updated by the component
+    expect(mockReplace).toHaveBeenLastCalledWith(
+      '/dashboard/transactions?asset=XLM',
+      { scroll: false }
+    );
+
+    // Simulate browser back: URL returns to ?asset=BTC
+    (useSearchParams as any).mockReturnValue(new URLSearchParams('?asset=BTC'));
+    rerender(<TransactionFilters totalCount={10} />);
+
+    // Wait for the re-sync effect to run and verify filter UI shows the restored value
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Asset/i)).toHaveValue('BTC');
+    });
   });
 
 });

--- a/components/features/dashboard/components/TransactionFilters.tsx
+++ b/components/features/dashboard/components/TransactionFilters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, forwardRef, useCallback } from "react";
+import React, { useState, useEffect, forwardRef, useRef } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
@@ -60,8 +60,35 @@ export default function TransactionFilters({ totalCount }: TransactionFiltersPro
     toDateStr ? new Date(toDateStr) : null
   );
 
-  // Sync back to URL when local state changes
-  // Debounce search slightly
+  // Tracks the last URL params string we wrote so the URL→state effect
+  // can distinguish our own router.replace calls from external navigation
+  // (browser back/forward, links from other pages).
+  const prevParamsRef = useRef(searchParams.toString());
+
+  // ── Effect 1: URL → local state ─────────────────────────────────────
+  // Re-syncs local filter state when searchParams change externally.
+  useEffect(() => {
+    const currentParams = searchParams.toString();
+    if (currentParams === prevParamsRef.current) {
+      return; // Our own change — local state is already correct
+    }
+    prevParamsRef.current = currentParams;
+
+    // External change detected — re-derive all local state from URL
+    setAsset(searchParams.get("asset") || "");
+    setType(searchParams.get("type") || "");
+    setStatus(searchParams.get("status") || "");
+    setSearch(searchParams.get("search") || "");
+
+    const fromDate = searchParams.get("fromDate");
+    setDateFromObj(fromDate ? new Date(fromDate) : null);
+
+    const toDate = searchParams.get("toDate");
+    setDateToObj(toDate ? new Date(toDate) : null);
+  }, [searchParams]);
+
+  // ── Effect 2: local state → URL ─────────────────────────────────────
+  // Pushes current local state into the URL whenever a filter value changes.
   useEffect(() => {
     const params = new URLSearchParams(searchParams.toString());
 
@@ -86,8 +113,12 @@ export default function TransactionFilters({ totalCount }: TransactionFiltersPro
     
     // Create query string
     const query = params.toString();
+
+    // Record the URL we're about to push so Effect 1 knows it's our own change
+    prevParamsRef.current = query;
+
     router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
-  }, [asset, type, status, dateFromObj, dateToObj, pathname, router, searchParams]);
+  }, [asset, type, status, dateFromObj, dateToObj, pathname, router]);
 
   // Handle Search separately with debounce or on Enter
   const handleSearchBlur = () => {
@@ -96,6 +127,7 @@ export default function TransactionFilters({ totalCount }: TransactionFiltersPro
     else params.delete("search");
     params.delete("page");
     const query = params.toString();
+    prevParamsRef.current = query;
     router.replace(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
   };
   
@@ -112,6 +144,7 @@ export default function TransactionFilters({ totalCount }: TransactionFiltersPro
     setSearch("");
     setDateFromObj(null);
     setDateToObj(null);
+    prevParamsRef.current = "";
     router.replace(pathname, { scroll: false });
   };
 


### PR DESCRIPTION
…
## Summary

Adds a dedicated unit test suite for `context/WalletContext.tsx`, covering the provider's full state machine: connect/disconnect transitions, network state resolution, session persistence rehydration, consumer re-renders, and the hook guard.

## Changes

### New Files

- **`context/WalletContext.test.tsx`** — 23 test cases organized into 7 `describe` blocks
- **`context/WALLET_CONTEXT_TESTS.md`** — Test plan documentation for reviewers

### Modified Files

- **`vitest.config.ts`** — Added `context/**/*.test.{ts,tsx}` to the `accessibility` project's include patterns so the new test file is discovered by `vitest`

## Test Coverage

| Category | Tests | What's Covered |
|---|---|---|
| Initial state | 2 | Starts disconnected, null address, null error; network derived from config |
| Rehydration | 6 | sessionStorage restore, server session restore, sessionStorage priority, server clearing stale state, fetch failure, network error tolerance |
| Connect | 6 | Full success flow, Freighter missing, null pubkey, challenge API failure, verify API failure, error cleared on retry |
| Disconnect | 3 | Connected→disconnected, server DELETE failure (local state still cleared), no-op when already disconnected |
| Network state | 3 | `TESTNET` for testnet, `PUBLIC` for mainnet, `PUBLIC` for PUBLIC string |
| Consumer re-renders | 2 | Spy assertions verify consumers re-render with correct values on connect and disconnect |
| Hook guard | 1 | `useWalletContext` throws outside `WalletProvider` |

## Verification

```bash
# Run just the new tests
npx vitest run --project accessibility context/WalletContext

# Expected output: 23 passed, 0 failed
```

All 23 tests pass deterministically. The suite uses DOM-based rendering with `data-testid` attributes for state assertions and wraps async transitions in `act()` with `waitFor` polling for stability.

## Edge Cases Covered

- Connect failure when `window.stellar` is absent vs. when it returns invalid data
- Disconnect when the server DELETE request fails (network error)
- Disconnect when the user is already disconnected
- Rehydration race condition where sessionStorage has data but the server returns no session
- Network error during rehydration (server unreachable)
- Switching from error state back to connected on a subsequent attempt
- Environment override for `NEXT_PUBLIC_STELLAR_NETWORK` (mainnet/PUBLIC)

Closes #985
