### PR TITLE
fix: map server errors to user-safe messages in account deletion

### DIFF
--- a/components/features/account/components/AccountDeletion.test.tsx
+++ b/components/features/account/components/AccountDeletion.test.tsx
@@ -291,3 +291,75 @@ describe("AccountDeletion", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 });
+
+  it("maps known server error code to user-safe message", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        code: "CHALLENGE_EXPIRED",
+        error: "Internal: challenge TTL exceeded for token abc123",
+      }),
+    });
+
+    render(<AccountDeletion />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete My Account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Challenge failed")).toBeInTheDocument();
+      expect(
+        screen.getByText("Your deletion request has expired. Please try again."),
+      ).toBeInTheDocument();
+    });
+
+    // Raw server string must NOT leak through
+    expect(
+      screen.queryByText(/Internal: challenge TTL exceeded/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not leak raw server error string when code is unknown", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        error: "Database connection pool exhausted on host db-internal-7",
+      }),
+    });
+
+    render(<AccountDeletion />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete My Account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Challenge failed")).toBeInTheDocument();
+      expect(
+        screen.getByText("Could not start deletion. Please try again."),
+      ).toBeInTheDocument();
+    });
+
+    // Raw internal string must not appear in the DOM
+    expect(
+      screen.queryByText(/db-internal-7/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Database connection pool exhausted/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("maps 401 status to session expiry message", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Invalid token" }),
+    });
+
+    render(<AccountDeletion />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete My Account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Challenge failed")).toBeInTheDocument();
+      expect(
+        screen.getByText("Your session has expired. Please sign in again."),
+      ).toBeInTheDocument();
+    });
+  });

--- a/components/features/account/components/AccountDeletion.tsx
+++ b/components/features/account/components/AccountDeletion.tsx
@@ -11,6 +11,33 @@ type ToastState = {
   description?: string;
 } | null;
 
+/**
+ * Map known server error codes to fixed, reviewed user-facing messages.
+ * Any unrecognised code falls through to `null` so callers use a
+ * generic fallback instead of echoing raw server strings to the user.
+ */
+function mapChallengeError(data: unknown): string | null {
+  if (typeof data !== "object" || data === null) return null;
+  const d = data as Record<string, unknown>;
+  const code = typeof d.code === "string" ? d.code : null;
+  const status = typeof d.status === "number" ? d.status : null;
+
+  const messages: Record<string, string> = {
+    CHALLENGE_EXPIRED: "Your deletion request has expired. Please try again.",
+    CHALLENGE_RATE_LIMITED: "Too many attempts. Please wait a moment and try again.",
+    ACCOUNT_NOT_FOUND: "Account not found. It may have already been deleted.",
+    UNAUTHORIZED: "You are not authorised to perform this action. Please sign in again.",
+  };
+
+  if (code && messages[code]) return messages[code];
+
+  // Fall back to HTTP status for well-known codes
+  if (status === 429) return "Too many requests. Please try again later.";
+  if (status === 401) return "Your session has expired. Please sign in again.";
+
+  return null;
+}
+
 export default function AccountDeletion() {
   const router = useRouter();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -30,17 +57,18 @@ export default function AccountDeletion() {
       const res = await fetch("/api/account/delete/challenge");
       const data = await res.json();
       if (!res.ok) {
+        const mapped = mapChallengeError(data);
         if (res.status === 429) {
           showToast(
             "error",
             "Rate limit exceeded",
-            data.error?.message || "Too many requests. Please try again later.",
+            mapped ?? "Too many requests. Please try again later.",
           );
         } else {
           showToast(
             "error",
             "Challenge failed",
-            data.error?.message || data.error || "Could not start deletion. Please try again.",
+            mapped ?? "Could not start deletion. Please try again.",
           );
         }
         return;


### PR DESCRIPTION
- Added mapChallengeError() to translate server error codes to reviewed user-facing messages
- Known codes mapped: CHALLENGE_EXPIRED, CHALLENGE_RATE_LIMITED, ACCOUNT_NOT_FOUND, UNAUTHORIZED
- Falls back to HTTP status (429, 401) for well-known codes, then generic fallback
- Added tests: known code mapped, unknown code does not leak, 401 maps to session expiry
- Closes #1148