### PR TITLE
fix(dashboard): consolidate formatAmount into shared formatCurrency helper (#1174)

### DIFF
--- a/components/features/dashboard/components/LiquidationsPanel.test.tsx
+++ b/components/features/dashboard/components/LiquidationsPanel.test.tsx
@@ -118,9 +118,9 @@ describe("LiquidationsPanel", () => {
 
     const rows = screen.getAllByRole("row").slice(1);
 
-    expect(within(rows[0]).getByText("100 USDC")).toBeInTheDocument();
-    expect(within(rows[1]).getByText("100 XLM")).toBeInTheDocument();
-    expect(within(rows[2]).getByText("100 ETH")).toBeInTheDocument();
+    expect(within(rows[0]).getByText("100.00 USDC")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("100.00 XLM")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("100.00 ETH")).toBeInTheDocument();
     expect(within(rows[3]).getByText("100 BTC")).toBeInTheDocument();
   });
 
@@ -164,8 +164,8 @@ describe("LiquidationsPanel", () => {
 
     const rows = screen.getAllByRole("row").slice(1);
 
-    expect(within(rows[0]).getByText("100 XLM")).toBeInTheDocument();
-    expect(within(rows[1]).getByText("100 BTC")).toBeInTheDocument();
+    expect(within(rows[0]).getByText("100.00 XLM")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("100.00 BTC")).toBeInTheDocument();
     expect(within(rows[1]).getAllByText("N/A")).toHaveLength(2);
     expect(within(rows[1]).getAllByText("Unavailable")).toHaveLength(2);
   });

--- a/components/features/dashboard/components/LiquidationsPanel.tsx
+++ b/components/features/dashboard/components/LiquidationsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import { UtilizationBar } from "@/components/atoms/UtilizationBar/UtilizationBar";
+import { formatCurrency } from "@/lib/utils/format";
 import type {
   LiquidationPosition,
   LiquidationsResponse,
@@ -36,12 +37,6 @@ export function getDistanceToLiquidationPercent(
   }
 
   return Math.round((position.healthFactor - 1) * 1000) / 10;
-}
-
-function formatAmount(amount: number, asset: string): string {
-  return `${new Intl.NumberFormat("en-US", {
-    maximumFractionDigits: 2,
-  }).format(amount)} ${asset}`;
 }
 
 function formatLiquidationPriceFactor(factor: number): string {
@@ -384,13 +379,10 @@ export default function LiquidationsPanel({
                     className="bg-[#072815]"
                   >
                     <td className="rounded-l-lg px-3 py-3 font-semibold">
-                      {formatAmount(position.borrowedAmount, position.asset)}
+                      {formatCurrency(position.borrowedAmount, 2, position.asset)}
                     </td>
                     <td className="px-3 py-3">
-                      {formatAmount(
-                        position.collateralAmount,
-                        position.collateralAsset,
-                      )}
+                      {formatCurrency(position.collateralAmount, 2, position.collateralAsset)}
                     </td>
                     <td className="px-3 py-3">
                       <UtilizationBar asset={position.asset} />


### PR DESCRIPTION
## Overview
The `LiquidationsPanel.tsx` component defined its own local `formatAmount` function using `Intl.NumberFormat('en-US', { maximumFractionDigits: 2 })` instead of leveraging the shared `formatCurrency` helper in `lib/utils/format.ts`. This was a third distinct number-formatting implementation alongside `formatCurrency` and `SupplyApyChart.tsx`'s local `formatCurrency`, each with subtly different rounding/localization behavior.

## Related Issue
Closes #1174

## Changes

### ♻️ Consolidated formatting logic
- **[REMOVE]** `LiquidationsPanel.tsx` — Removed the local `formatAmount` function (lines 41-45) that used `Intl.NumberFormat('en-US', { maximumFractionDigits: 2 })`.
- **[ADD]**  `LiquidationsPanel.tsx` — Added import of `formatCurrency` from `@/lib/utils/format`.
- **[REPLACE]** Replaced `formatAmount(position.borrowedAmount, position.asset)` with `formatCurrency(position.borrowedAmount, 2, position.asset)`.
- **[REPLACE]** Replaced `formatAmount(position.collateralAmount, position.collateralAsset)` with `formatCurrency(position.collateralAmount, 2, position.collateralAsset)`.

### ✅ Test alignment
- **[UPDATE]** `LiquidationsPanel.test.tsx` — Updated expected values from `"100 XLM"` to `"100.00 XLM"` (and similar for USDC, ETH, BTC) to match the shared helper's consistent decimal formatting.
