### PR TITLE
fix(account): anchor AccountDeletionUndo countdown to Date.now() to p…

### DIFF
--- a/components/features/account/components/AccountDeletionUndo.test.tsx
+++ b/components/features/account/components/AccountDeletionUndo.test.tsx
@@ -11,6 +11,7 @@ import AccountDeletionDialog from "@/components/shared/common/AccountDeletionDia
 describe("AccountDeletionUndo", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
   });
 
   afterEach(() => {
@@ -30,6 +31,17 @@ describe("AccountDeletionUndo", () => {
 
     act(() => vi.advanceTimersByTime(1000));
     expect(screen.getByTestId("undo-countdown")).toHaveTextContent("3");
+  });
+
+  it("adjusts correctly when timer fires late due to throttling", () => {
+    render(<AccountDeletionUndo durationSeconds={10} onUndo={vi.fn()} onElapsed={vi.fn()} />);
+
+    // Simulate throttling where the 1000ms timeout fires 3000ms late (total 4000ms elapsed)
+    vi.setSystemTime(new Date("2024-01-01T00:00:03Z"));
+    act(() => vi.advanceTimersByTime(1000));
+    
+    // 4000ms elapsed -> 10 - 4 = 6 seconds remaining
+    expect(screen.getByTestId("undo-countdown")).toHaveTextContent("6");
   });
 
   it("shows the Undo button", () => {
@@ -149,6 +161,7 @@ function openAndConfirm() {
 describe("AccountDeletionDialog – undo window integration", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
   });
 
   afterEach(() => {

--- a/components/features/account/components/AccountDeletionUndo.tsx
+++ b/components/features/account/components/AccountDeletionUndo.tsx
@@ -16,7 +16,7 @@ export default function AccountDeletionUndo({
   onElapsed,
 }: AccountDeletionUndoProps) {
   const [secondsRemaining, setSecondsRemaining] = useState(durationSeconds);
-  const mountTimeRef = useRef(Date.now());
+  const mountTimeRef = useRef(new Date().getTime());
   const onElapsedRef = useRef(onElapsed);
   const undoButtonRef = useRef<HTMLButtonElement>(null);
 

--- a/components/features/account/components/AccountDeletionUndo.tsx
+++ b/components/features/account/components/AccountDeletionUndo.tsx
@@ -16,6 +16,7 @@ export default function AccountDeletionUndo({
   onElapsed,
 }: AccountDeletionUndoProps) {
   const [secondsRemaining, setSecondsRemaining] = useState(durationSeconds);
+  const mountTimeRef = useRef(Date.now());
   const onElapsedRef = useRef(onElapsed);
   const undoButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -32,9 +33,12 @@ export default function AccountDeletionUndo({
       onElapsedRef.current();
       return;
     }
-    const timerId = setTimeout(() => setSecondsRemaining((s) => s - 1), 1000);
+    const timerId = setTimeout(() => {
+      const elapsedSeconds = Math.floor((Date.now() - mountTimeRef.current) / 1000);
+      setSecondsRemaining(Math.max(0, durationSeconds - elapsedSeconds));
+    }, 1000);
     return () => clearTimeout(timerId);
-  }, [secondsRemaining]);
+  }, [secondsRemaining, durationSeconds]);
 
   const percentage = (secondsRemaining / durationSeconds) * 100;
 

--- a/components/features/account/components/AccountDeletionUndo.tsx
+++ b/components/features/account/components/AccountDeletionUndo.tsx
@@ -34,7 +34,9 @@ export default function AccountDeletionUndo({
       return;
     }
     const timerId = setTimeout(() => {
-      const elapsedSeconds = Math.floor((Date.now() - mountTimeRef.current) / 1000);
+      const elapsedSeconds = Math.floor(
+        (Date.now() - mountTimeRef.current) / 1000,
+      );
       setSecondsRemaining(Math.max(0, durationSeconds - elapsedSeconds));
     }, 1000);
     return () => clearTimeout(timerId);


### PR DESCRIPTION
Fix: Anchor AccountDeletionUndo countdown to Date.now() to prevent drift

Description Resolves #1139. (Also verified #1158).

The AccountDeletionUndo component relied on successive setTimeout(..., 1000) calls to decrement the remaining seconds. When the browser tab was backgrounded or throttled, these intervals could fire significantly later than 1000ms, causing the visible countdown—and the actual account deletion trigger—to drift away from the promised 10-second window.

This PR fixes the drift by tracking the initial mount time and evaluating the true elapsed time on each interval tick, anchoring the countdown back to the real wall-clock time.

Additionally, the codebase was audited for the MetricsCards issue (#1158). The component's structure is correctly un-nested, and the regression tests ensuring copyToClipboard errors trigger the expected toasts are intact and passing.

Changes Made

Stored Date.now() in a ref at component mount to establish an absolute starting time.
Updated the useEffect interval to compute remaining seconds based on the elapsed real-world time rather than statically decrementing by 1.
Added a new Vitest suite to explicitly simulate an elapsed timeline where the timer fires late due to simulated throttling, validating that the remaining seconds calculate correctly.
Validation

 Tested unit behavior under simulated throttle delays (tests pass).
 Verified #1158 regression test coverage is fully present.
 Code adheres to the project's architecture and coding standards.
 
 closes #1158 