### PR TITLE
test: add unit tests for scanFile in check-bundle-secrets

### DIFF
--- a/scripts/__tests__/check-bundle-secrets.test.ts
+++ b/scripts/__tests__/check-bundle-secrets.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { scanFile } from '../check-bundle-secrets';
+import {
+  AWS_ACCESS_KEY_PATTERN,
+  AWS_SECRET_KEY_PATTERN,
+  SECRET_PATTERNS,
+} from '../../lib/security/secret-patterns';
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+import { readFileSync } from 'fs';
+
+const mockReadFileSync = vi.mocked(readFileSync);
+
+describe('scanFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detects a critical AWS Access Key ID in file content', () => {
+    mockReadFileSync.mockReturnValue("const key = 'AKIAIOSFODNN7EXAMPLE';");
+    const matches = scanFile('/fake/file.js', SECRET_PATTERNS);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].pattern).toBe('AWS Access Key ID');
+    expect(matches[0].match).toBe('AKIAIOSFODNN7EXAMPLE');
+    expect(matches[0].severity).toBe('critical');
+  });
+
+  it('excludes 40-char hex strings as AWS Secret Access Key false positives', () => {
+    mockReadFileSync.mockReturnValue(
+      "const hash = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0';",
+    );
+    const matches = scanFile('/fake/file.js', [AWS_SECRET_KEY_PATTERN]);
+
+    expect(matches).toHaveLength(0);
+  });
+
+  it('detects a real AWS Secret Access Key (mixed chars, not purely hex)', () => {
+    mockReadFileSync.mockReturnValue(
+      "const secret = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';",
+    );
+    const matches = scanFile('/fake/file.js', [AWS_SECRET_KEY_PATTERN]);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].pattern).toBe('AWS Secret Access Key');
+    expect(matches[0].match).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+    expect(matches[0].severity).toBe('critical');
+  });
+
+  it('reports correct line and column numbers in a multi-line file', () => {
+    const content = [
+      'line1',
+      'line2',
+      "const key = 'AKIAIOSFODNN7EXAMPLE';",
+      'line4',
+    ].join('\n');
+    mockReadFileSync.mockReturnValue(content);
+    const matches = scanFile('/fake/file.js', [AWS_ACCESS_KEY_PATTERN]);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].line).toBe(3);
+    expect(matches[0].column).toBe(14);
+    expect(matches[0].match).toBe('AKIAIOSFODNN7EXAMPLE');
+  });
+});

--- a/scripts/check-bundle-secrets.ts
+++ b/scripts/check-bundle-secrets.ts
@@ -18,7 +18,7 @@ import {
   getPatternsBySeverity
 } from '../lib/security/secret-patterns';
 
-interface SecretMatch {
+export interface SecretMatch {
   pattern: string;
   file: string;
   line: number;
@@ -64,7 +64,7 @@ function scanDirectory(dir: string, extensions: string[]): string[] {
 /**
  * Scan a single file for secret patterns
  */
-function scanFile(filePath: string, patterns: SecretPattern[]): SecretMatch[] {
+export function scanFile(filePath: string, patterns: SecretPattern[]): SecretMatch[] {
   const matches: SecretMatch[] = [];
   
   try {
@@ -277,5 +277,7 @@ function main(): void {
   process.exit(0);
 }
 
-// Run the scanner
-main();
+// Run the scanner (skip when imported by tests)
+if (process.env.VITEST !== 'true') {
+  main();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -113,6 +113,7 @@ export default defineConfig({
             "lib/streams/**/*.test.ts",
             "lib/soroban/**/*.test.ts",
             "lib/indexer/**/*.test.ts",
+            "scripts/**/*.test.ts",
           ],
         },
       },


### PR DESCRIPTION
Closes #1110

Add unit tests for the `scanFile` function in `scripts/check-bundle-secrets.ts`:

- **Genuine secret match**: detects AWS Access Key ID with correct pattern name, match text, and severity
- **AWS hex-hash false-positive exclusion**: 40-character hex strings (build/commit hashes) are correctly filtered out for AWS Secret Access Key
- **Real AWS Secret Access Key detection**: non-hex mixed-character keys are still detected
- **Line/column reporting**: verifies correct line (3) and column (14) for a secret on the third line of a multi-line fixture

### Changes
- Exported `scanFile` and `SecretMatch` interface from `scripts/check-bundle-secrets.ts`
- Guarded top-level `main()` execution with `process.env.VITEST` check to prevent side effects on import
- Added `scripts/**/*.test.ts` to the `server-unit` project include in `vitest.config.ts`
- Created `scripts/__tests__/check-bundle-secrets.test.ts` with 4 unit tests