### PR TITLE
fix: rename FastSecure icon to FastSecureIcon; fix MarketsCardSkeleto…

### DIFF
--- a/components/features/lending/components/MarketsTable.test.tsx
+++ b/components/features/lending/components/MarketsTable.test.tsx
@@ -483,4 +483,62 @@ describe("MarketsTable", () => {
       ).toBeInTheDocument();
     });
   });
+
+  describe("skeleton loading accessibility", () => {
+    it("desktop skeleton exposes aria-busy and aria-label on the table element", () => {
+      vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+      render(<MarketsTable />);
+
+      // The <table> inside MarketsTableSkeleton carries aria-busy="true"
+      const table = screen.getByRole("table");
+      expect(table).toHaveAttribute("aria-busy", "true");
+
+      // The wrapping div carries aria-label="Loading markets"
+      expect(
+        screen.getByLabelText("Loading markets"),
+      ).toBeInTheDocument();
+    });
+
+    it("mobile skeleton exposes the same aria-busy and aria-label as the desktop skeleton", () => {
+      vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+      render(<MarketsTable />);
+
+      // Both skeletons sit inside data-testid="markets-loading"
+      const loadingWrapper = screen.getByTestId("markets-loading");
+
+      // Every element labelled "Loading markets" (desktop wrapper + mobile wrapper)
+      const labelledRegions = within(loadingWrapper).getAllByLabelText(
+        "Loading markets",
+      );
+
+      // At least two: one for the desktop table wrapper, one for the mobile card wrapper
+      expect(labelledRegions.length).toBeGreaterThanOrEqual(2);
+
+      // All of them must advertise aria-busy="true"
+      for (const region of labelledRegions) {
+        expect(region).toHaveAttribute("aria-busy", "true");
+      }
+    });
+
+    it("both skeleton variants have identical loading semantics regardless of viewport", () => {
+      vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+      render(<MarketsTable />);
+
+      const loadingWrapper = screen.getByTestId("markets-loading");
+      const labelledRegions = within(loadingWrapper).getAllByLabelText(
+        "Loading markets",
+      );
+
+      // Collect the unique set of aria-label values — should all be identical
+      const labels = new Set(
+        labelledRegions.map((el) => el.getAttribute("aria-label")),
+      );
+      const busyValues = new Set(
+        labelledRegions.map((el) => el.getAttribute("aria-busy")),
+      );
+
+      expect(labels).toEqual(new Set(["Loading markets"]));
+      expect(busyValues).toEqual(new Set(["true"]));
+    });
+  });
 });

--- a/components/features/lending/components/MarketsTable.tsx
+++ b/components/features/lending/components/MarketsTable.tsx
@@ -295,7 +295,7 @@ function MarketsTableSkeleton() {
 /** Mobile skeleton cards */
 function MarketsCardSkeleton() {
   return (
-    <div className="md:hidden space-y-4">
+    <div className="md:hidden space-y-4" aria-busy="true" aria-label="Loading markets">
       {Array.from({ length: 4 }, (_, i) => (
         <div
           key={i}

--- a/components/shared/ui/icons/FastSecure.tsx
+++ b/components/shared/ui/icons/FastSecure.tsx
@@ -1,14 +1,14 @@
-interface FastSecureProps {
+interface FastSecureIconProps {
   className?: string;
   width?: string | number;
   height?: string | number;
 }
 
-export const FastSecure = ({
+export const FastSecureIcon = ({
   className = "",
   width = "400",
   height = "400",
-}: FastSecureProps) => {
+}: FastSecureIconProps) => {
   return (
     <svg
       className={className}

--- a/components/shared/ui/icons/index.ts
+++ b/components/shared/ui/icons/index.ts
@@ -13,5 +13,5 @@ export { Dollar } from './Dollar';
 export { Dropdown } from './Dropdown';
 export { File } from './File';
 export { Global } from './Global';
-export { FastSecure } from './FastSecure';
+export { FastSecureIcon } from './FastSecure';
 export { IconPlaceholder } from './IconPlaceholder';


### PR DESCRIPTION
## Summary



---

### Closes #1118 — FastSecure icon/section naming collision

**Problem:** `components/shared/ui/icons/FastSecure.tsx` exported a named `FastSecure`
component (an SVG icon) while `components/marketing/FastSecure.tsx` exported a default
`FastSecure` component (the full marketing section). Both lived in the codebase
simultaneously, creating a silent autocomplete trap.

**Fix:**
- Renamed icon export: `FastSecure` → `FastSecureIcon` in the icon file and its barrel.
- No other file imported the old icon name, so there are no broken consumers.

---

### Closes #1133 — MarketsCardSkeleton missing ARIA wiring

**Problem:** `MarketsTableSkeleton` (desktop) carried `aria-busy="true"` and
`aria-label="Loading markets"`. `MarketsCardSkeleton` (mobile) had neither, making the
loading state invisible to screen readers on mobile.

**Fix:**
- Added `aria-busy="true"` and `aria-label="Loading markets"` to the outer `<div>` of
  `MarketsCardSkeleton`.
- Added a `describe("skeleton loading accessibility")` block in `MarketsTable.test.tsx`
  with three tests asserting both variants expose identical loading semantics regardless
  of viewport.

## Files changed

| File | Change |
|---|---|
| `components/shared/ui/icons/FastSecure.tsx` | Rename component + props interface |
| `components/shared/ui/icons/index.ts` | Update barrel re-export |
| `components/features/lending/components/MarketsTable.tsx` | Add ARIA attrs to `MarketsCardSkeleton` |
| `components/features/lending/components/MarketsTable.test.tsx` | Add skeleton a11y tests |

