### PR TITLE
fix(context): read displayCurrency from /api/account/preferences instead of currency

### DIFF
--- a/context/CurrencyContext.test.tsx
+++ b/context/CurrencyContext.test.tsx
@@ -11,17 +11,17 @@ const TestComponent = () => {
 
 describe("CurrencyContext", () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
+    global.fetch = vi.fn();
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
   });
 
-  it("fetches and provides the currency preference", async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
+  it("fetches and provides the displayCurrency preference", async () => {
+    global.fetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ currency: "EUR" }),
+      json: async () => ({ displayCurrency: "EUR" }),
     });
 
     render(
@@ -36,8 +36,25 @@ describe("CurrencyContext", () => {
     });
   });
 
+  it("picks up a non-USD displayCurrency from the preferences endpoint", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ displayCurrency: "BTC" }),
+    });
+
+    render(
+      <CurrencyProvider>
+        <TestComponent />
+      </CurrencyProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("currency")).toHaveTextContent("BTC");
+    });
+  });
+
   it("falls back to USD if preference is unset", async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
+    global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({}),
     });
@@ -54,7 +71,7 @@ describe("CurrencyContext", () => {
   });
 
   it("falls back to USD on invalid preference or fetch error", async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("Network error"));
+    global.fetch.mockRejectedValueOnce(new Error("Network error"));
 
     render(
       <CurrencyProvider>
@@ -65,6 +82,5 @@ describe("CurrencyContext", () => {
     await waitFor(() => {
       expect(screen.getByTestId("error")).toHaveTextContent("Network error");
     });
-    // The state currency is technically still USD internally though.
   });
 });

--- a/context/CurrencyContext.tsx
+++ b/context/CurrencyContext.tsx
@@ -23,8 +23,8 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
           throw new Error("Failed to fetch preferences");
         }
         const data = await response.json();
-        if (data && data.currency) {
-          setCurrency(data.currency);
+        if (data && data.displayCurrency) {
+          setCurrency(data.displayCurrency);
         }
       } catch (err) {
         setError(err instanceof Error ? err : new Error(String(err)));


### PR DESCRIPTION
﻿## Overview
Fixes #925: context/CurrencyContext.tsx was reading the wrong field name `data.currency` from the `/api/account/preferences` endpoint. The actual preferences schema and frontend interfaces all use `displayCurrency`, never `currency`. This caused the currency preference to silently stay at the hardcoded `"USD"` default forever, regardless of what a user actually saved.

## Related Issue
Closes #925

## Changes
- context/CurrencyContext.tsx: Changed `data.currency` to `data.displayCurrency` so the currency preference is properly picked up from the preferences endpoint
- context/CurrencyContext.test.tsx: Fixed mock setup to use vitest's `vi.fn()` (was incorrectly using `jest.fn()`), updated mock data to use `displayCurrency` field, and added a new test asserting CurrencyProvider picks up a non-USD `displayCurrency` from the preferences endpoint

## Verification Results
All 4 CurrencyContext tests pass:
- fetches and provides the displayCurrency preference
- picks up a non-USD displayCurrency from the preferences endpoint
- falls back to USD if preference is unset
- falls back to USD on invalid preference or fetch error