### PR TITLE
fix: wire onClick navigation to /lending for Hero.tsx and Navbar.tsx CTA buttons

### DIFF
--- a/components/marketing/Hero.tsx
+++ b/components/marketing/Hero.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { ChevronRight } from "lucide-react";
 import Button from "@/components/shared/ui/Button";
 import Image from "next/image";
@@ -10,6 +11,7 @@ import MobileHeroImage from "@/public/images/heromobile.png";
 import { motion, Variants } from "framer-motion";
 
 export default function Hero() {
+  const router = useRouter();
   // Animation variants
   const containerVariants: Variants = {
     hidden: { opacity: 0 },
@@ -82,6 +84,7 @@ export default function Hero() {
             <motion.div variants={itemVariants}>
               <Button
                 text="Launch App"
+                onClick={() => router.push("/lending")}
                 className="bg-[#15A350] 
                 text-[#F8F8F8] text-xs md:text-sm font-medium rounded-lg 
                 flex items-center py-2 sm:py-3 px-4 sm:px-6 cursor-pointer"
@@ -91,6 +94,7 @@ export default function Hero() {
             <motion.div variants={itemVariants}>
               <Button
                 text="Sign Up"
+                onClick={() => router.push("/lending")}
                 className="border border-[#15A350] text-[#15A350] 
                 text-xs md:text-sm font-medium rounded-lg 
                 flex items-center py-2 sm:py-3 px-4 sm:px-6 cursor-pointer

--- a/components/shared/layout/Navbar.tsx
+++ b/components/shared/layout/Navbar.tsx
@@ -2,10 +2,12 @@
 
 import { X, Menu } from "lucide-react";
 import React, { useState } from "react";
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 import NavLink from "./NavLink";
 
 const Header = () => {
+  const router = useRouter();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
@@ -24,10 +26,16 @@ const Header = () => {
           </div>
 
           <div className="hidden md:flex text-white space-x-4">
-            <button className="px-3 py-2 rounded-sm hover:border hover:border-[#15A350] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2 focus-visible:ring-offset-black">
+            <button
+              onClick={() => router.push("/lending")}
+              className="px-3 py-2 rounded-sm hover:border hover:border-[#15A350] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            >
               Launch app
             </button>
-            <button className="bg-[#15A350] text-white px-3 py-2 rounded-sm hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2 focus-visible:ring-offset-black">
+            <button
+              onClick={() => router.push("/lending")}
+              className="bg-[#15A350] text-white px-3 py-2 rounded-sm hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            >
               Sign Up
             </button>
           </div>
@@ -50,10 +58,16 @@ const Header = () => {
             <NavLink href="#features">Features</NavLink>
             <NavLink href="#testimonials">Testimonials</NavLink>
             <div className="flex flex-col w-fit text-white space-y-4">
-              <button className="px-3 py-2 rounded-sm hover:border hover:border-[#15A350] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2 focus-visible:ring-offset-black">
+              <button
+                onClick={() => router.push("/lending")}
+                className="px-3 py-2 rounded-sm hover:border hover:border-[#15A350] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
                 Launch app
               </button>
-              <button className="bg-[#15A350] text-white px-3 py-2 rounded-sm hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2 focus-visible:ring-offset-black">
+              <button
+                onClick={() => router.push("/lending")}
+                className="bg-[#15A350] text-white px-3 py-2 rounded-sm hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#15A350] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
                 Sign Up
               </button>
             </div>


### PR DESCRIPTION
## Description

Both `Hero.tsx` and `Navbar.tsx` rendered "Launch App" and "Sign Up" buttons without any `onClick` handler, making them non-functional despite being the primary call-to-action on the landing page.

## Changes

- Added `useRouter` from `next/navigation` to both components.
- Wired `onClick={() => router.push("/lending")}` on all four button instances (2 in Hero.tsx, 2 in Navbar.tsx desktop, 2 in Navbar.tsx mobile).
- The destination `/lending` matches the established CTA pattern used by `ExploreFeatures.tsx` and `HowItWorks.tsx`.

Closes #1151
