### PR TITLE
test: add coverage for challenge-expiry rate-limit sequence (#1171)

### DIFF
--- a/app/api/account/delete/challenge/route.ratelimit.test.ts
+++ b/app/api/account/delete/challenge/route.ratelimit.test.ts
@@ -16,6 +16,15 @@ vi.mock('@/lib/config', () => ({
   },
 }));
 
+vi.mock('@/lib/account/challenge-store', () => ({
+  createDeletionChallenge: (userId: string) => ({
+    challenge: 'mock-challenge',
+    userId,
+    expiresAt: new Date(Date.now() + 50),
+    createdAt: new Date(),
+  }),
+}));
+
 import { GET as ChallengeGET } from './route';
 
 const USER = { id: 'rate-limit-user', email: 'rate-limit@example.com' };
@@ -87,5 +96,28 @@ describe('GET /api/account/delete/challenge rate limiting', () => {
 
     const res = await ChallengeGET(makeRequest(token));
     expect(res.status).toBe(200);
+  });
+
+  it('rate-limits a new challenge request after a prior challenge has expired unused', async () => {
+    vi.useFakeTimers();
+    const token = signToken(USER);
+
+    await ChallengeGET(makeRequest(token));
+    const r1 = await ChallengeGET(makeRequest(token));
+    expect(r1.status).toBe(200);
+
+    const blocked = await ChallengeGET(makeRequest(token));
+    expect(blocked.status).toBe(429);
+
+    vi.advanceTimersByTime(100);
+
+    const blocked2 = await ChallengeGET(makeRequest(token));
+    expect(blocked2.status).toBe(429);
+    expect(blocked2.headers.get('X-RateLimit-Remaining')).toBe('0');
+
+    vi.advanceTimersByTime(900);
+
+    const r2 = await ChallengeGET(makeRequest(token));
+    expect(r2.status).toBe(200);
   });
 });


### PR DESCRIPTION
Closes #1171

Adds a test to `app/api/account/delete/challenge/route.ratelimit.test.ts` covering the scenario where a challenge is issued, expires unused, and a new one is requested — confirming the rate limiter still counts the original requests and does not grant a free pass on expiry.