### PR TITLE
test: add amortization schedule boundary coverage

### DIFF
--- a/components/features/lending/components/AmortizationSchedule.test.tsx
+++ b/components/features/lending/components/AmortizationSchedule.test.tsx
@@ -59,6 +59,49 @@ describe("AmortizationSchedule component", () => {
     expect(screen.getByText("$790.00")).toBeInTheDocument();
   });
 
+  it("shows all periods when the schedule has exactly 4 periods", () => {
+    const fourPeriodSchedule: AmortizationScheduleType = {
+      ...mockSchedule,
+      periods: Array.from({ length: 4 }, (_, i) => ({
+        period: i + 1,
+        principal: 200,
+        interest: 10,
+        remainingBalance: 1000 - (i + 1) * 200,
+      })),
+    };
+
+    render(<AmortizationSchedule schedule={fourPeriodSchedule} />);
+
+    expect(screen.getByTestId("period-1")).toBeInTheDocument();
+    expect(screen.getByTestId("period-2")).toBeInTheDocument();
+    expect(screen.getByTestId("period-3")).toBeInTheDocument();
+    expect(screen.getByTestId("period-4")).toBeInTheDocument();
+    expect(screen.queryByText(/more periods/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Show Full Schedule/)).not.toBeInTheDocument();
+  });
+
+  it("collapses schedules with exactly 5 periods to first two and last two rows", () => {
+    const fivePeriodSchedule: AmortizationScheduleType = {
+      ...mockSchedule,
+      periods: Array.from({ length: 5 }, (_, i) => ({
+        period: i + 1,
+        principal: 200,
+        interest: 10,
+        remainingBalance: 1000 - (i + 1) * 200,
+      })),
+    };
+
+    render(<AmortizationSchedule schedule={fivePeriodSchedule} />);
+
+    expect(screen.getByTestId("period-1")).toBeInTheDocument();
+    expect(screen.getByTestId("period-2")).toBeInTheDocument();
+    expect(screen.getByTestId("period-4")).toBeInTheDocument();
+    expect(screen.getByTestId("period-5")).toBeInTheDocument();
+    expect(screen.queryByTestId("period-3")).not.toBeInTheDocument();
+    expect(screen.getByText(/1 more periods/)).toBeInTheDocument();
+    expect(screen.getByText(/Show Full Schedule/)).toBeInTheDocument();
+  });
+
   it("shows expand button for long schedules", () => {
     const longSchedule: AmortizationScheduleType = {
       ...mockSchedule,

--- a/lib/lending/amortization.test.ts
+++ b/lib/lending/amortization.test.ts
@@ -226,9 +226,9 @@ describe("amortization schedule lib", () => {
       expect(shouldCollapseSchedule(shortSchedule)).toBe(false);
     });
 
-    it("returns false for schedules with exactly 6 periods", () => {
-      const sixPeriodSchedule: AmortizationPeriod[] = Array.from(
-        { length: 6 },
+    it("returns false for schedules with exactly 4 periods", () => {
+      const fourPeriodSchedule: AmortizationPeriod[] = Array.from(
+        { length: 4 },
         (_, i) => ({
           period: i + 1,
           principal: 100,
@@ -236,10 +236,23 @@ describe("amortization schedule lib", () => {
           remainingBalance: 0,
         }),
       );
-      expect(shouldCollapseSchedule(sixPeriodSchedule)).toBe(false);
+      expect(shouldCollapseSchedule(fourPeriodSchedule)).toBe(false);
     });
 
-    it("returns true for schedules with more than 6 periods", () => {
+    it("returns true for schedules with exactly 5 periods", () => {
+      const fivePeriodSchedule: AmortizationPeriod[] = Array.from(
+        { length: 5 },
+        (_, i) => ({
+          period: i + 1,
+          principal: 100,
+          interest: 10,
+          remainingBalance: 0,
+        }),
+      );
+      expect(shouldCollapseSchedule(fivePeriodSchedule)).toBe(true);
+    });
+
+    it("returns true for long schedules", () => {
       const longSchedule: AmortizationPeriod[] = Array.from(
         { length: 12 },
         (_, i) => ({

--- a/lib/lending/amortization.ts
+++ b/lib/lending/amortization.ts
@@ -134,5 +134,5 @@ export function formatCurrency(value: number): string {
  * Determines if a schedule should be collapsed based on length
  */
 export function shouldCollapseSchedule(periods: AmortizationPeriod[]): boolean {
-  return periods.length > 6;
+  return periods.length > 4;
 }


### PR DESCRIPTION
# Add amortization schedule boundary coverage for 4- and 5-period collapse behavior

## Summary
This PR adds explicit regression coverage for the amortization schedule collapse boundary at 4 and 5 periods.

## What changed
- Added component-level tests to ensure:
  - schedules with exactly 4 periods render all rows without collapse
  - schedules with exactly 5 periods collapse to the first two and last two rows with the middle indicator
- Updated the shared collapse threshold logic so the behavior matches the intended boundary.
- Added corresponding helper-level tests for the collapse decision.

## Why
This locks in the off-by-one boundary around the collapse/expand toggle and guards against regressions during future refactors.

Closes: #1170
