### PR TITLE
refactor: use shared explorer utility in TransactionReceipt and add verification test

### DIFF
--- a/components/features/dashboard/components/TransactionReceipt.test.tsx
+++ b/components/features/dashboard/components/TransactionReceipt.test.tsx
@@ -8,6 +8,19 @@ import {
 import TransactionReceipt from "./TransactionReceipt";
 import type { Transaction } from "@/types/Transaction";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { buildStellarExpertTransactionUrl } from "@/lib/utils/explorer";
+
+// Mock lib/config so the explorer link test has a deterministic network
+vi.mock("@/lib/config", () => ({
+  default: {
+    stellar: { network: "testnet" },
+    app: { name: "Stellarlend", version: "1.0.0", environment: "test" },
+    api: { baseUrl: "http://localhost:3001", timeout: 10000 },
+    rateLimit: { max: 100, window: 60000, account: { limit: 30, windowMs: 60000, burst: 60 } },
+    analytics: {},
+    logging: { level: "debug" },
+  },
+}));
 
 // Mock next/image so JSDOM does not need the Next.js runtime/config.
 vi.mock("next/image", () => ({
@@ -584,6 +597,45 @@ describe("TransactionReceipt Component", () => {
       // Should only contain receipt-related content, no nav/header/footer from main app
       expect(container.querySelector("nav")).not.toBeInTheDocument();
       expect(container.querySelector("header")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Explorer Link Integration with Shared Utility", () => {
+    it("renders explorer link matching buildStellarExpertTransactionUrl when constructed locally", () => {
+      const txHash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd";
+      const expectedUrl = buildStellarExpertTransactionUrl(txHash, "TESTNET");
+
+      render(
+        <TransactionReceipt
+          transaction={buildTransaction({ id: txHash })}
+        />,
+      );
+
+      const link = screen.getByText("View on Stellar Expert");
+      expect(link).toHaveAttribute("href", expectedUrl);
+    });
+
+    it("uses details.explorerUrl when provided instead of constructing locally", () => {
+      const customUrl = "https://stellar.explorer.custom/tx/custom123";
+      render(
+        <TransactionReceipt
+          transaction={buildTransaction({ id: "a".repeat(64) })}
+          details={{ explorerUrl: customUrl }}
+        />,
+      );
+
+      const link = screen.getByText("View on Stellar Expert");
+      expect(link).toHaveAttribute("href", customUrl);
+    });
+
+    it("does not render explorer link for non-hash transaction ids", () => {
+      render(
+        <TransactionReceipt
+          transaction={buildTransaction({ id: "TXN-001" })}
+        />,
+      );
+
+      expect(screen.queryByText("View on Stellar Expert")).not.toBeInTheDocument();
     });
   });
 });

--- a/components/features/dashboard/components/TransactionReceipt.tsx
+++ b/components/features/dashboard/components/TransactionReceipt.tsx
@@ -4,7 +4,8 @@ import { Printer, ArrowLeft } from "lucide-react";
 import Image from "next/image";
 import type { Transaction } from "@/types/Transaction";
 import { sanitiseString } from "@/lib/security/input-sanitizer";
-import { isValidTxHash } from "@/lib/validation/stellar";
+import type { StellarNetwork } from "@/lib/wallet/connectHandshake";
+import { getTransactionHash, buildStellarExpertTransactionUrl } from "@/lib/utils/explorer";
 import config from "@/lib/config";
 
 interface TransactionReceiptProps {
@@ -59,20 +60,18 @@ export default function TransactionReceipt({ transaction, details, onBack }: Tra
     return `${datePart} ${timePart}`;
   };
 
-  const getExplorerLink = () => {
-    if (!id || !isValidTxHash(id)) {
+  const explorerLink = (() => {
+    if (details?.explorerUrl) {
+      return details.explorerUrl;
+    }
+    const hash = getTransactionHash(transaction);
+    if (!hash) {
       return null;
     }
-    const net = config.stellar.network.toLowerCase() === 'public' || config.stellar.network.toLowerCase() === 'mainnet' ? 'public' : 'testnet';
-    const baseUrl = `https://stellar.expert/explorer/${net}/tx/`;
-    
-    // Ensure base URL starts with a safe https protocol and allowlisted domain
-    if (!baseUrl.startsWith("https://stellar.expert/")) {
-      return null;
-    }
-    
-    return `${baseUrl}${id}`;
-  };
+    const isMainnet = config.stellar.network.toLowerCase() === 'public' || config.stellar.network.toLowerCase() === 'mainnet';
+    const network: StellarNetwork = isMainnet ? 'PUBLIC' : 'TESTNET';
+    return buildStellarExpertTransactionUrl(hash, network);
+  })();
 
   return (
     <>
@@ -221,11 +220,11 @@ export default function TransactionReceipt({ transaction, details, onBack }: Tra
               </div>
             )}
 
-            {getExplorerLink() && (
+            {explorerLink && (
               <div className="grid grid-cols-2 gap-4 py-3 border-b border-gray-200">
                 <span className="font-semibold text-gray-700">Blockchain Explorer:</span>
                 <a
-                  href={getExplorerLink() || undefined}
+                  href={explorerLink}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-blue-600 hover:underline break-all text-sm no-print"
@@ -233,7 +232,7 @@ export default function TransactionReceipt({ transaction, details, onBack }: Tra
                   View on Stellar Expert
                 </a>
                 <span className="hidden print:inline text-gray-900 break-all text-sm">
-                  {getExplorerLink()}
+                  {explorerLink}
                 </span>
               </div>
             )}


### PR DESCRIPTION
## Description

The \TransactionReceipt\ component had its own inline \getExplorerLink()\ function that duplicated the URL-building logic already available in \lib/utils/explorer.ts\ (via \getTransactionHash()\ and \uildStellarExpertTransactionUrl()\). This introduced a risk of URL format divergence. Additionally, the optional \details.explorerUrl\ prop was not being used.

## Changes

- Replaced the inline \getExplorerLink()\ with calls to the shared \getTransactionHash()\ and \uildStellarExpertTransactionUrl()\ utilities.
- When \details.explorerUrl\ is provided, it is used directly instead of constructing a URL from the transaction hash.
- Removed the now-unused \isValidTxHash\ import.
- Added tests:
  - The local explorer link matches \uildStellarExpertTransactionUrl\ output for the same hash.
  - \details.explorerUrl\ is preferred when provided.
  - Non-hash transaction IDs do not render an explorer link.

Closes #1145