### PR TITLE
test(account): add preferences validation unit tests (#903)

### DIFF
--- a/lib/account/preferences-validation.test.ts
+++ b/lib/account/preferences-validation.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { validatePreferences } from './preferences-validation';
+
+describe('validatePreferences', () => {
+  const validPreferences = {
+    email: 'alice@example.com',
+    locale: 'en-US',
+    displayCurrency: 'USD',
+    notifications: { email: true, push: true, sms: false, inApp: true },
+  };
+
+  it('accepts a fully valid payload', () => {
+    const result = validatePreferences(validPreferences);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(validPreferences);
+    }
+  });
+
+  it('accepts an empty payload and applies defaults', () => {
+    const result = validatePreferences({});
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.locale).toBe('en-US');
+      expect(result.data.displayCurrency).toBe('USD');
+      expect(result.data.notifications.email).toBe(true);
+      expect(result.data.notifications.push).toBe(true);
+      expect(result.data.notifications.sms).toBe(false);
+      expect(result.data.notifications.inApp).toBe(true);
+    }
+  });
+
+  it('rejects an invalid email', () => {
+    const result = validatePreferences({ ...validPreferences, email: 'not-an-email' });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors.email).toBe('Invalid email address');
+    }
+  });
+
+  it('rejects an unsupported locale', () => {
+    const result = validatePreferences({ ...validPreferences, locale: 'xx-XX' });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors.locale).toBeTruthy();
+    }
+  });
+
+  it('rejects an unsupported displayCurrency', () => {
+    const result = validatePreferences({ ...validPreferences, displayCurrency: 'XYZ' });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors.displayCurrency).toBeTruthy();
+    }
+  });
+
+  it('rejects invalid notification channel values', () => {
+    const result = validatePreferences({
+      ...validPreferences,
+      notifications: { ...validPreferences.notifications, email: 'yes' },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors['notifications.email']).toBeTruthy();
+    }
+  });
+
+  it('returns a generic error key for malformed input without a path', () => {
+    const result = validatePreferences(null);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(Object.keys(result.errors).length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds dedicated unit tests for `lib/account/preferences-validation.ts` so the preferences validation schema is covered as the single source of truth for account preference persistence.

## Related Issue

Closes #903

## Changes

* Added `lib/account/preferences-validation.test.ts`
* Added coverage for valid input, defaulting behavior, invalid email, unsupported locale, unsupported display currency, invalid notification channel values, and malformed payload error handling

## Verification Results

```
npx vitest run lib/account/preferences-validation.test.ts --coverage.enabled false
✅ 7/7 tests passed
```

## Acceptance Criteria

| Acceptance Criteria | Status |
| --- | --- |
| Dedicated validator test file exists | ✅ |
| Supported preference values are accepted | ✅ |
| Unsupported locale/currency are rejected | ✅ |
| Default values apply when fields are omitted | ✅ |
| Notification channel validation errors are reported | ✅ |