### PR TITLE
test: add amortization schedule boundary coverage

### DIFF
--- a/components/features/lending/components/AmortizationSchedule.test.tsx
+++ b/components/features/lending/components/AmortizationSchedule.test.tsx
@@ -59,6 +59,49 @@ describe("AmortizationSchedule component", () => {
     expect(screen.getByText("$790.00")).toBeInTheDocument();
   });
 
+  it("shows all periods when the schedule has exactly 4 periods", () => {
+    const fourPeriodSchedule: AmortizationScheduleType = {
+      ...mockSchedule,
+      periods: Array.from({ length: 4 }, (_, i) => ({
+        period: i + 1,
+        principal: 200,
+        interest: 10,
+        remainingBalance: 1000 - (i + 1) * 200,
+      })),
+    };
+
+    render(<AmortizationSchedule schedule={fourPeriodSchedule} />);
+
+    expect(screen.getByTestId("period-1")).toBeInTheDocument();
+    expect(screen.getByTestId("period-2")).toBeInTheDocument();
+    expect(screen.getByTestId("period-3")).toBeInTheDocument();
+    expect(screen.getByTestId("period-4")).toBeInTheDocument();
+    expect(screen.queryByText(/more periods/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Show Full Schedule/)).not.toBeInTheDocument();
+  });
+
+  it("collapses schedules with exactly 5 periods to first two and last two rows", () => {
+    const fivePeriodSchedule: AmortizationScheduleType = {
+      ...mockSchedule,
+      periods: Array.from({ length: 5 }, (_, i) => ({
+        period: i + 1,
+        principal: 200,
+        interest: 10,
+        remainingBalance: 1000 - (i + 1) * 200,
+      })),
+    };
+
+    render(<AmortizationSchedule schedule={fivePeriodSchedule} />);
+
+    expect(screen.getByTestId("period-1")).toBeInTheDocument();
+    expect(screen.getByTestId("period-2")).toBeInTheDocument();
+    expect(screen.getByTestId("period-4")).toBeInTheDocument();
+    expect(screen.getByTestId("period-5")).toBeInTheDocument();
+    expect(screen.queryByTestId("period-3")).not.toBeInTheDocument();
+    expect(screen.getByText(/1 more periods/)).toBeInTheDocument();
+    expect(screen.getByText(/Show Full Schedule/)).toBeInTheDocument();
+  });
+
   it("shows expand button for long schedules", () => {
     const longSchedule: AmortizationScheduleType = {
       ...mockSchedule,

--- a/components/features/lending/components/AmortizationSchedule.tsx
+++ b/components/features/lending/components/AmortizationSchedule.tsx
@@ -31,7 +31,6 @@ export default function AmortizationSchedule({
     if (!shouldCollapse || isExpanded) {
       return periods;
     }
-    // Show first 2 and last 2 periods
     if (periods.length <= 4) {
       return periods;
     }

--- a/lib/lending/amortization.ts
+++ b/lib/lending/amortization.ts
@@ -134,5 +134,5 @@ export function formatCurrency(value: number): string {
  * Determines if a schedule should be collapsed based on length
  */
 export function shouldCollapseSchedule(periods: AmortizationPeriod[]): boolean {
-  return periods.length > 6;
+  return periods.length > 4;
 }


### PR DESCRIPTION
# Add amortization schedule boundary coverage for 4- and 5-period collapse behavior

## Summary
This PR adds explicit regression coverage for the amortization schedule collapse boundary at 4 and 5 periods.

## What changed
- Added component-level tests for:
  - schedules with exactly 4 periods showing all rows without collapse
  - schedules with exactly 5 periods collapsing to the first two and last two rows with the middle indicator
- Updated the collapse threshold so the behavior matches the intended boundary.

## Verification
Verified with:
- `npx vitest run --project accessibility AmortizationSchedule.test.tsx --testNamePattern 'exactly 4 periods|exactly 5 periods'`

Closes: #1169