### PR TITLE
updated work done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 
 *storybook.log
 storybook-static
+.opencode

--- a/components/features/dashboard/components/CollateralBreakdown.tsx
+++ b/components/features/dashboard/components/CollateralBreakdown.tsx
@@ -44,14 +44,11 @@ export function CollateralBreakdown({ shares, isLoading }: CollateralBreakdownPr
         </thead>
         <tbody>
           {shares.map(({ asset, usdValue, share }) => {
-            const meta = getAsset(asset);
-            const label = meta ? meta.name : asset;
             return (
               <tr
                 key={asset}
                 className="border-t border-[#71B48D22] focus-within:bg-[#071e0f]"
                 tabIndex={0}
-                aria-label={`${label}: $${formatCurrency(usdValue)}, ${share}%`}
               >
                 <td className="py-2 text-white font-medium">{asset}</td>
                 <td className="py-2 text-right text-[#D4F3E6] font-mono">


### PR DESCRIPTION
Closes #1187 
Remove aria-label override that flattened semantic table structure, preventing screen reader users from navigating cells with column header context. Native table semantics with scope="col" headers now properly convey the data relationships.


