### PR TITLE
feat: validate audit payload size before storing

### DIFF
--- a/lib/audit/__tests__/audit.test.ts
+++ b/lib/audit/__tests__/audit.test.ts
@@ -42,6 +42,30 @@ describe('account audit events', () => {
     expect(deleted[0].type).toBe('account.deleted');
   });
 
+  it('truncates oversized metadata before storing it', () => {
+    const oversizedMetadata = {
+      message: 'x'.repeat(6_000),
+      nested: {
+        detail: 'y'.repeat(6_000),
+      },
+    };
+
+    const event = emitAccountAuditEvent('account.deleted', 'user-2', oversizedMetadata);
+    const stored = getAccountAuditEvents({ userId: 'user-2' }).find((e) => e.id === event.id);
+
+    expect(stored).toBeDefined();
+    expect(stored?.metadata).not.toEqual(oversizedMetadata);
+    expect(stored?.metadata).toEqual(
+      expect.objectContaining({
+        __truncated: true,
+        __reason: 'audit payload exceeded maximum size',
+        __originalSizeBytes: expect.any(Number),
+        preview: expect.any(String),
+      }),
+    );
+    expect((stored?.metadata.preview as string).length).toBeLessThanOrEqual(1_024);
+  });
+
   it('filters by since timestamp', () => {
     clearAuditLog();
     const past = new Date(Date.now() - 10_000).toISOString();

--- a/lib/audit/index.ts
+++ b/lib/audit/index.ts
@@ -69,6 +69,9 @@ let maxEvents = DEFAULT_MAX_AUDIT_EVENTS;
 const auditLog: AuditEvent[] = [];
 let eventIdCounter = 0;
 
+const MAX_AUDIT_PAYLOAD_BYTES = 4 * 1024;
+const MAX_AUDIT_PREVIEW_BYTES = 1_024;
+
 function generateId(): string {
   eventIdCounter += 1;
   return `audit-${Date.now()}-${eventIdCounter}`;
@@ -78,6 +81,35 @@ function evict(): void {
   if (auditLog.length > maxEvents) {
     auditLog.splice(0, auditLog.length - maxEvents);
   }
+}
+
+function sanitizeAuditPayload(
+  payload?: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!payload) {
+    return {};
+  }
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(payload);
+  } catch {
+    return {
+      __truncated: true,
+      __reason: 'audit payload could not be serialized',
+    };
+  }
+
+  if (serialized.length <= MAX_AUDIT_PAYLOAD_BYTES) {
+    return payload;
+  }
+
+  return {
+    __truncated: true,
+    __reason: 'audit payload exceeded maximum size',
+    __originalSizeBytes: serialized.length,
+    preview: serialized.slice(0, MAX_AUDIT_PREVIEW_BYTES),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -95,7 +127,7 @@ export function emitAccountAuditEvent(
     type,
     userId,
     timestamp: new Date().toISOString(),
-    metadata,
+    metadata: sanitizeAuditPayload(metadata),
   };
 
   auditLog.push(event);
@@ -187,7 +219,7 @@ export function emitAdminAuditEvent(
     timestamp: new Date().toISOString(),
     action,
     actorId,
-    context,
+    context: sanitizeAuditPayload(context),
   };
 
   process.stdout.write(JSON.stringify(event) + '\n');


### PR DESCRIPTION
# Add audit payload size validation before storing audit details

## Summary
This PR adds a size guard for audit payloads before they are stored so oversized metadata is sanitized instead of being written verbatim.

## What changed
- Added payload sanitization at the audit write boundary in the audit module.
- Oversized payloads are now transformed into a compact, truncated record containing:
  - a truncation flag
  - the reason
  - the original serialized size
  - a preview snippet
- Added a regression test covering an oversized metadata object to ensure it is not stored as-is.

## Verification
I verified the implementation by inspecting the new sanitization path in the audit writer and by adding a regression test for oversized metadata.

Closes: #1170