### PR TITLE
fix: add missing route param to logger calls in pool.ts and inject.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           ESLINT_USE_FLAT_CONFIG: "false"
 
       - name: Type checking
-        run: npx tsc --noEmit
+        run: npm run type-check
 
       - name: Run tests
         run: npm run test:coverage

--- a/lib/chaos/inject.ts
+++ b/lib/chaos/inject.ts
@@ -25,7 +25,7 @@ export async function chaosInject(request: NextRequest): Promise<NextResponse | 
   try {
     config = JSON.parse(header);
   } catch (e) {
-    logger.warn('Invalid x-chaos-inject header JSON', { error: e });
+    logger.warn('Invalid x-chaos-inject header JSON', 'lib/chaos/inject', { error: e });
     return null;
   }
 
@@ -33,24 +33,24 @@ export async function chaosInject(request: NextRequest): Promise<NextResponse | 
 
   // Latency injection (milliseconds)
   if (config.latency && config.latency > 0) {
-    logger.info('Injecting latency', { route, latency: config.latency });
+    logger.info('Injecting latency', 'lib/chaos/inject', { route, latency: config.latency });
     await new Promise((resolve) => setTimeout(resolve, config.latency));
   }
 
   // Rate‑limit injection – respond with 429
   if (config.rateLimit && config.rateLimit > 0) {
-    logger.info('Injecting rate‑limit', { route, rateLimit: config.rateLimit });
+    logger.info('Injecting rate‑limit', 'lib/chaos/inject', { route, rateLimit: config.rateLimit });
     // In a real implementation a token‑bucket would be used; here we short‑circuit.
     return NextResponse.json({ error: 'Rate limit injected by chaos middleware' }, { status: 429 });
   }
 
   // 5xx error injection
   if (config.status && config.status >= 500 && config.status < 600) {
-    logger.info('Injecting error status', { route, status: config.status });
+    logger.info('Injecting error status', 'lib/chaos/inject', { route, status: config.status });
     return NextResponse.json({ error: `Injected ${config.status} error by chaos middleware` }, { status: config.status });
   }
 
   // If we reach here, only latency (or none) was applied.
-  logger.info('Chaos injection completed', { route });
+  logger.info('Chaos injection completed', 'lib/chaos/inject', { route });
   return null;
 }

--- a/lib/db/pool.ts
+++ b/lib/db/pool.ts
@@ -8,7 +8,7 @@ export function buildSslConfig(): boolean | Record<string, unknown> {
   }
 
   if (process.env.DATABASE_SSL_INSECURE === 'true') {
-    logger.warn('DATABASE_SSL_INSECURE is enabled — TLS certificate verification is disabled. Do not use in production without explicit sign-off.');
+    logger.warn('DATABASE_SSL_INSECURE is enabled — TLS certificate verification is disabled. Do not use in production without explicit sign-off.', 'lib/db/pool');
     return { rejectUnauthorized: false };
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "types": ["node", "vitest/globals"],
     "paths": {


### PR DESCRIPTION
## Summary

Fixes logger calls that omitted the required `route` parameter, and unblocks the CI type-check gate so this class of mistake is caught going forward.

Closes #1178

## Changes

### `lib/db/pool.ts` (line 11)
- `logger.warn(message)` → `logger.warn(message, 'lib/db/pool')`
- The security-relevant TLS verification warning was being emitted with no route metadata

### `lib/chaos/inject.ts` (5 logger calls)
All logger calls were passing context objects as the second argument (where `route: string` is required), so route metadata was silently lost:
- `logger.warn(msg, { error })` → `logger.warn(msg, 'lib/chaos/inject', { error })`
- `logger.info(msg, { route, ... })` → `logger.info(msg, 'lib/chaos/inject', { route, ... })` (4 calls)

### `.github/workflows/ci.yml`
- Changed type-check step from `npx tsc --noEmit` to `npm run type-check` for consistency with the existing `package.json` script

### `tsconfig.json`
- Removed invalid `ignoreDeprecations: "6.0"` — only `"5.0"` is valid. This value was causing `tsc` to fail immediately with `TS5103`, which meant the CI type-check gate was effectively a no-op and could never catch signature mismatches like the ones fixed here.

## Notes

The codebase has many pre-existing type errors in other files that were previously masked by the `tsc` immediately failing on the invalid `ignoreDeprecations` option. Those are out of scope for this PR and should be addressed separately.
