### PR TITLE
fix(transactions): validate transaction row mapping and remove unsafe any casts (#922)

### DIFF
--- a/lib/transactions/store.test.ts
+++ b/lib/transactions/store.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { mapTransactionRow } from './store';
+
+describe('mapTransactionRow', () => {
+  it('maps a valid transaction row successfully', () => {
+    const row = {
+      id: 'TXN12345',
+      type: 'Deposit',
+      amount: 2000,
+      asset: 'XLM',
+      date: '2025-04-12',
+      time: '09:32AM',
+      status: 'Completed',
+    };
+
+    const transaction = mapTransactionRow(row);
+
+    expect(transaction).toEqual({
+      id: 'TXN12345',
+      type: 'Deposit',
+      amount: 2000,
+      asset: 'XLM',
+      date: '2025-04-12',
+      time: '09:32AM',
+      status: 'Completed',
+    });
+  });
+
+  it('throws when asset is invalid', () => {
+    const row = {
+      id: 'TXN12346',
+      type: 'Withdrawal',
+      amount: -7500,
+      asset: 'INVALID_ASSET',
+      date: '2025-02-28',
+      time: '04:45PM',
+      status: 'Completed',
+    };
+
+    expect(() => mapTransactionRow(row)).toThrow(
+      'Invalid transaction asset: INVALID_ASSET',
+    );
+  });
+
+  it('throws when status is invalid', () => {
+    const row = {
+      id: 'TXN12347',
+      type: 'Loan Payment',
+      amount: -250,
+      asset: 'BTC',
+      date: '2025-03-10',
+      time: '11:15AM',
+      status: 'INVALID_STATUS',
+    };
+
+    expect(() => mapTransactionRow(row)).toThrow(
+      'Invalid transaction status: INVALID_STATUS',
+    );
+  });
+});

--- a/lib/transactions/store.ts
+++ b/lib/transactions/store.ts
@@ -1,6 +1,53 @@
 import type { Transaction } from "@/types/Transaction";
-import type { TransactionStatus } from "@/types/enums";
-import { fetchTransactions } from "@/lib/transactions/repository";
+import { isAssetSymbol, isTransactionStatus } from "@/types/enums";
+import { db } from "../db/client";
+import { transactions as transactionsTable } from "../db/schema/transactions";
+import { eq } from "drizzle-orm";
+
+interface TransactionRow {
+  id: string;
+  type: string;
+  amount: number;
+  asset: string;
+  date: string;
+  time: string;
+  status: string;
+}
+
+const MOCK_TRANSACTIONS: TransactionRow[] = [
+  { id: 'TXN12345', type: 'Deposit',      amount: 2000,    asset: 'XLM',  date: '2025-04-12', time: '09:32AM', status: 'Completed'  },
+  { id: 'TXN12346', type: 'Loan Payment', amount:  -250,    asset: 'BTC',  date: '2025-03-10', time: '11:15AM', status: 'Processing' },
+  { id: 'TXN12347', type: 'Withdrawal',   amount:  -7500,   asset: 'STRK', date: '2025-02-28', time: '04:45PM', status: 'Completed'  },
+  { id: 'TXN12348', type: 'Lend Funds',   amount:  -1500,   asset: 'XLM',  date: '2025-01-05', time: '08:00AM', status: 'Completed'  },
+  { id: 'TXN12349', type: 'Lend Funds',   amount:  -607.87, asset: 'BTC',  date: '2024-12-20', time: '10:20PM', status: 'Failed'     },
+  { id: 'TXN12350', type: 'Deposit',      amount: 20000,   asset: 'STRK', date: '2024-11-15', time: '01:05PM', status: 'Completed'  },
+];
+
+async function fetchMockTransactions() {
+  for (const txn of MOCK_TRANSACTIONS) {
+    await db.insert(transactionsTable).values(txn).onConflictDoNothing();
+  }
+}
+
+export function mapTransactionRow(row: TransactionRow): Transaction {
+  if (!isAssetSymbol(row.asset)) {
+    throw new Error(`Invalid transaction asset: ${String(row.asset)}`);
+  }
+
+  if (!isTransactionStatus(row.status)) {
+    throw new Error(`Invalid transaction status: ${String(row.status)}`);
+  }
+
+  return {
+    id: row.id,
+    type: row.type,
+    amount: row.amount,
+    asset: row.asset,
+    date: row.date,
+    time: row.time,
+    status: row.status,
+  };
+}
 
 async function ensureSeeded() {
   const rows = await db.select().from(transactionsTable);
@@ -22,15 +69,7 @@ export async function getTransaction(
 
   if (!row) return undefined;
 
-  return {
-    id: row.id,
-    type: row.type,
-    amount: row.amount,
-    asset: row.asset as any,
-    date: row.date,
-    time: row.time,
-    status: row.status as any,
-  };
+  return mapTransactionRow(row);
 }
 
 /**
@@ -51,15 +90,7 @@ export async function updateTransactionStatus(
 
   if (!row) return null;
 
-  return {
-    id: row.id,
-    type: row.type,
-    amount: row.amount,
-    asset: row.asset as any,
-    date: row.date,
-    time: row.time,
-    status: row.status as any,
-  };
+  return mapTransactionRow(row);
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR refactors `lib/transactions/store.ts` to use a shared validated row mapper for transaction rows, removing unsafe `any` casts and adding regression coverage for invalid `asset`/`status` values.

## Related Issue

Closes #922

## Changes

* Added `mapTransactionRow` helper with `isAssetSymbol` and `isTransactionStatus` guards
* Replaced duplicate `asset as any` and `status as any` casts in `getTransaction` and `updateTransactionStatus`
* Added `lib/transactions/store.test.ts` to verify valid rows and reject invalid asset/status values
* Seeded transaction mock insertion helper restored in `lib/transactions/store.ts`

## Verification Results

```
npx vitest run lib/transactions/store.test.ts --coverage.enabled false
✅ 3/3 tests passed
```

## Acceptance Criteria

| Acceptance Criteria | Status |
| --- | --- |
| Shared transaction row mapper exists | ✅ |
| Invalid asset/status values are rejected | ✅ |
| Duplicate unsafe casts removed | ✅ |
| Regression coverage added | ✅ |