### PR TITLE
fix(#1115): add pgEnum constraints for transaction type/asset/status columns

### DIFF
--- a/drizzle/0003_transaction_enums.sql
+++ b/drizzle/0003_transaction_enums.sql
@@ -1,0 +1,11 @@
+CREATE TYPE "transaction_type" AS ENUM ('Deposit', 'Withdrawal', 'Lend Funds', 'Loan Payment');
+
+CREATE TYPE "asset_symbol" AS ENUM ('XLM', 'USDC', 'BTC', 'ETH');
+
+CREATE TYPE "transaction_status" AS ENUM ('Completed', 'Processing', 'Failed');
+
+ALTER TABLE "transactions" ALTER COLUMN "type" SET DATA TYPE transaction_type USING "type"::transaction_type;
+
+ALTER TABLE "transactions" ALTER COLUMN "asset" SET DATA TYPE asset_symbol USING "asset"::asset_symbol;
+
+ALTER TABLE "transactions" ALTER COLUMN "status" SET DATA TYPE transaction_status USING "status"::transaction_status;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1780790400000,
       "tag": "0002_notification_type_enum",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784060800000,
+      "tag": "0003_transaction_enums",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema/transactions.ts
+++ b/lib/db/schema/transactions.ts
@@ -1,13 +1,18 @@
-import { doublePrecision, index, pgTable, text } from 'drizzle-orm/pg-core';
+import { doublePrecision, index, pgEnum, pgTable, text } from 'drizzle-orm/pg-core';
+import { TRANSACTION_TYPES, ASSET_SYMBOLS, TRANSACTION_STATUSES } from '@/types/enums';
+
+export const transactionTypeEnum = pgEnum('transaction_type', [...TRANSACTION_TYPES]);
+export const assetSymbolEnum = pgEnum('asset_symbol', [...ASSET_SYMBOLS]);
+export const transactionStatusEnum = pgEnum('transaction_status', [...TRANSACTION_STATUSES]);
 
 export const transactions = pgTable('transactions', {
   id: text('id').primaryKey(),
-  type: text('type').notNull(),
+  type: transactionTypeEnum('type').notNull(),
   amount: doublePrecision('amount').notNull(),
-  asset: text('asset').notNull(),
+  asset: assetSymbolEnum('asset').notNull(),
   date: text('date').notNull(),
   time: text('time').notNull(),
-  status: text('status').notNull(),
+  status: transactionStatusEnum('status').notNull(),
 }, (table) => ({
   dateIdIdx: index('transactions_date_id_idx').on(table.date, table.id),
 }));

--- a/lib/transactions/store.ts
+++ b/lib/transactions/store.ts
@@ -39,10 +39,10 @@ export async function getTransaction(
       id: row.id,
       type: row.type,
       amount: row.amount,
-      asset: row.asset as any,
+      asset: row.asset,
       date: row.date,
       time: row.time,
-      status: row.status as any,
+      status: row.status,
     };
   } catch {
     return inMemoryStore.get(id);
@@ -61,7 +61,7 @@ export async function updateTransactionStatus(
   if (isTestEnv) {
     const mem = inMemoryStore.get(id);
     if (!mem) return null;
-    mem.status = status as any;
+    mem.status = status;
     return mem;
   }
   try {
@@ -74,7 +74,7 @@ export async function updateTransactionStatus(
     if (!row) {
       const mem = inMemoryStore.get(id);
       if (!mem) return null;
-      mem.status = status as any;
+      mem.status = status;
       return mem;
     }
 
@@ -82,15 +82,15 @@ export async function updateTransactionStatus(
       id: row.id,
       type: row.type,
       amount: row.amount,
-      asset: row.asset as any,
+      asset: row.asset,
       date: row.date,
       time: row.time,
-      status: row.status as any,
+      status: row.status,
     };
   } catch {
     const mem = inMemoryStore.get(id);
     if (!mem) return null;
-    mem.status = status as any;
+    mem.status = status;
     return mem;
   }
 }


### PR DESCRIPTION
## Summary

Adds `pgEnum` types for the three unconstrained `text()` columns in `lib/db/schema/transactions.ts` so invalid values are rejected at the database boundary rather than silently accepted.

## Changes

| File | What |
|---|---|
| `lib/db/schema/transactions.ts` | Define `transactionTypeEnum`, `assetSymbolEnum`, `transactionStatusEnum` from `types/enums.ts` canonical arrays; swap `text()` columns to `pgEnum()` |
| `drizzle/0003_transaction_enums.sql` | Migration: CREATE TYPE + ALTER COLUMN for all three columns |
| `drizzle/meta/_journal.json` | Register migration entry |
| `lib/transactions/store.ts` | Remove `as any` casts (pgEnum columns now infer correct union types directly) |

## Migration SQL

```sql
CREATE TYPE "transaction_type" AS ENUM ('Deposit', 'Withdrawal', 'Lend Funds', 'Loan Payment');
CREATE TYPE "asset_symbol" AS ENUM ('XLM', 'USDC', 'BTC', 'ETH');
CREATE TYPE "transaction_status" AS ENUM ('Completed', 'Processing', 'Failed');

ALTER TABLE "transactions" ALTER COLUMN "type" SET DATA TYPE transaction_type USING "type"::transaction_type;
ALTER TABLE "transactions" ALTER COLUMN "asset" SET DATA TYPE asset_symbol USING "asset"::asset_symbol;
ALTER TABLE "transactions" ALTER COLUMN "status" SET DATA TYPE transaction_status USING "status"::transaction_status;
```

## Verification

- No new type errors in changed files
- All existing passing server tests continue to pass
- Pre-existing test failures are unrelated to this change

## Notes

Enum values are spread from `types/enums.ts` so they stay in sync. Future additions to the canonical arrays will require a corresponding `ALTER TYPE ... ADD VALUE` migration.

closes: #1115