### PR TITLE
fix(prices): use PRICE_ORACLE_API_KEY in production and keep mocks in dev/test (#889)

### DIFF
--- a/lib/prices/fetcher.test.ts
+++ b/lib/prices/fetcher.test.ts
@@ -3,12 +3,26 @@
  * Tests for upstream price fetching and response validation
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetchUpstreamPrices, isValidUpstreamResponse } from '@/lib/prices/fetcher';
 
 describe('fetchUpstreamPrices', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalPriceOracleApiKey = process.env.PRICE_ORACLE_API_KEY;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    delete process.env.PRICE_ORACLE_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalPriceOracleApiKey === undefined) {
+      delete process.env.PRICE_ORACLE_API_KEY;
+    } else {
+      process.env.PRICE_ORACLE_API_KEY = originalPriceOracleApiKey;
+    }
   });
 
   describe('Mock Implementation', () => {
@@ -86,6 +100,15 @@ describe('fetchUpstreamPrices', () => {
     it('should validate response structure', async () => {
       const result = await fetchUpstreamPrices(['XLM']);
       expect(isValidUpstreamResponse(result)).toBe(true);
+    });
+
+    it('should throw when PRICE_ORACLE_API_KEY is missing in production', async () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.PRICE_ORACLE_API_KEY;
+
+      await expect(fetchUpstreamPrices(['XLM'])).rejects.toThrow(
+        'PRICE_ORACLE_API_KEY not configured',
+      );
     });
   });
 

--- a/lib/prices/fetcher.ts
+++ b/lib/prices/fetcher.ts
@@ -49,6 +49,52 @@ async function fetchMockPrices(assets: SupportedAsset[]): Promise<UpstreamPriceS
   };
 }
 
+async function fetchRealUpstreamPrices(
+  assets: SupportedAsset[],
+  apiKey: string,
+  config: PriceSourceConfig,
+): Promise<UpstreamPriceSource> {
+  const apiUrl = process.env.PRICE_ORACLE_API_URL;
+  if (!apiUrl) {
+    throw new Error('PRICE_ORACLE_API_URL not configured');
+  }
+
+  const url = new URL(apiUrl);
+  assets.forEach((asset) => url.searchParams.append('assets', asset));
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), config.timeout);
+
+  try {
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Price oracle upstream error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    if (!isValidUpstreamResponse(data)) {
+      throw new Error('Invalid upstream price response structure');
+    }
+
+    return data;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Price oracle request timed out');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 /**
  * Fetches prices from an upstream oracle API
  * Uses API key from environment variables (kept server-side only)
@@ -63,14 +109,16 @@ export async function fetchUpstreamPrices(
   config: Partial<PriceSourceConfig> = {}
 ): Promise<UpstreamPriceSource> {
   const finalConfig = { ...DEFAULT_CONFIG, ...config };
+  const apiKey = process.env.PRICE_ORACLE_API_KEY;
 
-  // For now, use mock prices. In production, integrate with real API
-  // Example production integration:
-  // const apiKey = process.env.PRICE_ORACLE_API_KEY;
-  // if (!apiKey) throw new Error('PRICE_ORACLE_API_KEY not configured');
-  // return fetchRealUpstreamPrices(assets, apiKey, finalConfig);
+  if (!apiKey) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('PRICE_ORACLE_API_KEY not configured');
+    }
+    return fetchMockPrices(assets);
+  }
 
-  return fetchMockPrices(assets);
+  return fetchRealUpstreamPrices(assets, apiKey, finalConfig);
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR updates `lib/prices/fetcher.ts` so production builds require `PRICE_ORACLE_API_KEY` and only use mock prices in development/test environments.

## Related Issue

Closes #889

## Changes

* Added production-only `PRICE_ORACLE_API_KEY` guard
* Implemented `fetchRealUpstreamPrices` using `PRICE_ORACLE_API_URL` and response validation
* Kept dev/test fallback to `fetchMockPrices` for local and CI compatibility
* Added regression coverage in `lib/prices/fetcher.test.ts`

## Verification Results

```
npx vitest run lib/prices/fetcher.test.ts --coverage.enabled false
✅ 41/41 tests passed
```

## Acceptance Criteria

| Acceptance Criteria | Status |
| --- | --- |
| Production builds require PRICE_ORACLE_API_KEY | ✅ |
| Mock fallback remains available in dev/test | ✅ |
| Invalid or missing production API key is surfaced | ✅ |
| Price response validation remains intact | ✅ |