### PR TITLE
fix(#1106,#1111,#1113): add grouping tests, fix PriceTicker landmark,…

### DIFF
--- a/app/api/tx/build/route.ts
+++ b/app/api/tx/build/route.ts
@@ -15,6 +15,10 @@ import {
   extractUnsignedXdr,
   isTxBuildRequest,
 } from '@/lib/soroban/tx';
+import {
+  isSorobanRpcErrorResponse,
+  type SorobanRpcResponse,
+} from '@/lib/soroban/types';
 
 export const runtime = 'nodejs';
 
@@ -96,18 +100,18 @@ export async function POST(request: NextRequest) {
   );
 
   try {
-    const rpcResponse = await httpPost<unknown>(serverConfig.stellar.sorobanRpcUrl, payload, {
+    const rpcResponse: SorobanRpcResponse = await httpPost<SorobanRpcResponse>(serverConfig.stellar.sorobanRpcUrl, payload, {
       timeoutMs: 10000,
     });
 
-    if (typeof rpcResponse === 'object' && rpcResponse && 'error' in rpcResponse) {
+    if (isSorobanRpcErrorResponse(rpcResponse)) {
       return NextResponse.json(
-        { error: buildSorobanRpcError((rpcResponse as any).error) },
+        { error: buildSorobanRpcError(rpcResponse.error) },
         { status: 502 },
       );
     }
 
-    const unsignedXdr = extractUnsignedXdr((rpcResponse as any).result ?? rpcResponse);
+    const unsignedXdr = extractUnsignedXdr(rpcResponse.result);
     if (!unsignedXdr) {
       return rpcFailure();
     }

--- a/components/shared/common/PriceTicker.test.tsx
+++ b/components/shared/common/PriceTicker.test.tsx
@@ -185,11 +185,11 @@ describe("PriceTicker", () => {
 
     const { container } = render(<PriceTicker />);
 
-    const nav = container.querySelector("nav");
-    expect(nav?.className).not.toContain("transition-opacity");
+    const ticker = container.querySelector('[role="marquee"]');
+    expect(ticker?.className).not.toContain("transition-opacity");
   });
 
-  it("has accessible aria-label on nav element", () => {
+  it("has accessible aria-label on marquee element", () => {
     const mockPrices = createMockPrices([
       [
         "XLM",
@@ -209,8 +209,8 @@ describe("PriceTicker", () => {
 
     render(<PriceTicker />);
 
-    const nav = screen.getByRole("navigation", { name: "Live market prices" });
-    expect(nav).toBeInTheDocument();
+    const ticker = screen.getByRole("marquee", { name: "Live market prices" });
+    expect(ticker).toBeInTheDocument();
   });
 
   it("has aria-labels on individual price items describing symbol and price", () => {
@@ -282,5 +282,63 @@ describe("PriceTicker", () => {
     const symbolTexts = Array.from(symbols).map((s) => s.textContent);
 
     expect(symbolTexts).toEqual(["ETH", "XLM"]);
+  });
+});
+
+describe("PriceTicker accessibility", () => {
+  beforeEach(() => {
+    mockUseReducedMotion.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not expose a navigation landmark", () => {
+    const mockPrices = createMockPrices([
+      [
+        "XLM",
+        {
+          symbol: "XLM",
+          price: 0.1245,
+          direction: "up",
+          timestamp: "2026-06-28T10:00:00.000Z",
+        },
+      ],
+    ]);
+
+    mockUsePriceStream.mockReturnValue({
+      prices: mockPrices,
+      isLoading: false,
+    });
+
+    render(<PriceTicker />);
+
+    const navElements = screen.queryAllByRole("navigation");
+    expect(navElements).toHaveLength(0);
+  });
+
+  it("uses role marquee for the price list container", () => {
+    const mockPrices = createMockPrices([
+      [
+        "BTC",
+        {
+          symbol: "BTC",
+          price: 65000,
+          direction: "down",
+          timestamp: "2026-06-28T10:00:00.000Z",
+        },
+      ],
+    ]);
+
+    mockUsePriceStream.mockReturnValue({
+      prices: mockPrices,
+      isLoading: false,
+    });
+
+    render(<PriceTicker />);
+
+    const ticker = screen.getByRole("marquee");
+    expect(ticker).toHaveAttribute("aria-label", "Live market prices");
   });
 });

--- a/components/shared/common/PriceTicker.tsx
+++ b/components/shared/common/PriceTicker.tsx
@@ -97,7 +97,8 @@ export const PriceTicker: React.FC<PriceTickerProps> = ({ className }) => {
   }
 
   return (
-    <nav
+    <div
+      role="marquee"
       className={cn(
         "flex flex-wrap items-center gap-x-6 gap-y-2 text-sm",
         prefersReducedMotion ? "" : "transition-opacity duration-300",
@@ -116,7 +117,7 @@ export const PriceTicker: React.FC<PriceTickerProps> = ({ className }) => {
           <DirectionIndicator direction={data.direction} />
         </div>
       ))}
-    </nav>
+    </div>
   );
 };
 

--- a/lib/notifications/grouping.test.ts
+++ b/lib/notifications/grouping.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Notification } from './types';
+import {
+  getDateGroup,
+  getDateGroupLabel,
+  groupNotifications,
+  sortGroupedNotifications,
+  type DateGroup,
+  type GroupedNotifications,
+} from './grouping';
+
+function makeNotification(overrides: Partial<Notification> & { createdAt: string }): Notification {
+  return {
+    id: overrides.id ?? `n-${Math.random().toString(36).slice(2, 8)}`,
+    userId: overrides.userId ?? 'user-1',
+    title: overrides.title ?? 'Test',
+    message: overrides.message ?? 'Test message',
+    read: overrides.read ?? false,
+    pinned: overrides.pinned,
+    createdAt: overrides.createdAt,
+    type: overrides.type ?? 'info',
+  };
+}
+
+function daysAgo(n: number, date: Date = new Date()): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() - n);
+  return d;
+}
+
+function startOfToday(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function getStartOfWeek(now: Date): Date {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  return d;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('getDateGroup', () => {
+  it('classifies a timestamp at exactly midnight (start of today) as today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-15T12:00:00Z'));
+
+    const startOfDay = new Date('2025-07-15T00:00:00Z');
+    expect(getDateGroup(startOfDay)).toBe('today');
+  });
+
+  it('classifies a timestamp one millisecond before midnight as older (not today)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-15T00:00:00Z'));
+
+    const justBeforeMidnight = new Date('2025-07-14T23:59:59.999Z');
+    // It's before startOfToday but should still be within the week
+    const group = getDateGroup(justBeforeMidnight);
+    expect(group).not.toBe('today');
+    expect(group).toBe('earlier_this_week');
+  });
+
+  it('classifies a notification from earlier this week as earlier_this_week', () => {
+    vi.useFakeTimers();
+    // Wednesday 2025-07-16 12:00 UTC — start of week is Monday 2025-07-14
+    vi.setSystemTime(new Date('2025-07-16T12:00:00Z'));
+
+    // Tuesday is within the week
+    const tuesday = new Date('2025-07-15T10:00:00Z');
+    expect(getDateGroup(tuesday)).toBe('earlier_this_week');
+  });
+
+  it('classifies a notification from before the week boundary as older', () => {
+    vi.useFakeTimers();
+    // Monday 2025-07-14 00:00 UTC — start of week is Monday 2025-07-14
+    vi.setSystemTime(new Date('2025-07-14T00:00:00Z'));
+
+    // Sunday before is the previous week
+    const sunday = new Date('2025-07-13T23:59:59Z');
+    expect(getDateGroup(sunday)).toBe('older');
+  });
+
+  it('handles Sunday correctly — Sunday is not part of the current Mon–Sun week start', () => {
+    vi.useFakeTimers();
+    // Saturday 2025-07-19 12:00 UTC — start of week is Monday 2025-07-14
+    vi.setSystemTime(new Date('2025-07-19T12:00:00Z'));
+
+    // Previous Sunday 2025-07-13 is before the Monday start, so "older"
+    const prevSunday = new Date('2025-07-13T12:00:00Z');
+    expect(getDateGroup(prevSunday)).toBe('older');
+  });
+
+  it('classifies "now" as today', () => {
+    vi.useFakeTimers();
+    const now = new Date('2025-09-01T15:30:00Z');
+    vi.setSystemTime(now);
+
+    expect(getDateGroup(new Date(now))).toBe('today');
+  });
+
+  it('classifies a date far in the past as older', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-15T12:00:00Z'));
+
+    const ancient = new Date('2020-01-01T00:00:00Z');
+    expect(getDateGroup(ancient)).toBe('older');
+  });
+
+  it('boundary: date exactly at startOfWeek is earlier_this_week, one ms before is older', () => {
+    vi.useFakeTimers();
+    // Wednesday 2025-07-16 → week starts Monday 2025-07-14
+    vi.setSystemTime(new Date('2025-07-16T12:00:00Z'));
+
+    const startOfWeek = getStartOfWeek(new Date('2025-07-16T12:00:00Z'));
+    expect(startOfWeek.toISOString()).toBe('2025-07-14T00:00:00.000Z');
+
+    expect(getDateGroup(startOfWeek)).toBe('earlier_this_week');
+
+    const oneMsBefore = new Date(startOfWeek.getTime() - 1);
+    expect(getDateGroup(oneMsBefore)).toBe('older');
+  });
+});
+
+describe('getDateGroupLabel', () => {
+  it('returns correct labels for all groups', () => {
+    expect(getDateGroupLabel('today')).toBe('Today');
+    expect(getDateGroupLabel('earlier_this_week')).toBe('Earlier this week');
+    expect(getDateGroupLabel('older')).toBe('Older');
+  });
+});
+
+describe('groupNotifications', () => {
+  it('places pinned notifications in the pinned group regardless of their date', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-15T12:00:00Z'));
+
+    const oldNotification = makeNotification({
+      id: 'old-pinned',
+      createdAt: '2020-01-01T00:00:00Z',
+      pinned: true,
+    });
+    const todayNotification = makeNotification({
+      id: 'today-unpinned',
+      createdAt: '2025-07-15T10:00:00Z',
+    });
+
+    const pinnedIds = new Set(['old-pinned']);
+    const grouped = groupNotifications([oldNotification, todayNotification], pinnedIds);
+
+    expect(grouped.pinned).toHaveLength(1);
+    expect(grouped.pinned[0].id).toBe('old-pinned');
+    expect(grouped.today).toHaveLength(1);
+    expect(grouped.today[0].id).toBe('today-unpinned');
+    expect(grouped.older).toHaveLength(0);
+  });
+
+  it('places unpinned notifications into the correct date bucket', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-16T12:00:00Z'));
+    // Week starts Monday 2025-07-14
+
+    const today = makeNotification({ id: 't', createdAt: '2025-07-16T08:00:00Z' });
+    const thisWeek = makeNotification({ id: 'w', createdAt: '2025-07-15T08:00:00Z' });
+    const older = makeNotification({ id: 'o', createdAt: '2025-07-12T08:00:00Z' });
+
+    const grouped = groupNotifications([today, thisWeek, older], new Set());
+
+    expect(grouped.pinned).toHaveLength(0);
+    expect(grouped.today).toHaveLength(1);
+    expect(grouped.today[0].id).toBe('t');
+    expect(grouped.earlier_this_week).toHaveLength(1);
+    expect(grouped.earlier_this_week[0].id).toBe('w');
+    expect(grouped.older).toHaveLength(1);
+    expect(grouped.older[0].id).toBe('o');
+  });
+
+  it('returns empty groups when given an empty array', () => {
+    const grouped = groupNotifications([], new Set());
+    expect(grouped.pinned).toHaveLength(0);
+    expect(grouped.today).toHaveLength(0);
+    expect(grouped.earlier_this_week).toHaveLength(0);
+    expect(grouped.older).toHaveLength(0);
+  });
+
+  it('handles an empty pinnedIds set', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-15T12:00:00Z'));
+
+    const n = makeNotification({ createdAt: '2025-07-15T10:00:00Z' });
+    const grouped = groupNotifications([n], new Set());
+    expect(grouped.pinned).toHaveLength(0);
+    expect(grouped.today).toHaveLength(1);
+  });
+});
+
+describe('sortGroupedNotifications', () => {
+  it('sorts each group in descending order by createdAt', () => {
+    const grouped: GroupedNotifications = {
+      pinned: [
+        makeNotification({ id: 'p1', createdAt: '2025-07-10T00:00:00Z' }),
+        makeNotification({ id: 'p2', createdAt: '2025-07-15T00:00:00Z' }),
+        makeNotification({ id: 'p3', createdAt: '2025-07-12T00:00:00Z' }),
+      ],
+      today: [
+        makeNotification({ id: 't1', createdAt: '2025-07-15T06:00:00Z' }),
+        makeNotification({ id: 't2', createdAt: '2025-07-15T12:00:00Z' }),
+      ],
+      earlier_this_week: [
+        makeNotification({ id: 'w1', createdAt: '2025-07-14T08:00:00Z' }),
+        makeNotification({ id: 'w2', createdAt: '2025-07-15T02:00:00Z' }),
+      ],
+      older: [
+        makeNotification({ id: 'o1', createdAt: '2025-07-01T00:00:00Z' }),
+        makeNotification({ id: 'o2', createdAt: '2025-06-01T00:00:00Z' }),
+      ],
+    };
+
+    sortGroupedNotifications(grouped);
+
+    expect(grouped.pinned.map((n) => n.id)).toEqual(['p2', 'p3', 'p1']);
+    expect(grouped.today.map((n) => n.id)).toEqual(['t2', 't1']);
+    expect(grouped.earlier_this_week.map((n) => n.id)).toEqual(['w2', 'w1']);
+    expect(grouped.older.map((n) => n.id)).toEqual(['o1', 'o2']);
+  });
+
+  it('mutates the object in place and returns nothing', () => {
+    const grouped: GroupedNotifications = {
+      pinned: [
+        makeNotification({ id: 'a', createdAt: '2025-01-01T00:00:00Z' }),
+        makeNotification({ id: 'b', createdAt: '2025-06-01T00:00:00Z' }),
+      ],
+      today: [],
+      earlier_this_week: [],
+      older: [],
+    };
+
+    const result = sortGroupedNotifications(grouped);
+    expect(result).toBeUndefined();
+    expect(grouped.pinned[0].id).toBe('b');
+    expect(grouped.pinned[1].id).toBe('a');
+  });
+
+  it('handles empty groups without error', () => {
+    const grouped: GroupedNotifications = {
+      pinned: [],
+      today: [],
+      earlier_this_week: [],
+      older: [],
+    };
+
+    expect(() => sortGroupedNotifications(grouped)).not.toThrow();
+  });
+});

--- a/lib/soroban/tx.ts
+++ b/lib/soroban/tx.ts
@@ -1,10 +1,7 @@
 import type { LendingData } from '@/lib/lending/types';
+import type { SorobanRpcError } from './types';
 
-export type SorobanRpcError = {
-  code: number | string;
-  message: string;
-  data?: unknown;
-};
+export type { SorobanRpcError };
 
 export type SorobanRpcBuildResult = {
   transaction?: string;

--- a/lib/soroban/types.test.ts
+++ b/lib/soroban/types.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSorobanRpcErrorResponse,
+  isSorobanRpcSuccessResponse,
+  type SorobanRpcResponse,
+} from './types';
+import { extractUnsignedXdr } from './tx';
+
+describe('SorobanRpcResponse type guards', () => {
+  describe('isSorobanRpcErrorResponse', () => {
+    it('returns true for a valid error response', () => {
+      const response: SorobanRpcResponse = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: { code: -32000, message: 'Transaction failed' },
+      };
+      expect(isSorobanRpcErrorResponse(response)).toBe(true);
+    });
+
+    it('returns false for a valid success response', () => {
+      const response: SorobanRpcResponse = {
+        jsonrpc: '2.0',
+        id: '1',
+        result: { transaction: 'AAAA...' },
+      };
+      expect(isSorobanRpcErrorResponse(response)).toBe(false);
+    });
+
+    it('returns false for non-object values', () => {
+      expect(isSorobanRpcErrorResponse(null)).toBe(false);
+      expect(isSorobanRpcErrorResponse(undefined)).toBe(false);
+      expect(isSorobanRpcErrorResponse('string')).toBe(false);
+      expect(isSorobanRpcErrorResponse(42)).toBe(false);
+    });
+
+    it('returns false for objects with error set to null', () => {
+      expect(isSorobanRpcErrorResponse({ error: null })).toBe(false);
+    });
+  });
+
+  describe('isSorobanRpcSuccessResponse', () => {
+    it('returns true for a valid success response', () => {
+      const response: SorobanRpcResponse = {
+        jsonrpc: '2.0',
+        id: '1',
+        result: { transaction: 'AAAA...' },
+      };
+      expect(isSorobanRpcSuccessResponse(response)).toBe(true);
+    });
+
+    it('returns false for a valid error response', () => {
+      const response: SorobanRpcResponse = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: { code: -32000, message: 'Transaction failed' },
+      };
+      expect(isSorobanRpcSuccessResponse(response)).toBe(false);
+    });
+
+    it('returns false for non-object values', () => {
+      expect(isSorobanRpcSuccessResponse(null)).toBe(false);
+      expect(isSorobanRpcSuccessResponse(undefined)).toBe(false);
+    });
+  });
+});
+
+describe('Soroban RPC response handling consistency', () => {
+  const errorResponseFixture: SorobanRpcResponse = {
+    jsonrpc: '2.0',
+    id: 'test-1',
+    error: { code: -32600, message: 'Invalid request', data: { extra: 'details' } },
+  };
+
+  const successResponseFixture: SorobanRpcResponse = {
+    jsonrpc: '2.0',
+    id: 'test-2',
+    result: { transaction: 'AAAAAG15dXNy...', transaction_xdr: 'AAAAAG15dXNy...' },
+  };
+
+  it('isSorobanRpcErrorResponse correctly discriminates the error fixture', () => {
+    expect(isSorobanRpcErrorResponse(errorResponseFixture)).toBe(true);
+    expect(isSorobanRpcSuccessResponse(errorResponseFixture)).toBe(false);
+  });
+
+  it('isSorobanRpcSuccessResponse correctly discriminates the success fixture', () => {
+    expect(isSorobanRpcSuccessResponse(successResponseFixture)).toBe(true);
+    expect(isSorobanRpcErrorResponse(successResponseFixture)).toBe(false);
+  });
+
+  it('both type guards agree on a malformed response (neither matches)', () => {
+    const malformed = { jsonrpc: '2.0', id: 'x' } as SorobanRpcResponse;
+    expect(isSorobanRpcErrorResponse(malformed)).toBe(false);
+    expect(isSorobanRpcSuccessResponse(malformed)).toBe(false);
+  });
+
+  it('extractUnsignedXdr works with the success result from the shared response type', () => {
+    const xdr = extractUnsignedXdr(successResponseFixture.result);
+    expect(xdr).toBe('AAAAAG15dXNy...');
+  });
+});

--- a/lib/soroban/types.ts
+++ b/lib/soroban/types.ts
@@ -1,0 +1,44 @@
+export interface SorobanRpcError {
+  code: number | string;
+  message: string;
+  data?: unknown;
+}
+
+export interface SorobanRpcSuccessResponse {
+  jsonrpc: '2.0';
+  id: string;
+  result: unknown;
+  error?: never;
+}
+
+export interface SorobanRpcErrorResponse {
+  jsonrpc: '2.0';
+  id: string;
+  error: SorobanRpcError;
+  result?: never;
+}
+
+export type SorobanRpcResponse = SorobanRpcSuccessResponse | SorobanRpcErrorResponse;
+
+export function isSorobanRpcErrorResponse(
+  response: unknown,
+): response is SorobanRpcErrorResponse {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    'error' in response &&
+    typeof (response as Record<string, unknown>).error === 'object' &&
+    (response as Record<string, unknown>).error !== null
+  );
+}
+
+export function isSorobanRpcSuccessResponse(
+  response: unknown,
+): response is SorobanRpcSuccessResponse {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    'result' in response &&
+    !('error' in response && (response as Record<string, unknown>).error != null)
+  );
+}


### PR DESCRIPTION
Changes


Closes #1106 — Add unit tests for notification grouping date-bucketing
- New file: lib/notifications/grouping.test.ts
- Tests getDateGroup at exact day/week boundaries (midnight edge, start-of-week 1ms precision)
- Tests Sunday handling (day === 0 ? -6 : 1 - day normalization)
- Tests pinned notifications go to the pinned group regardless of date
- Tests sortGroupedNotifications sorts each group descending by createdAt
- Uses vi.useFakeTimers() for deterministic date bucketing
Closes #1111 — Fix PriceTicker landmark role
- Modified: components/shared/common/PriceTicker.tsx — Changed <nav> → <div role="marquee">, preserving aria-label
- Modified: components/shared/common/PriceTicker.test.tsx — Updated existing tests to target role="marquee", added tests asserting no navigation landmark is exposed
Closes #1113 — Shared Soroban RPC response type
- New file: lib/soroban/types.ts — Defines SorobanRpcResponse discriminated union + type guards
- Modified: lib/soroban/tx.ts — SorobanRpcError now imported from ./types (re-exported for backwards compat)
- Modified: app/api/tx/build/route.ts — Replaced as any casts with typed type guards
- New file: lib/soroban/types.test.ts — Tests type guards and cross-site consistency