### PR TITLE
feat(dashboard): add visible indicator for stale position data

### DIFF
--- a/components/features/dashboard/components/PositionSummary.test.tsx
+++ b/components/features/dashboard/components/PositionSummary.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { render, screen } from "@/test/test-utils";
 import PositionSummary from "./PositionSummary";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import * as UsePositionsHook from "@/hooks/usePositions";
 
 describe("PositionSummary Component", () => {
   const mockHealthyData = {
@@ -444,6 +445,26 @@ describe("PositionSummary Component", () => {
 
       const grid = document.querySelector(".grid");
       expect(grid).toHaveClass("grid-cols-2", "md:grid-cols-2");
+    });
+  });
+
+  describe("Stale Data Indicator", () => {
+    it("renders the stale data warning when useCollateralShares reports isStale", () => {
+      // Force the hook to return isStale: true for this specific test
+      const spy = vi.spyOn(UsePositionsHook, "useCollateralShares").mockReturnValue({
+        shares: [],
+        isLoading: false,
+        isStale: true,
+      });
+
+      render(<PositionSummary data={mockHealthyData} />);
+
+      // Assert the banner is visible
+      expect(screen.getByRole("alert", { name: "Stale data warning" })).toBeInTheDocument();
+      expect(screen.getByText("Data May Be Outdated")).toBeInTheDocument();
+
+      // Clean up the mock so other tests don't fail
+      spy.mockRestore();
     });
   });
 

--- a/components/features/dashboard/components/PositionSummary.tsx
+++ b/components/features/dashboard/components/PositionSummary.tsx
@@ -132,7 +132,7 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({
   isLoading = false,
 }) => {
   const shouldReduceMotion = useReducedMotion();
-  const { shares, isLoading: sharesLoading } = useCollateralShares();
+  const { shares, isLoading: sharesLoading, isStale } = useCollateralShares();
   const { netPosition, formattedNetPosition, healthStatus } = useMemo(() => {
     if (!data || isLoading) {
       return {
@@ -198,6 +198,23 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({
           : "worsening"
       }
     >
+      {/* Stale Data Warning */}
+      {isStale && (
+        <div
+          className="mb-6 flex items-start gap-3 rounded-lg border border-amber-700 bg-amber-950 p-4"
+          role="alert"
+          aria-label="Stale data warning"
+        >
+          <AlertCircle className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <h3 className="text-amber-400 text-sm font-bold">Data May Be Outdated</h3>
+            <p className="text-[#AAABAB] text-xs mt-1 font-medium">
+              We encountered a network issue. The numbers displayed below might not reflect your current real-time position.
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Main Position Display */}
       <div className="mb-8">
         <div className="flex items-center gap-3 mb-3">


### PR DESCRIPTION
**Closes #1143** 

This pull request introduces the visual stale-data warning infrastructure required by the bounty to prevent the silent display of outdated risk metrics.

**Modifications:**
* Extracted the `isStale` telemetry from the `useCollateralShares` hook within `PositionSummary.tsx`.
* Engineered a high-contrast, conditional warning banner utilizing existing Tailwind amber UI tokens and the `AlertCircle` icon to alert users of failed network refreshes.
* Wired strict Vitest assertions using `vi.spyOn` to mock the underlying hook's state and mathematically prove the stale-data banner renders correctly, gracefully restoring the mock to protect the remaining test suite.