### PR TITLE
fix: clear input text on outside click in SearchBar

### DIFF
--- a/components/molecules/SearchBar/SearchBar.results.test.tsx
+++ b/components/molecules/SearchBar/SearchBar.results.test.tsx
@@ -339,6 +339,30 @@ describe('SearchBar Live Results', () => {
       expect(onSearch).not.toHaveBeenCalled();
     });
 
+    it('should clear input text on outside click and not re-trigger search on refocus', () => {
+      const onSearch = vi.fn();
+      render(
+        <SearchBar
+          results={loadingResults('test')}
+          onSearch={onSearch}
+        />
+      );
+
+      const input = screen.getByRole('combobox') as HTMLInputElement;
+      expect(input.value).toBe('test');
+
+      fireEvent.mouseDown(document.body);
+      fireEvent.mouseUp(document.body);
+
+      expect(onSearch).toHaveBeenCalledWith('');
+      expect(input.value).toBe('');
+
+      onSearch.mockClear();
+      fireEvent.focus(input);
+
+      expect(onSearch).not.toHaveBeenCalled();
+    });
+
     it('should not close when clicking inside the dropdown', () => {
       const onSearch = vi.fn();
       const { container } = render(

--- a/components/molecules/SearchBar/SearchBar.tsx
+++ b/components/molecules/SearchBar/SearchBar.tsx
@@ -287,6 +287,7 @@ const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
           inputRef.current &&
           !inputRef.current.contains(e.target as Node)
         ) {
+          setValue('');
           onSearch?.('');
         }
       };


### PR DESCRIPTION
## Problem

The SearchBar `handleClickOutside` handler clears the dropdown results via `onSearch?.()` but leaves the typed query text in the input field. When the user refocuses the input, `handleInputFocus` does not re-trigger search because the internal state is no longer idle, creating an inconsistent UI state.

## Fix

- Added `setValue()` in `handleClickOutside` to clear the input text alongside the dropdown state, matching the behavior of `handleClear`.

Fixes #1125