### PR TITLE
fix: repair Transaction.tsx parse error, add sort/scroll virtualization regression test

### DIFF
--- a/components/shared/common/Transaction.tsx
+++ b/components/shared/common/Transaction.tsx
@@ -8,22 +8,15 @@ import {
   ListFilter,
   CalendarDays,
 } from "lucide-react";
-import Image from "next/image";
-import { StatusBadge } from "../ui";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { format } from "date-fns";
-import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { Pagination } from "./Pagination";
 import { EmptyState } from "./EmptyState";
 import { TransactionsSkeleton } from "./Skeleton";
 import { TransactionRow, TransactionMobileRow } from "./TransactionRow";
-import {
-  StatusBadge,
-  transactionStatusToVariant,
-} from "@/components/shared/ui/StatusBadge";
 import { usePendingTransactions } from "@/hooks/usePendingTransactions";
 import {
   fetchTransactions,
@@ -517,8 +510,9 @@ export const Transactions = ({
             <div
               className="hidden md:block overflow-x-auto"
               ref={scrollContainerRef}
-              data-testid="transactions-virtualizer"
+              data-testid={shouldVirtualize ? "transactions-virtualizer" : undefined}
               style={shouldVirtualize ? { height: `${viewportHeight}px`, overflowY: "auto" } : undefined}
+              onScroll={shouldVirtualize ? (e) => setScrollTop(e.currentTarget.scrollTop) : undefined}
             >
               <table
                 className="min-w-full text-sm border"

--- a/components/shared/common/__tests__/transactions-virtualization.test.tsx
+++ b/components/shared/common/__tests__/transactions-virtualization.test.tsx
@@ -48,13 +48,24 @@ vi.mock("@/types/Transaction", async () => {
 const mockedFetchTransactions = vi.mocked(fetchTransactions);
 
 function makeTransaction(id: number) {
+  // Distinct, strictly decreasing timestamps (id 1 = most recent) so the
+  // default "date desc" sort has no ties to break and preserves a
+  // predictable id order across the suite.
+  const timestamp = new Date(2024, 0, 1, 12, 0, 0);
+  timestamp.setMinutes(timestamp.getMinutes() - id);
+  const pad = (n: number) => String(n).padStart(2, "0");
+
   return {
     id: `tx-${id}`,
     type: id % 2 === 0 ? "Borrow" : "Repay",
     amount: id * 10,
     asset: "XLM",
-    date: "2024-01-01",
-    time: "10:00 AM",
+    date: `${timestamp.getFullYear()}-${pad(timestamp.getMonth() + 1)}-${pad(timestamp.getDate())}`,
+    time: timestamp.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    }),
     status: "Completed" as const,
   };
 }
@@ -149,4 +160,75 @@ describe("Transactions virtualization", () => {
     const virtualizer = screen.getByTestId("transactions-virtualizer");
     expect(virtualizer).toHaveStyle({ height: "560px" });
   });
+
+  it("re-measures the visible window instead of rendering blank rows when scrolled partway down", async () => {
+    const transactions = Array.from({ length: 200 }, (_, index) =>
+      makeTransaction(index + 1),
+    );
+    mockedFetchTransactions.mockResolvedValue({
+      transactions,
+      total: transactions.length,
+    });
+
+    render(<Transactions showPagination={false} rowHeight={40} />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0),
+    );
+
+    const virtualizer = screen.getByTestId("transactions-virtualizer");
+
+    fireEvent.scroll(virtualizer, { target: { scrollTop: 4000 } });
+
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-100").length).toBeGreaterThan(0),
+    );
+    expect(screen.queryAllByText("#tx-1")).toHaveLength(0);
+    expect(screen.queryAllByText("#tx-200")).toHaveLength(0);
+  });
+
+  it("does not jump or leave a blank viewport when the sort order changes mid-scroll", async () => {
+    const transactions = Array.from({ length: 200 }, (_, index) =>
+      makeTransaction(index + 1),
+    );
+    mockedFetchTransactions.mockResolvedValue({
+      transactions,
+      total: transactions.length,
+    });
+
+    render(<Transactions showPagination={false} rowHeight={40} />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0),
+    );
+
+    // Switch to a numerically-ordered sort key (amount) so row identity at
+    // each index is deterministic, then scroll partway down that list.
+    fireEvent.click(screen.getByText("Sort"));
+    fireEvent.click(screen.getByRole("button", { name: "Amount" }));
+
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-200").length).toBeGreaterThan(0),
+    );
+
+    const virtualizer = screen.getByTestId("transactions-virtualizer");
+    fireEvent.scroll(virtualizer, { target: { scrollTop: 4000 } });
+
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-100").length).toBeGreaterThan(0),
+    );
+
+    // Flip sort direction while scrolled partway down. The visible window
+    // must reset cleanly to the new top of the list, not leave stale rows
+    // from the old scroll position or a blank gap from a mismatched
+    // scrollTop/DOM reset.
+    fireEvent.click(screen.getByText("Sort"));
+    fireEvent.click(screen.getByText("Toggle Direction"));
+
+    await waitFor(() =>
+      expect(screen.getAllByText("#tx-1").length).toBeGreaterThan(0),
+    );
+    expect(screen.queryAllByText("#tx-100")).toHaveLength(0);
+    expect((virtualizer as HTMLDivElement).scrollTop).toBe(0);
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
- `components/shared/common/Transaction.tsx` failed to parse due to duplicate imports left over from a bad merge: `Image` from `next/image` was imported twice, and `StatusBadge` was imported both from `../ui` and directly from `@/components/shared/ui/StatusBadge` (the same underlying export, re-exported through the index). Neither identifier is actually used anywhere in this file - `TransactionRow.tsx` already imports and renders them - so the dead/duplicate imports are removed.
- The virtualized row window never updated on real user scrolling: the scroll container had no `onScroll` handler wired to the `scrollTop` state that drives `startIndex`/`endIndex`, so scrolling past the initially-mounted rows would show blank space instead of the rest of the list. Added the missing handler.
- Extended `__tests__/transactions-virtualization.test.tsx` with two regression tests covering the actual risk flagged in #1152: scrolling partway down a long list re-measures the visible window instead of going blank, and changing sort order while scrolled resets cleanly to the top instead of leaving stale rows or a scrollTop/DOM mismatch.
- Also adjusted the existing test fixtures to use distinct timestamps instead of identical ones (the default date-sort tie-break was otherwise reordering ties lexicographically by id, which is what was silently failing all 4 pre-existing tests in this file once it could finally compile), and scoped the virtualizer's `data-testid` to only render when virtualization is actually active, matching what those pre-existing tests already assumed.

## Test plan
- [x] `npx vitest run components/shared/common/__tests__/transactions-virtualization.test.tsx` — all 6 tests pass (4 pre-existing + 2 new)
- [x] `npx eslint` on changed files — 0 errors (pre-existing unrelated `jsx-a11y` warnings only)
- [x] `npx tsc --noEmit` — no errors attributable to changed files

Closes #1152