### PR TITLE
feat: add max entries cap to NonceStore with eviction

### DIFF
--- a/lib/webhooks/verify.test.ts
+++ b/lib/webhooks/verify.test.ts
@@ -197,3 +197,73 @@ describe("NonceStore", () => {
     expect(store.has("recent-nonce")).toBe(true);
   });
 });
+
+describe("NonceStore maximum entries cap", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("evicts oldest entry when exceeding maxEntries", () => {
+    const store = new NonceStore(DEFAULT_TOLERANCE_MS, 5);
+
+    // Add 6 entries with sequential timestamps
+    const now = Date.now();
+    for (let i = 0; i < 6; i++) {
+      store.add("nonce-" + i, now + i);
+    }
+
+    // The first entry (nonce-0) should be evicted
+    expect(store.has("nonce-0")).toBe(false);
+
+    // Entries 1-5 should still be present
+    for (let i = 1; i < 6; i++) {
+      expect(store.has("nonce-" + i)).toBe(true);
+    }
+
+    // Size must not exceed the cap
+    expect(store.size).toBe(5);
+  });
+
+  it("does not evict when at exactly maxEntries", () => {
+    const store = new NonceStore(DEFAULT_TOLERANCE_MS, 3);
+    const now = Date.now();
+
+    store.add("a", now);
+    store.add("b", now + 1);
+    store.add("c", now + 2);
+
+    expect(store.size).toBe(3);
+    expect(store.has("a")).toBe(true);
+    expect(store.has("b")).toBe(true);
+    expect(store.has("c")).toBe(true);
+  });
+
+  it("evicts oldest-first across multiple overflows", () => {
+    const store = new NonceStore(DEFAULT_TOLERANCE_MS, 3);
+    const now = Date.now();
+
+    // First batch: fill to 3
+    store.add("a", now);
+    store.add("b", now + 1);
+    store.add("c", now + 2);
+
+    // Overflow twice
+    store.add("d", now + 3);
+    store.add("e", now + 4);
+
+    // First two should be gone
+    expect(store.has("a")).toBe(false);
+    expect(store.has("b")).toBe(false);
+
+    // Last three should remain
+    expect(store.has("c")).toBe(true);
+    expect(store.has("d")).toBe(true);
+    expect(store.has("e")).toBe(true);
+    expect(store.size).toBe(3);
+  });
+});

--- a/lib/webhooks/verify.ts
+++ b/lib/webhooks/verify.ts
@@ -5,6 +5,12 @@ import { createHmac, timingSafeEqual } from "crypto";
  */
 export const DEFAULT_TOLERANCE_MS = 5 * 60 * 1000;
 
+/**
+ * Maximum number of distinct nonces tracked within the tolerance window.
+ * Once exceeded, the oldest entry is evicted to bound memory usage.
+ */
+export const NONCE_STORE_MAX_ENTRIES = 10_000;
+
 // ---------------------------------------------------------------------------
 // Signature verification
 // ---------------------------------------------------------------------------
@@ -100,14 +106,25 @@ interface NonceEntry {
 /**
  * In-memory nonce store that tracks recently-seen event nonces to prevent
  * replay attacks. Old entries are automatically pruned when new ones are added.
+ *
+ * The store is bounded by two constraints:
+ * 1. Time-based: entries older than `toleranceMs` are pruned on every operation.
+ * 2. Count-based: if more than `NONCE_STORE_MAX_ENTRIES` distinct nonces
+ *    accumulate within the tolerance window, the oldest entry is evicted
+ *    to prevent unbounded memory growth during traffic spikes or replay floods.
  */
 export class NonceStore {
   private readonly entries: NonceEntry[] = [];
   private readonly seen: Set<string> = new Set();
   private readonly toleranceMs: number;
+  private readonly maxEntries: number;
 
-  constructor(toleranceMs: number = DEFAULT_TOLERANCE_MS) {
+  constructor(
+    toleranceMs: number = DEFAULT_TOLERANCE_MS,
+    maxEntries: number = NONCE_STORE_MAX_ENTRIES,
+  ) {
     this.toleranceMs = toleranceMs;
+    this.maxEntries = maxEntries;
   }
 
   /** Returns `true` if the nonce has already been processed. */
@@ -116,10 +133,17 @@ export class NonceStore {
     return this.seen.has(nonce);
   }
 
-  /** Record a nonce as processed. */
+  /** Record a nonce as processed. Evicts oldest if at max capacity. */
   add(nonce: string, timestamp: number): void {
     this.prune();
     if (!this.seen.has(nonce)) {
+      // Enforce maximum entries cap: evict oldest-first
+      while (this.entries.length >= this.maxEntries) {
+        const evicted = this.entries.shift();
+        if (evicted) {
+          this.seen.delete(evicted.nonce);
+        }
+      }
       this.seen.add(nonce);
       this.entries.push({ nonce, timestamp });
     }


### PR DESCRIPTION
- Added NONCE_STORE_MAX_ENTRIES (10000) constant to bound NonceStore memory
- NonceStore.add() evicts oldest entry when at capacity
- Added tests: eviction at max+1, no eviction at exactly max, oldest-first across multiple overflows
- Updated JSDoc documenting both time-based and count-based bounds
- Closes #1137