### PR TITLE
docs: reference lending health thresholds in dashboard banner

### DIFF
--- a/docs/dashboard-alert-banner.md
+++ b/docs/dashboard-alert-banner.md
@@ -4,9 +4,9 @@ This component surfaces near-due payment and collateral risk alerts at the top o
 
 ## Trigger thresholds
 
-- `critical` when a payment is due in 1 day or less, or when the health factor drops to `1.15` or below.
-- `warning` when a payment is due in 3 days or less, or when the health factor drops to `1.25` or below.
-- `info` when a payment is due in 7 days or less, or when the health factor drops to `1.35` or below.
+- `critical` when a payment is due in 1 day or less, or when the health factor reaches or falls below the critical threshold defined by `CRITICAL_HEALTH_FACTOR_THRESHOLD` in `lib/lending/health.ts`.
+- `warning` when a payment is due in 3 days or less, or when the health factor reaches or falls below the healthy threshold defined by `HEALTHY_HEALTH_FACTOR_THRESHOLD` in `lib/lending/health.ts`.
+- `info` when a payment is due in 7 days or less, or when the health factor reaches or falls below the same lending-health thresholds in `lib/lending/health.ts` for the banner’s health-based severity logic.
 
 ## Behavior
 


### PR DESCRIPTION
# docs: reference lending health thresholds in dashboard banner

## Summary

This PR updates the dashboard alert banner documentation so it references the shared lending-health constants in `lib/lending/health.ts` instead of restating hardcoded health-factor thresholds in prose.

### What changed
- Replaced the hardcoded threshold values in the docs with references to `CRITICAL_HEALTH_FACTOR_THRESHOLD` and `HEALTHY_HEALTH_FACTOR_THRESHOLD`.
- Kept the documentation aligned with the canonical source of truth for health-based severity logic, reducing the risk of doc/code drift.

Closes: #1156