### PR TITLE
fix(#1099): extract shared SSE controller cleanup helper

### DIFF
--- a/app/api/notifications/stream/route.test.ts
+++ b/app/api/notifications/stream/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET } from './route';
+import { notificationHub } from '@/lib/streams/notification-hub';
 
 vi.mock('@/lib/auth', () => ({
   getUser: vi.fn(),
@@ -24,5 +25,26 @@ describe('GET /api/notifications/stream', () => {
     expect(res.status).toBe(200);
     const ct = res.headers.get('Content-Type') || res.headers.get('content-type');
     expect(ct).toMatch(/text\/event-stream/i);
+  });
+
+  it('runs notification hub cleanup when the stream is cancelled', async () => {
+    const userId = 'user-cancel-cleanup';
+    mockGetUser.mockResolvedValue({ id: userId } as any);
+
+    const unsubscribe = vi.fn();
+    const subscribeSpy = vi
+      .spyOn(notificationHub, 'subscribe')
+      .mockReturnValue(unsubscribe);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(subscribeSpy).toHaveBeenCalledWith(userId, expect.any(Function));
+
+    const reader = res.body!.getReader();
+    await reader.cancel();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+    subscribeSpy.mockRestore();
   });
 });

--- a/app/api/notifications/stream/route.ts
+++ b/app/api/notifications/stream/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getUser } from '@/lib/auth';
 import { notificationHub } from '@/lib/streams/notification-hub';
+import { withControllerCleanup } from '@/lib/streams/with-controller-cleanup';
 
 export const runtime = 'nodejs';
 
@@ -20,8 +21,8 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const stream = new ReadableStream({
-    start(controller) {
+  const stream = new ReadableStream(
+    withControllerCleanup((controller, onCleanup) => {
       // Send a comment and retry hint to help clients
       controller.enqueue(new TextEncoder().encode('retry: 5000\n\n'));
 
@@ -33,19 +34,9 @@ export async function GET() {
         }
       });
 
-      // When the consumer closes, unsubscribe
-      (controller as any).unsubscribe = unsubscribe;
-    },
-    cancel() {
-      // cancel is called when the downstream terminates
-      try {
-        const anyController = this as any;
-        if (typeof anyController.unsubscribe === 'function') anyController.unsubscribe();
-      } catch (e) {
-        // noop
-      }
-    },
-  });
+      onCleanup(unsubscribe);
+    }),
+  );
 
   return new NextResponse(stream, {
     headers: {

--- a/app/api/stream/prices/route.ts
+++ b/app/api/stream/prices/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { SupportedAsset } from "@/lib/prices/types";
 import { SUPPORTED_ASSETS } from "@/lib/prices/constants";
+import { withControllerCleanup } from "@/lib/streams/with-controller-cleanup";
 
 export const runtime = "nodejs";
 
@@ -15,8 +16,8 @@ function formatSSE(data: PriceUpdate): string {
 }
 
 export async function GET() {
-  const stream = new ReadableStream({
-    async start(controller) {
+  const stream = new ReadableStream(
+    withControllerCleanup((controller, onCleanup) => {
       controller.enqueue(
         new TextEncoder().encode("retry: 3000\n\n"),
       );
@@ -61,21 +62,11 @@ export async function GET() {
         );
       }, 3000);
 
-      (controller as any).cleanup = () => {
+      onCleanup(() => {
         clearInterval(interval);
-      };
-    },
-    cancel() {
-      try {
-        const anyController = this as any;
-        if (typeof anyController.cleanup === "function") {
-          anyController.cleanup();
-        }
-      } catch {
-        // noop
-      }
-    },
-  });
+      });
+    }),
+  );
 
   return new NextResponse(stream, {
     headers: {

--- a/lib/streams/with-controller-cleanup.test.ts
+++ b/lib/streams/with-controller-cleanup.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withControllerCleanup } from './with-controller-cleanup';
+
+describe('withControllerCleanup', () => {
+  it('invokes the registered cleanup when the stream is cancelled', async () => {
+    const cleanup = vi.fn();
+
+    const stream = new ReadableStream(
+      withControllerCleanup((controller, onCleanup) => {
+        controller.enqueue(new TextEncoder().encode('hello'));
+        onCleanup(cleanup);
+      }),
+    );
+
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows errors thrown by cleanup', async () => {
+    const stream = new ReadableStream(
+      withControllerCleanup((_controller, onCleanup) => {
+        onCleanup(() => {
+          throw new Error('cleanup failed');
+        });
+      }),
+    );
+
+    const reader = stream.getReader();
+    await expect(reader.cancel()).resolves.toBeUndefined();
+  });
+
+  it('does not throw when cancel runs without a registered cleanup', async () => {
+    const stream = new ReadableStream(
+      withControllerCleanup(() => {
+        // no onCleanup registration
+      }),
+    );
+
+    const reader = stream.getReader();
+    await expect(reader.cancel()).resolves.toBeUndefined();
+  });
+});

--- a/lib/streams/with-controller-cleanup.ts
+++ b/lib/streams/with-controller-cleanup.ts
@@ -1,0 +1,43 @@
+type CleanupFn = () => void;
+
+type StartWithCleanup<T> = (
+  controller: ReadableStreamDefaultController<T>,
+  onCleanup: (cleanupFn: CleanupFn) => void,
+) => void | Promise<void>;
+
+/**
+ * Builds a ReadableStream underlying source that registers cleanup via a
+ * typed callback instead of monkey-patching the controller with `as any`.
+ *
+ * Usage:
+ * ```ts
+ * new ReadableStream(
+ *   withControllerCleanup((controller, onCleanup) => {
+ *     const unsubscribe = hub.subscribe(...);
+ *     onCleanup(unsubscribe);
+ *   }),
+ * );
+ * ```
+ */
+export function withControllerCleanup<T = Uint8Array>(
+  start: StartWithCleanup<T>,
+): UnderlyingDefaultSource<T> {
+  let cleanupFn: CleanupFn | undefined;
+
+  return {
+    start(controller) {
+      return start(controller, (fn) => {
+        cleanupFn = fn;
+      });
+    },
+    cancel() {
+      try {
+        cleanupFn?.();
+      } catch {
+        // noop — cleanup must not throw out of cancel
+      } finally {
+        cleanupFn = undefined;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extract shared `withControllerCleanup` helper to replace duplicated `as any` ReadableStreamController monkey-patches
- Update notifications and prices SSE routes to use the helper
- Add tests asserting notification stream cleanup runs on cancel

Closes #1099

## Test plan
- [x] `vitest run lib/streams/with-controller-cleanup.test.ts app/api/notifications/stream/route.test.ts app/api/stream/prices/route.test.ts`