### PR TITLE
fix: add docblock contract to StatusAnnouncer (#1167)

### DIFF
--- a/components/shared/common/StatusAnnouncer.test.tsx
+++ b/components/shared/common/StatusAnnouncer.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { render, screen } from "@/test/test-utils";
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import StatusAnnouncer from "./StatusAnnouncer";
+
+const lendingForms = [
+  {
+    file: "LendingForm.tsx",
+    type: "lend",
+  },
+  {
+    file: "BorrowingForm.tsx",
+    type: "borrow",
+  },
+  {
+    file: "RepayForm.tsx",
+    type: "repay",
+  },
+  {
+    file: "WithdrawForm.tsx",
+    type: "withdraw",
+  },
+] as const;
+
+describe("StatusAnnouncer", () => {
+  it("renders nothing when status is idle", () => {
+    const { container } = render(
+      <StatusAnnouncer status="idle" type="lend" />,
+    );
+    expect(container.querySelector('[data-testid="status-announcer"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="status-announcer"]')).toHaveTextContent("");
+  });
+
+  it("announces submitting state", () => {
+    render(<StatusAnnouncer status="submitting" type="lend" />);
+    expect(screen.getByTestId("status-announcer")).toHaveTextContent(
+      "Submitting lend request...",
+    );
+  });
+
+  it("announces success state with default message", () => {
+    render(<StatusAnnouncer status="success" type="borrow" />);
+    expect(screen.getByTestId("status-announcer")).toHaveTextContent(
+      "borrow request completed successfully.",
+    );
+  });
+
+  it("announces success state with custom message", () => {
+    render(
+      <StatusAnnouncer
+        status="success"
+        type="repay"
+        message="Repayment successful."
+      />,
+    );
+    expect(screen.getByTestId("status-announcer")).toHaveTextContent(
+      "Repayment successful.",
+    );
+  });
+
+  it("announces error state with default message", () => {
+    render(<StatusAnnouncer status="error" type="withdraw" />);
+    expect(screen.getByTestId("status-announcer")).toHaveTextContent(
+      "An error occurred during withdraw request.",
+    );
+  });
+
+  it("announces error state with custom message", () => {
+    render(
+      <StatusAnnouncer
+        status="error"
+        type="lend"
+        message="Something went wrong."
+      />,
+    );
+    expect(screen.getByTestId("status-announcer")).toHaveTextContent(
+      "Something went wrong.",
+    );
+  });
+});
+
+describe("StatusAnnouncer contract", () => {
+  it.each(lendingForms)(
+    "$file renders StatusAnnouncer with type='$type'",
+    ({ file, type }) => {
+      const source = fs.readFileSync(
+        path.join(
+          process.cwd(),
+          "components",
+          "features",
+          "lending",
+          "components",
+          file,
+        ),
+        "utf8",
+      );
+
+      expect(source).toContain("<StatusAnnouncer");
+      expect(source).toContain(`type="${type}"`);
+    },
+  );
+
+  it("documents the lending form StatusAnnouncer contract", () => {
+    const source = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        "components",
+        "shared",
+        "common",
+        "StatusAnnouncer.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      "Every lending action form (lend / borrow / repay / withdraw) MUST render",
+    );
+  });
+});

--- a/components/shared/common/StatusAnnouncer.tsx
+++ b/components/shared/common/StatusAnnouncer.tsx
@@ -1,5 +1,18 @@
 "use client";
 
+/**
+ * Accessibility announcement component for lending action statuses.
+ *
+ * Every lending action form (lend / borrow / repay / withdraw) MUST render
+ * this component with its corresponding `type` prop so that screen-reader
+ * users receive live feedback when a form transitions through
+ * idle -> submitting -> success / error states.
+ *
+ * If a new lending action type is added to the app, both the `type` union
+ * below and each form that implements that action must include a
+ * `<StatusAnnouncer>` instance.
+ */
+
 import React, { useEffect, useState } from "react";
 
 export type AnnouncerStatus = "idle" | "submitting" | "success" | "error";


### PR DESCRIPTION
Adds a JSDoc docblock to StatusAnnouncer.tsx documenting the contract that every lending action form (lend/borrow/repay/withdraw) must render this component with its corresponding type prop. Also includes a test that asserts all four lending form components render StatusAnnouncer.

Co-authored-by: Netty-kun <182667336@users.noreply.github.com>

Closes #1167