### PR TITLE
Refactor: Migrate to shared useToast hook in account settings

### DIFF
--- a/components/features/account/components/AccountDeletion.tsx
+++ b/components/features/account/components/AccountDeletion.tsx
@@ -3,13 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import AccountDeletionDialog from "@/components/shared/common/AccountDeletionDialog";
-import Toast, { ToastVariant } from "@/components/shared/common/Toast";
-
-type ToastState = {
-  variant: ToastVariant;
-  title: string;
-  description?: string;
-} | null;
+import { useToast } from "@/components/shared/common/Toast";
 
 /**
  * Map known server error codes to fixed, reviewed user-facing messages.
@@ -43,12 +37,7 @@ export default function AccountDeletion() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [challenge, setChallenge] = useState<string | null>(null);
   const [fetching, setFetching] = useState(false);
-  const [toast, setToast] = useState<ToastState>(null);
-
-  const showToast = (variant: ToastVariant, title: string, description?: string) => {
-    setToast({ variant, title, description });
-    setTimeout(() => setToast(null), 5000);
-  };
+  const { showToast } = useToast();
 
   const handleInitiate = async () => {
     if (fetching) return;
@@ -59,24 +48,24 @@ export default function AccountDeletion() {
       if (!res.ok) {
         const mapped = mapChallengeError(data);
         if (res.status === 429) {
-          showToast(
-            "error",
-            "Rate limit exceeded",
-            mapped ?? "Too many requests. Please try again later.",
-          );
+          showToast({
+            variant: "error",
+            title: "Rate limit exceeded",
+            description: mapped ?? "Too many requests. Please try again later.",
+          });
         } else {
-          showToast(
-            "error",
-            "Challenge failed",
-            mapped ?? "Could not start deletion. Please try again.",
-          );
+          showToast({
+            variant: "error",
+            title: "Challenge failed",
+            description: mapped ?? "Could not start deletion. Please try again.",
+          });
         }
         return;
       }
       setChallenge(data.challenge);
       setDialogOpen(true);
     } catch {
-      showToast("error", "Network error", "Could not reach the server. Check your connection.");
+      showToast({ variant: "error", title: "Network error", description: "Could not reach the server. Check your connection." });
     } finally {
       setFetching(false);
     }
@@ -125,14 +114,6 @@ export default function AccountDeletion() {
         onCancel={handleCancel}
         onConfirmDelete={handleConfirmDelete}
       />
-
-      {toast && (
-        <Toast
-          title={toast.title}
-          description={toast.description}
-          variant={toast.variant}
-        />
-      )}
     </>
   );
 }

--- a/components/features/account/components/DataExportButton.tsx
+++ b/components/features/account/components/DataExportButton.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import { Download } from "lucide-react";
 import Button from "@/components/atoms/Button";
-import Toast, { ToastVariant } from "@/components/shared/common/Toast";
+import { useToast } from "@/components/shared/common/Toast";
 
 interface DataExportButtonProps {
   className?: string;
@@ -20,23 +20,14 @@ function readCookie(name: string): string | null {
 export default function DataExportButton({ className = "" }: DataExportButtonProps) {
   const [isExporting, setIsExporting] = useState(false);
   const [hasFailed, setHasFailed] = useState(false);
-  const [toast, setToast] = useState<{
-    variant: ToastVariant;
-    title: string;
-    description?: string;
-  } | null>(null);
-
-  const showToast = (variant: ToastVariant, title: string, description?: string) => {
-    setToast({ variant, title, description });
-    setTimeout(() => setToast(null), 5000);
-  };
+  const { showToast } = useToast();
 
   const handleExport = async () => {
     if (isExporting) return;
 
     setIsExporting(true);
     setHasFailed(false);
-    showToast("processing", "Preparing your data export...", "This may take a moment.");
+    showToast({ variant: "processing", title: "Preparing your data export...", description: "This may take a moment." });
 
     const csrfToken = readCookie("csrf-token");
     const headers: Record<string, string> = {
@@ -56,17 +47,17 @@ export default function DataExportButton({ className = "" }: DataExportButtonPro
 
       if (!response.ok) {
         if (response.status === 429) {
-          showToast(
-            "error",
-            "Export rate limit exceeded",
-            data.error || "Please wait 24 hours before requesting another export."
-          );
+          showToast({
+            variant: "error",
+            title: "Export rate limit exceeded",
+            description: data.error || "Please wait 24 hours before requesting another export."
+          });
         } else {
-          showToast(
-            "error",
-            "Export failed",
-            data.error || "An error occurred while preparing your export."
-          );
+          showToast({
+            variant: "error",
+            title: "Export failed",
+            description: data.error || "An error occurred while preparing your export."
+          });
         }
         setHasFailed(true);
         return;
@@ -89,26 +80,26 @@ export default function DataExportButton({ className = "" }: DataExportButtonPro
         link.remove();
         URL.revokeObjectURL(downloadUrlObj);
 
-        showToast(
-          "success",
-          "Export ready",
-          "Your data export has been downloaded successfully."
-        );
+        showToast({
+          variant: "success",
+          title: "Export ready",
+          description: "Your data export has been downloaded successfully."
+        });
       } else {
         setHasFailed(true);
-        showToast(
-          "error",
-          "Export incomplete",
-          "No download URL received. Please try again."
-        );
+        showToast({
+          variant: "error",
+          title: "Export incomplete",
+          description: "No download URL received. Please try again."
+        });
       }
     } catch (error) {
       setHasFailed(true);
-      showToast(
-        "error",
-        "Export failed",
-        "Network error occurred. Please check your connection and try again."
-      );
+      showToast({
+        variant: "error",
+        title: "Export failed",
+        description: "Network error occurred. Please check your connection and try again."
+      });
     } finally {
       setIsExporting(false);
     }
@@ -135,14 +126,6 @@ export default function DataExportButton({ className = "" }: DataExportButtonPro
         <span id="export-status" className="sr-only">
           Your data export is being prepared. Please wait.
         </span>
-      )}
-
-      {toast && (
-        <Toast
-          title={toast.title}
-          description={toast.description}
-          variant={toast.variant}
-        />
       )}
     </>
   );

--- a/components/features/account/components/NotificationPreferences.tsx
+++ b/components/features/account/components/NotificationPreferences.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useState } from "react";
-import Toast from "@/components/shared/common/Toast";
+import { useToast } from "@/components/shared/common/Toast";
 
 interface NotificationChannels {
   email: boolean;
@@ -10,11 +10,7 @@ interface NotificationChannels {
   inApp: boolean;
 }
 
-interface Toast {
-  variant: "success" | "error";
-  title: string;
-  description?: string;
-}
+
 
 const CHANNELS: { key: keyof NotificationChannels; label: string; description: string }[] = [
   { key: "email", label: "Email", description: "Receive notifications via email." },
@@ -27,12 +23,7 @@ export default function NotificationPreferences() {
   const [prefs, setPrefs] = useState<NotificationChannels | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [toast, setToast] = useState<Toast | null>(null);
-
-  const showToast = (t: Toast) => {
-    setToast(t);
-    setTimeout(() => setToast(null), 4000);
-  };
+  const { showToast } = useToast();
 
   useEffect(() => {
     fetch("/api/account/preferences")
@@ -121,9 +112,6 @@ export default function NotificationPreferences() {
         ))}
       </ul>
 
-      {toast && (
-        <Toast variant={toast.variant} title={toast.title} description={toast.description} />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #1128 

Description
This pull request addresses an architectural inconsistency where multiple components in the account settings domain were managing their own local toast-lifecycle logic.

Previously, NotificationPreferences, DataExportButton, and AccountDeletion were each re-implementing an identical toast pattern using local state and setTimeout. This resulted in duplicated code and inconsistent auto-dismiss timings across the app (some components dismissed toasts after 4000ms, while others used 5000ms), leading to a fractured user experience.

This PR refactors these components to use the centralized app-wide ToastProvider via the shared useToast hook, aligning them with the rest of the application (e.g., TransactionExportButton.tsx).

Changes Made
components/features/account/components/NotificationPreferences.tsx:
Removed the local Toast interface and [toast, setToast] state.
Replaced the local showToast method with the showToast method extracted from useToast().
Removed the local <Toast> component rendering from the JSX tree.
components/features/account/components/DataExportButton.tsx:
Removed the local toast state and rendering logic.
Updated the 6 distinct showToast calls (success, error, and processing states) to pass an object payload ({ variant, title, description }) as expected by the shared context.
components/features/account/components/AccountDeletion.tsx:
Removed the ToastState type, local state tracking, and local rendering block.
Refactored API error mapping and initiation success paths to correctly use the global useToast hook.
Impact & Benefits
Consistency: Ensures all toasts in the account settings share the exact same dismissal duration, animations, and styling behavior provided by the global ToastProvider.
Reduced Boilerplate: Eliminated ~45 lines of duplicated local state management across the three files.
Maintainability: Any future changes to toast behavior only need to happen in the ToastProvider rather than hunting down disparate local implementations.
