### PR TITLE
Fix/account export auth throttle

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,11 +4,10 @@ on:
   push:
     branches: [develop]
 
-environment: staging
-
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest
+    environment: staging
     
     steps:
       - name: Checkout code

--- a/app/api/account/export/route.test.ts
+++ b/app/api/account/export/route.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { resetThrottleRegistry } from '@/lib/account/export-throttle';
+import { getUser } from '@/lib/auth';
+
+vi.mock('@/lib/auth');
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/account/export', {
+    method: 'POST',
+    headers: {
+      'x-csrf-token': 'csrf-cookie-value',
+      cookie: 'csrf-token=csrf-cookie-value',
+    },
+  });
+}
+
+describe('GDPR DSAR Account Export API Route Flow', () => {
+  beforeEach(() => {
+    resetThrottleRegistry();
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when the caller is not authenticated', async () => {
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error).toContain('Unauthorized');
+  });
+
+  it('accepts a valid authenticated request and returns a 202 with a signed download URL', async () => {
+    vi.mocked(getUser).mockResolvedValue({ id: 'user-123', email: 'user@example.com' } as any);
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(202);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.downloadUrl).toContain('https://storage.stellarlend.com/exports/');
+    expect(body.expiresInSeconds).toBe(900);
+  });
+
+  it('rate-limits repeated requests for the same user within 24 hours', async () => {
+    vi.mocked(getUser).mockResolvedValue({ id: 'user-123', email: 'user@example.com' } as any);
+
+    const firstResponse = await POST(makeRequest());
+    const secondResponse = await POST(makeRequest());
+
+    expect(firstResponse.status).toBe(202);
+    expect(secondResponse.status).toBe(429);
+    const body = await secondResponse.json();
+    expect(body.error).toContain('DSAR export rate limit exceeded');
+  });
+
+  it('uses a separate throttle window for each authenticated user', async () => {
+    vi.mocked(getUser).mockResolvedValueOnce({ id: 'user-123', email: 'user1@example.com' } as any);
+    const firstResponse = await POST(makeRequest());
+
+    vi.mocked(getUser).mockResolvedValueOnce({ id: 'user-456', email: 'user2@example.com' } as any);
+    const secondResponse = await POST(makeRequest());
+
+    expect(firstResponse.status).toBe(202);
+    expect(secondResponse.status).toBe(202);
+    const body = await secondResponse.json();
+    expect(body.success).toBe(true);
+  });
+});

--- a/app/api/account/export/route.test.ts
+++ b/app/api/account/export/route.test.ts
@@ -1,51 +1,59 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { NextRequest } from 'next/server';
-import { POST } from './route';
-import { resetThrottleRegistry } from '@/lib/account/export-throttle';
-import { getUser } from '@/lib/auth';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { resetThrottleRegistry } from "@/lib/account/export-throttle";
+import { getUser } from "@/lib/auth";
 
-vi.mock('@/lib/auth');
+vi.mock("@/lib/auth");
 
 function makeRequest(): NextRequest {
-  return new NextRequest('http://localhost/api/account/export', {
-    method: 'POST',
+  return new NextRequest("http://localhost/api/account/export", {
+    method: "POST",
     headers: {
-      'x-csrf-token': 'csrf-cookie-value',
-      cookie: 'csrf-token=csrf-cookie-value',
+      "x-csrf-token": "csrf-cookie-value",
+      cookie: "csrf-token=csrf-cookie-value",
     },
   });
 }
 
-describe('GDPR DSAR Account Export API Route Flow', () => {
+describe("GDPR DSAR Account Export API Route Flow", () => {
   beforeEach(() => {
     resetThrottleRegistry();
     vi.clearAllMocks();
   });
 
-  it('returns 401 when the caller is not authenticated', async () => {
+  it("returns 401 when the caller is not authenticated", async () => {
     vi.mocked(getUser).mockResolvedValue(null);
 
     const response = await POST(makeRequest());
 
     expect(response.status).toBe(401);
     const body = await response.json();
-    expect(body.error).toContain('Unauthorized');
+    expect(body.error).toContain("Unauthorized");
   });
 
-  it('accepts a valid authenticated request and returns a 202 with a signed download URL', async () => {
-    vi.mocked(getUser).mockResolvedValue({ id: 'user-123', email: 'user@example.com' } as any);
+  it("accepts a valid authenticated request and returns a 202 with a signed download URL", async () => {
+    vi.mocked(getUser).mockResolvedValue({
+      id: "user-123",
+      email: "user@example.com",
+    } as any);
 
     const response = await POST(makeRequest());
 
     expect(response.status).toBe(202);
     const body = await response.json();
     expect(body.success).toBe(true);
-    expect(body.downloadUrl).toContain('https://storage.stellarlend.com/exports/');
+    expect(body.downloadUrl).toContain(
+      "https://storage.stellarlend.com/exports/",
+    );
     expect(body.expiresInSeconds).toBe(900);
   });
 
-  it('rate-limits repeated requests for the same user within 24 hours', async () => {
-    vi.mocked(getUser).mockResolvedValue({ id: 'user-123', email: 'user@example.com' } as any);
+  it("rate-limits repeated requests for the same user within 24 hours", async () => {
+    vi.mocked(getUser).mockResolvedValue({
+      id: "user-123",
+      email: "user@example.com",
+    } as any);
 
     const firstResponse = await POST(makeRequest());
     const secondResponse = await POST(makeRequest());
@@ -53,14 +61,20 @@ describe('GDPR DSAR Account Export API Route Flow', () => {
     expect(firstResponse.status).toBe(202);
     expect(secondResponse.status).toBe(429);
     const body = await secondResponse.json();
-    expect(body.error).toContain('DSAR export rate limit exceeded');
+    expect(body.error).toContain("DSAR export rate limit exceeded");
   });
 
-  it('uses a separate throttle window for each authenticated user', async () => {
-    vi.mocked(getUser).mockResolvedValueOnce({ id: 'user-123', email: 'user1@example.com' } as any);
+  it("uses a separate throttle window for each authenticated user", async () => {
+    vi.mocked(getUser).mockResolvedValueOnce({
+      id: "user-123",
+      email: "user1@example.com",
+    } as any);
     const firstResponse = await POST(makeRequest());
 
-    vi.mocked(getUser).mockResolvedValueOnce({ id: 'user-456', email: 'user2@example.com' } as any);
+    vi.mocked(getUser).mockResolvedValueOnce({
+      id: "user-456",
+      email: "user2@example.com",
+    } as any);
     const secondResponse = await POST(makeRequest());
 
     expect(firstResponse.status).toBe(202);

--- a/app/api/account/export/route.ts
+++ b/app/api/account/export/route.ts
@@ -1,15 +1,24 @@
 import { NextResponse, NextRequest } from 'next/server';
-import { processAccountExport } from '../../../lib/account/export-bundle';
+import { processAccountExport } from '@/lib/account/export-bundle';
 import { withCsrfProtection } from '@/lib/api/handler';
+import { getUser } from '@/lib/auth';
+import { exportThrottleStore, resetThrottleRegistry } from '@/lib/account/export-throttle';
 
-// Simple in-memory mock store tracking timestamps for the 24-hour rate limit throttle
-const exportThrottleStore = new Map<string, number>();
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 
 const postHandler = async (request: NextRequest) => {
   try {
-    // Simulated authenticated context retrieval (normally parsed from session token)
-    const userId = "user_test_9921"; 
+    // Retrieve authenticated user from session
+    const user = await getUser();
+    
+    if (!user || !user.id) {
+      return NextResponse.json(
+        { error: "Unauthorized: User must be authenticated to request account export" },
+        { status: 401 }
+      );
+    }
+
+    const userId = user.id; 
 
     // 1. Throttle check: Enforce maximum 1 export per 24 hours per account
     const now = Date.now();
@@ -25,9 +34,10 @@ const postHandler = async (request: NextRequest) => {
     }
 
     // Mock payload aggregation from database services
+    // In production, this would fetch real user data from the database
     const mockUserPayload = {
       userId,
-      profile: { email: "user@example.com", joinedAt: "2025-01-15" },
+      profile: { email: user.email || "user@example.com", joinedAt: "2025-01-15" },
       preferences: { darkMode: true, emailNotifications: true },
       transactions: [{ id: "tx_01", asset: "XLM", amount: 500 }],
       notifications: [{ id: "notif_01", message: "Deposit confirmed" }]
@@ -61,8 +71,3 @@ const postHandler = async (request: NextRequest) => {
 };
 
 export const POST = withCsrfProtection(postHandler);
-
-// Helper utility exposed to clear mock states during testing execution runs
-export function resetThrottleRegistry() {
-  exportThrottleStore.clear();
-}

--- a/components/shared/ui/Input.test.tsx
+++ b/components/shared/ui/Input.test.tsx
@@ -25,6 +25,28 @@ describe("Input Component", () => {
     expect(screen.getByText("Must be 8 characters")).toBeInTheDocument();
   });
 
+  it("wires aria-describedby and aria-invalid for error text", () => {
+    render(<Input label="Email" error="Invalid email" />);
+
+    const input = screen.getByLabelText("Email");
+    const error = screen.getByText("Invalid email");
+
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "email-error");
+    expect(error).toHaveAttribute("id", "email-error");
+  });
+
+  it("wires aria-describedby for helper text", () => {
+    render(<Input label="Password" helperText="Must be 8 characters" />);
+
+    const input = screen.getByLabelText("Password");
+    const helperText = screen.getByText("Must be 8 characters");
+
+    expect(input).toHaveAttribute("aria-describedby", "password-helper");
+    expect(helperText).toHaveAttribute("id", "password-helper");
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
   it("renders as a textarea when multiline is true", () => {
     render(<Input label="Bio" multiline placeholder="Tell us about yourself" />);
     

--- a/components/shared/ui/Input.test.tsx
+++ b/components/shared/ui/Input.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import { render, screen, fireEvent } from "@/test/test-utils";
 import { Input } from "./Input";
 import { describe, it, expect, vi } from "vitest";
@@ -6,14 +6,14 @@ import { describe, it, expect, vi } from "vitest";
 describe("Input Component", () => {
   it("renders with label and placeholder", () => {
     render(<Input label="Username" placeholder="Enter username" />);
-    
+
     expect(screen.getByText("Username")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Enter username")).toBeInTheDocument();
   });
 
   it("displays error message and applies error styles", () => {
     const { container } = render(<Input label="Email" error="Invalid email" />);
-    
+
     expect(screen.getByText("Invalid email")).toBeInTheDocument();
     const input = screen.getByLabelText("Email");
     expect(input).toHaveClass("border-red-500");
@@ -21,7 +21,7 @@ describe("Input Component", () => {
 
   it("displays helper text", () => {
     render(<Input label="Password" helperText="Must be 8 characters" />);
-    
+
     expect(screen.getByText("Must be 8 characters")).toBeInTheDocument();
   });
 
@@ -48,15 +48,17 @@ describe("Input Component", () => {
   });
 
   it("renders as a textarea when multiline is true", () => {
-    render(<Input label="Bio" multiline placeholder="Tell us about yourself" />);
-    
+    render(
+      <Input label="Bio" multiline placeholder="Tell us about yourself" />,
+    );
+
     const textarea = screen.getByPlaceholderText("Tell us about yourself");
     expect(textarea.tagName).toBe("TEXTAREA");
   });
 
   it("is disabled when disabled prop is true", () => {
     render(<Input label="Static" disabled />);
-    
+
     const input = screen.getByLabelText("Static");
     expect(input).toBeDisabled();
     expect(input).toHaveClass("bg-gray-50");
@@ -65,16 +67,16 @@ describe("Input Component", () => {
   it("calls onChange handler when value changes", () => {
     const handleChange = vi.fn();
     render(<Input label="Name" onChange={handleChange} />);
-    
+
     const input = screen.getByLabelText("Name");
     fireEvent.change(input, { target: { value: "John" } });
-    
+
     expect(handleChange).toHaveBeenCalled();
   });
 
   it("shows required asterisk when required is true", () => {
     render(<Input label="Email" required />);
-    
+
     expect(screen.getByText("*")).toBeInTheDocument();
   });
 });

--- a/components/shared/ui/Input.tsx
+++ b/components/shared/ui/Input.tsx
@@ -1,5 +1,5 @@
-import React, { InputHTMLAttributes, TextareaHTMLAttributes } from 'react';
-import { cn } from '@/lib/utils/cn';
+import React, { InputHTMLAttributes, TextareaHTMLAttributes } from "react";
+import { cn } from "@/lib/utils/cn";
 
 export interface BaseProps {
   label?: string;
@@ -10,92 +10,111 @@ export interface BaseProps {
   containerClassName?: string;
 }
 
-export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement>, BaseProps {
+export interface TextInputProps
+  extends InputHTMLAttributes<HTMLInputElement>, BaseProps {
   multiline?: false;
 }
 
-export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>, BaseProps {
+export interface TextAreaProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement>, BaseProps {
   multiline: true;
   rows?: number;
 }
 
 export type InputProps = TextInputProps | TextAreaProps;
 
-export const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
-  (props, ref) => {
-    const {
-      label,
-      error,
-      helperText,
-      required,
-      fullWidth = true,
-      className,
-      containerClassName,
-      id,
-      multiline,
-      ...rest
-    } = props;
+export const Input = React.forwardRef<
+  HTMLInputElement | HTMLTextAreaElement,
+  InputProps
+>((props, ref) => {
+  const {
+    label,
+    error,
+    helperText,
+    required,
+    fullWidth = true,
+    className,
+    containerClassName,
+    id,
+    multiline,
+    ...rest
+  } = props;
 
-    const inputId = id || (label ? label.toLowerCase().replace(/\s+/g, '-') : undefined);
-    const describedBy = error ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined;
-    const ariaInvalid = error ? 'true' : 'false';
+  const inputId =
+    id || (label ? label.toLowerCase().replace(/\s+/g, "-") : undefined);
+  const describedBy = error
+    ? `${inputId}-error`
+    : helperText
+      ? `${inputId}-helper`
+      : undefined;
+  const ariaInvalid = error ? "true" : "false";
 
-    const baseInputStyles = cn(
-      'w-full px-4 py-2.5 rounded-lg border transition-all duration-200 outline-none text-sm',
-      'bg-white text-gray-900 placeholder:text-gray-400',
-      error
-        ? 'border-red-500 focus:border-red-500 focus:ring-1 focus:ring-red-500'
-        : 'border-gray-300 focus:border-[#2600FF] focus:ring-1 focus:ring-[#2600FF]',
-      props.disabled && 'bg-gray-50 text-gray-500 border-gray-200 cursor-not-allowed',
-      className
-    );
+  const baseInputStyles = cn(
+    "w-full px-4 py-2.5 rounded-lg border transition-all duration-200 outline-none text-sm",
+    "bg-white text-gray-900 placeholder:text-gray-400",
+    error
+      ? "border-red-500 focus:border-red-500 focus:ring-1 focus:ring-red-500"
+      : "border-gray-300 focus:border-[#2600FF] focus:ring-1 focus:ring-[#2600FF]",
+    props.disabled &&
+      "bg-gray-50 text-gray-500 border-gray-200 cursor-not-allowed",
+    className,
+  );
 
-    return (
-      <div className={cn('flex flex-col gap-1.5', fullWidth ? 'w-full' : 'w-auto', containerClassName)}>
-        {label && (
-          <label
-            htmlFor={inputId}
-            className="text-sm font-medium text-gray-700 flex items-center gap-1"
-          >
-            {label}
-            {required && <span className="text-red-500" aria-hidden="true">*</span>}
-          </label>
-        )}
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-1.5",
+        fullWidth ? "w-full" : "w-auto",
+        containerClassName,
+      )}
+    >
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="text-sm font-medium text-gray-700 flex items-center gap-1"
+        >
+          {label}
+          {required && (
+            <span className="text-red-500" aria-hidden="true">
+              *
+            </span>
+          )}
+        </label>
+      )}
 
-        {multiline ? (
-          <textarea
-            id={inputId}
-            ref={ref as React.ForwardedRef<HTMLTextAreaElement>}
-            className={cn(baseInputStyles, 'resize-none')}
-            required={required}
-            aria-invalid={ariaInvalid}
-            aria-describedby={describedBy}
-            {...(rest as TextareaHTMLAttributes<HTMLTextAreaElement>)}
-          />
-        ) : (
-          <input
-            id={inputId}
-            ref={ref as React.ForwardedRef<HTMLInputElement>}
-            className={baseInputStyles}
-            required={required}
-            aria-invalid={ariaInvalid}
-            aria-describedby={describedBy}
-            {...(rest as InputHTMLAttributes<HTMLInputElement>)}
-          />
-        )}
+      {multiline ? (
+        <textarea
+          id={inputId}
+          ref={ref as React.ForwardedRef<HTMLTextAreaElement>}
+          className={cn(baseInputStyles, "resize-none")}
+          required={required}
+          aria-invalid={ariaInvalid}
+          aria-describedby={describedBy}
+          {...(rest as TextareaHTMLAttributes<HTMLTextAreaElement>)}
+        />
+      ) : (
+        <input
+          id={inputId}
+          ref={ref as React.ForwardedRef<HTMLInputElement>}
+          className={baseInputStyles}
+          required={required}
+          aria-invalid={ariaInvalid}
+          aria-describedby={describedBy}
+          {...(rest as InputHTMLAttributes<HTMLInputElement>)}
+        />
+      )}
 
-        {error ? (
-          <p className="text-xs text-red-500 mt-0.5" id={`${inputId}-error`}>
-            {error}
-          </p>
-        ) : helperText ? (
-          <p className="text-xs text-gray-500 mt-0.5" id={`${inputId}-helper`}>
-            {helperText}
-          </p>
-        ) : null}
-      </div>
-    );
-  }
-);
+      {error ? (
+        <p className="text-xs text-red-500 mt-0.5" id={`${inputId}-error`}>
+          {error}
+        </p>
+      ) : helperText ? (
+        <p className="text-xs text-gray-500 mt-0.5" id={`${inputId}-helper`}>
+          {helperText}
+        </p>
+      ) : null}
+    </div>
+  );
+});
 
-Input.displayName = 'Input';
+Input.displayName = "Input";

--- a/components/shared/ui/Input.tsx
+++ b/components/shared/ui/Input.tsx
@@ -37,6 +37,8 @@ export const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
     } = props;
 
     const inputId = id || (label ? label.toLowerCase().replace(/\s+/g, '-') : undefined);
+    const describedBy = error ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined;
+    const ariaInvalid = error ? 'true' : 'false';
 
     const baseInputStyles = cn(
       'w-full px-4 py-2.5 rounded-lg border transition-all duration-200 outline-none text-sm',
@@ -66,6 +68,8 @@ export const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
             ref={ref as React.ForwardedRef<HTMLTextAreaElement>}
             className={cn(baseInputStyles, 'resize-none')}
             required={required}
+            aria-invalid={ariaInvalid}
+            aria-describedby={describedBy}
             {...(rest as TextareaHTMLAttributes<HTMLTextAreaElement>)}
           />
         ) : (
@@ -74,6 +78,8 @@ export const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
             ref={ref as React.ForwardedRef<HTMLInputElement>}
             className={baseInputStyles}
             required={required}
+            aria-invalid={ariaInvalid}
+            aria-describedby={describedBy}
             {...(rest as InputHTMLAttributes<HTMLInputElement>)}
           />
         )}

--- a/docs/account-export-issue-resolution.md
+++ b/docs/account-export-issue-resolution.md
@@ -1,0 +1,10 @@
+# Resolved issue: Account export auth and rate-limit isolation
+
+## Title
+Fix DSAR export authentication and per-user rate-limit isolation
+
+## Description
+The account export endpoint no longer relies on a hardcoded mock user ID. It now resolves the authenticated user from the real session via the auth helper and uses that user ID for the 24-hour throttle key. This prevents cross-user leakage and ensures that one user's export request cannot block another user's export requests with a shared 429 response.
+
+## Verification
+- Added regression tests covering unauthenticated access, successful authenticated export, same-user throttling, and separate throttle windows for different users.

--- a/docs/account-export-issue-resolution.md
+++ b/docs/account-export-issue-resolution.md
@@ -1,10 +1,13 @@
 # Resolved issue: Account export auth and rate-limit isolation
 
 ## Title
+
 Fix DSAR export authentication and per-user rate-limit isolation
 
 ## Description
+
 The account export endpoint no longer relies on a hardcoded mock user ID. It now resolves the authenticated user from the real session via the auth helper and uses that user ID for the 24-hour throttle key. This prevents cross-user leakage and ensures that one user's export request cannot block another user's export requests with a shared 429 response.
 
 ## Verification
+
 - Added regression tests covering unauthenticated access, successful authenticated export, same-user throttling, and separate throttle windows for different users.

--- a/lib/account/export-throttle.ts
+++ b/lib/account/export-throttle.ts
@@ -1,0 +1,7 @@
+// Simple in-memory mock store tracking timestamps for the 24-hour rate limit throttle
+export const exportThrottleStore = new Map<string, number>();
+
+// Helper utility exposed to clear mock states during testing execution runs
+export function resetThrottleRegistry() {
+  exportThrottleStore.clear();
+}


### PR DESCRIPTION
Fixes #989

App/api/account/export/route.ts now uses real session authentication via getUser() from lib/auth.ts instead of hardcoded userId, and the rate-limit throttle is keyed per-user instead of shared across all users. Tests added for independent rate-limit windows.