### PR TITLE
fix(circuit-breaker): remove unconditional /api/health bypass in shouldAllow

### DIFF
--- a/__tests__/http/circuit-breaker.test.ts
+++ b/__tests__/http/circuit-breaker.test.ts
@@ -55,11 +55,14 @@ describe('CircuitBreaker', () => {
     expect(breaker.shouldAllow(host, path)).toBe(true);
   });
 
-  test('skips breaker for health probe', () => {
-    // Force open state
-    (process.env as any).CIRCUIT_FAILURE_RATE = '0';
-    (process.env as any).CIRCUIT_MIN_CALLS = '0';
+  test('blocks health probe paths when circuit is open', () => {
+    // Verify that /api/health paths are NOT exempt from circuit breaker protection.
+    // Force the circuit open via failures.
+    (process.env as any).CIRCUIT_FAILURE_RATE = '0.5';
+    (process.env as any).CIRCUIT_MIN_CALLS = '2';
     breaker.recordFailure(host);
-    expect(breaker.shouldAllow(host, healthPath)).toBe(true);
+    breaker.recordFailure(host);
+    // Circuit should now be OPEN — health paths must also be blocked.
+    expect(breaker.shouldAllow(host, healthPath)).toBe(false);
   });
 });

--- a/lib/http/circuit-breaker.ts
+++ b/lib/http/circuit-breaker.ts
@@ -35,9 +35,8 @@ export class CircuitBreaker {
     return stats;
   }
 
-  /** Returns true if the request should proceed. Skips breaker for health probes. */
+  /** Returns true if the request should proceed. All paths are subject to breaker protection. */
   shouldAllow(host: string, path: string): boolean {
-    if (path.startsWith('/api/health')) return true;
     const stats = this.getStats(host);
     this.transitionIfNeeded(stats);
     return stats.state !== CircuitState.OPEN;


### PR DESCRIPTION
## Summary

Fixes #1181 — `CircuitBreaker.shouldAllow` was unconditionally bypassing the circuit breaker for any path starting with `/api/health`, meaning health-check outbound traffic was never subject to failure-rate/cooldown logic at all.

## Problem

The `shouldAllow(host, path)` method in `lib/http/circuit-breaker.ts` had this early return:

```ts
if (path.startsWith('/api/health')) return true;
```

This check ran **before** any of the breaker's failure-rate or cooldown transitions were evaluated. Combined with the pre-existing issue that `app/api/health/route.ts`'s `checkApi`/`checkDatabase` probes may target nonexistent paths, the `/api/health` health-check endpoint could retry failing downstream calls indefinitely without any circuit-breaker backoff ever kicking in — because the very mechanism designed to stop hammering a failing dependency was explicitly disabled for this traffic.

The intent behind the bypass appears to have been ensuring the **inbound** `/api/health` route is always reachable. However, the bypass was checking the `path` parameter passed to `shouldAllow`, which represents **outbound** request paths — so it was inadvertently exempting health-check outbound calls from breaker protection, not the inbound route itself.

## Changes

### `lib/http/circuit-breaker.ts`

- **Removed** the `if (path.startsWith('/api/health')) return true;` early return from `shouldAllow()`.
- **Updated** the JSDoc comment from "Skips breaker for health probes" to "All paths are subject to breaker protection."

Before:
```ts
shouldAllow(host: string, path: string): boolean {
    if (path.startsWith('/api/health')) return true;  // ❌ unconditionally bypasses
    const stats = this.getStats(host);
    this.transitionIfNeeded(stats);
    return stats.state !== CircuitState.OPEN;
}
```

After:
```ts
shouldAllow(host: string, path: string): boolean {
    const stats = this.getStats(host);
    this.transitionIfNeeded(stats);
    return stats.state !== CircuitState.OPEN;
}
```

### `__tests__/http/circuit-breaker.test.ts`

- **Replaced** the `'skips breaker for health probe'` test (which validated the bypass) with a new test `'blocks health probe paths when circuit is open'` that **asserts the opposite behavior**: health paths are blocked when the circuit is open.

The new test:
1. Sets failure rate to `0.5` and min calls to `2`.
2. Records two failures to force the circuit open.
3. Asserts `shouldAllow(host, '/api/health')` returns `false`.

## Testing

- ✅ All 4 circuit-breaker unit tests pass (`npx vitest run __tests__/http/circuit-breaker.test.ts`)
- ✅ No new TypeScript errors introduced (pre-existing errors in unrelated files remain)
- ✅ Code review: clean and minimal change

## Notes

The circuit breaker's `shouldAllow` is not yet wired into `lib/http/client.ts`'s `httpGet` — that integration would be a logical follow-up PR to ensure the breaker is actually enforced at the HTTP client level.
