### PR TITLE
fix(analytics): remove dead exportCSV, use shared serializeTransactio…

### DIFF
--- a/app/dashboard/analytics/page.test.tsx
+++ b/app/dashboard/analytics/page.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import AnalyticsPage from "./page";
+
+// ── Next.js stubs ─────────────────────────────────────────────────────────────
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/dashboard/analytics",
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img {...props} />
+  ),
+}));
+
+// ── Layout / shared stubs ─────────────────────────────────────────────────────
+vi.mock("@/components", () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dashboard-layout">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/shared/common", () => ({
+  PageHeader: ({ title, actions }: { title: string; actions?: React.ReactNode }) => (
+    <div>
+      <h1>{title}</h1>
+      <div data-testid="page-header-actions">{actions}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/shared/common/Toast", () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+// ── Feature-component stubs ───────────────────────────────────────────────────
+vi.mock("@/components/features/dashboard/components/MetricsCards", () => ({
+  default: () => <div data-testid="metrics-cards" />,
+}));
+
+vi.mock("@/components/features/dashboard/components/SupplyApyChart", () => ({
+  SupplyApyChart: () => <div data-testid="supply-apy-chart" />,
+}));
+
+vi.mock("@/components/features/dashboard/components/NetWorthTrend", () => ({
+  default: () => <div data-testid="net-worth-trend" />,
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe("AnalyticsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders inside DashboardLayout", () => {
+    render(<AnalyticsPage />);
+    expect(screen.getByTestId("dashboard-layout")).toBeInTheDocument();
+  });
+
+  it("renders the Analytics page heading", () => {
+    render(<AnalyticsPage />);
+    expect(screen.getByRole("heading", { name: /analytics/i })).toBeInTheDocument();
+  });
+
+  it("renders the Export CSV button", () => {
+    render(<AnalyticsPage />);
+    expect(screen.getByRole("button", { name: /export csv/i })).toBeInTheDocument();
+  });
+
+  it("renders chart components", () => {
+    render(<AnalyticsPage />);
+    expect(screen.getByTestId("net-worth-trend")).toBeInTheDocument();
+    expect(screen.getByTestId("metrics-cards")).toBeInTheDocument();
+    expect(screen.getByTestId("supply-apy-chart")).toBeInTheDocument();
+  });
+
+  it("does not expose a dead exportCSV function on the module", async () => {
+    const mod = await import("./page");
+    // The module must not export any function named exportCSV.
+    expect((mod as Record<string, unknown>).exportCSV).toBeUndefined();
+  });
+
+  it("Export CSV button calls serializeTransactionsToCSV (shared utility), not a local naive join", async () => {
+    const mockSerialize = vi.fn().mockReturnValue("id,type\n");
+    vi.doMock("@/lib/transactions/csv", () => ({
+      serializeTransactionsToCSV: mockSerialize,
+    }));
+
+    // The module-level fetch mock for the transaction endpoint
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ transactions: [] }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<AnalyticsPage />);
+    const button = screen.getByRole("button", { name: /export csv/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith("/api/transactions", { method: "GET" });
+    });
+  });
+});

--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { DashboardLayout } from "@/components";
+import { PageHeader } from "@/components/shared/common";
+import MetricsCards from "@/components/features/dashboard/components/MetricsCards";
+import { SupplyApyChart } from "@/components/features/dashboard/components/SupplyApyChart";
+import NetWorthTrend from "@/components/features/dashboard/components/NetWorthTrend";
+import { useToast } from "@/components/shared/common/Toast";
+import { serializeTransactionsToCSV } from "@/lib/transactions/csv";
+import type { Transaction } from "@/lib/transactions/types";
+
+function downloadBlob(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function fetchAnalyticsData(): Promise<Transaction[]> {
+  const response = await fetch("/api/transactions", { method: "GET" });
+  if (!response.ok) {
+    throw new Error("Failed to fetch transactions");
+  }
+  const data = await response.json();
+  return Array.isArray(data?.transactions) ? data.transactions : [];
+}
+
+function ExportCsvButton() {
+  const [isExporting, setIsExporting] = useState(false);
+  const { showToast } = useToast();
+
+  const handleExport = useCallback(async () => {
+    if (isExporting) return;
+    setIsExporting(true);
+
+    try {
+      const transactions = await fetchAnalyticsData();
+      const csv = serializeTransactionsToCSV(transactions);
+      downloadBlob(csv, "analytics.csv", "text/csv;charset=utf-8;");
+      showToast({
+        title: "Export ready",
+        description: "Your analytics CSV has been downloaded.",
+        variant: "success",
+      });
+    } catch {
+      showToast({
+        title: "Export failed",
+        description: "Unable to prepare your CSV export. Please try again.",
+        variant: "error",
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  }, [isExporting, showToast]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      disabled={isExporting}
+      aria-busy={isExporting}
+      className="bg-[#15A350] hover:bg-[#0A3D1E] text-white border border-[#71B48D] rounded-lg flex items-center justify-center gap-2 py-3 px-6 font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-70"
+    >
+      {isExporting ? (
+        <>
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          <span>Preparing…</span>
+        </>
+      ) : (
+        <>
+          <Download className="h-4 w-4" aria-hidden="true" />
+          <span>Export CSV</span>
+        </>
+      )}
+    </button>
+  );
+}
+
+export default function AnalyticsPage() {
+  return (
+    <DashboardLayout>
+      <div className="pt-10 border-t px-6 md:px-12">
+        <PageHeader
+          title="Analytics"
+          description="Visualise your lending, borrowing, and collateral activity over time."
+          actions={<ExportCsvButton />}
+        />
+      </div>
+
+      <div className="px-6 md:px-12 mt-6 space-y-6">
+        <NetWorthTrend />
+        <MetricsCards />
+        <SupplyApyChart />
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
Closes #914.

`app/dashboard/analytics/page.tsx` is created without the dead `exportCSV`
function described in the issue. The CSV export button delegates entirely to
`serializeTransactionsToCSV` from `lib/transactions/csv.ts`, which properly
escapes fields (RFC 4180 double-quote wrapping) and guards against
CSV-injection via leading `=`/`+`/`-`/`@` characters.

## Changes
- `app/dashboard/analytics/page.tsx` — Analytics page; Export CSV button uses
  the shared `serializeTransactionsToCSV` utility only.
- `app/dashboard/analytics/page.test.tsx` — Unit tests, including an assertion
  that `exportCSV` is not exported from the module.

