### PR TITLE
test: add jitter bounds tests for fetchMockPrices (#1168)

### DIFF
--- a/lib/prices/fetcher.test.ts
+++ b/lib/prices/fetcher.test.ts
@@ -88,6 +88,76 @@ describe('fetchUpstreamPrices', () => {
       expect(typeof result1.prices.XLM).toBe('number');
       expect(typeof result2.prices.XLM).toBe('number');
     });
+
+    describe('Jitter Bounds', () => {
+      const BASE_PRICES: Record<string, { base: number; maxJitter: number }> = {
+        XLM: { base: 0.1245, maxJitter: 0.001 },
+        USDC: { base: 1.0, maxJitter: 0 },
+        BTC: { base: 67340.5, maxJitter: 50 },
+        ETH: { base: 3480.2, maxJitter: 5 },
+      };
+
+      const MAX_JITTER_PCT = 0.02;
+      const SAMPLES = 200;
+      const ALL_ASSETS: Array<'XLM' | 'USDC' | 'BTC' | 'ETH'> = ['XLM', 'USDC', 'BTC', 'ETH'];
+
+      beforeEach(() => {
+        vi.useFakeTimers();
+        vi.spyOn(global, 'setTimeout').mockImplementation((fn) => {
+          (fn as () => void)();
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        });
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('should keep every supported asset within jitter bounds across many random samples', async () => {
+        for (let i = 0; i < SAMPLES; i++) {
+          const result = await fetchUpstreamPrices(ALL_ASSETS);
+
+          for (const asset of ALL_ASSETS) {
+            const { base, maxJitter } = BASE_PRICES[asset];
+            const price = result.prices[asset];
+
+            expect(typeof price).toBe('number');
+            expect(price).toBeGreaterThanOrEqual(base - maxJitter);
+            expect(price).toBeLessThanOrEqual(base + maxJitter);
+          }
+        }
+      });
+
+      it('should never produce a price with jitter exceeding 2 % of base', async () => {
+        for (let i = 0; i < SAMPLES; i++) {
+          const result = await fetchUpstreamPrices(ALL_ASSETS);
+
+          for (const asset of ALL_ASSETS) {
+            const { base } = BASE_PRICES[asset];
+            const price = result.prices[asset];
+            const pctDeviation = Math.abs(price - base) / base;
+
+            expect(pctDeviation).toBeLessThanOrEqual(MAX_JITTER_PCT);
+          }
+        }
+      });
+
+      it('should always return USDC at exactly 1.0', async () => {
+        for (let i = 0; i < SAMPLES; i++) {
+          const result = await fetchUpstreamPrices(['USDC']);
+          expect(result.prices.USDC).toBe(1.0);
+        }
+      });
+
+      it('should produce some price variation (not stuck at one value)', async () => {
+        const seen = new Set<number>();
+        for (let i = 0; i < SAMPLES; i++) {
+          const result = await fetchUpstreamPrices(['XLM']);
+          seen.add(result.prices.XLM);
+        }
+        expect(seen.size).toBeGreaterThan(1);
+      });
+    });
   });
 
   describe('Error Handling', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -114,6 +114,7 @@ export default defineConfig({
             "lib/streams/**/*.test.ts",
             "lib/soroban/**/*.test.ts",
             "lib/indexer/**/*.test.ts",
+            "lib/prices/**/*.test.ts",
             "scripts/**/*.test.ts",
           ],
         },


### PR DESCRIPTION
## Summary

Add tests asserting `fetchMockPrices` output stays within intended jitter bounds across 200 random samples for every supported asset (XLM, USDC, BTC, ETH).

## Changes

- **`lib/prices/fetcher.test.ts`**: Added a new `Jitter Bounds` describe block with 4 tests:
  - `should keep every supported asset within jitter bounds across many random samples` — verifies each price stays within `base ± maxJitter`
  - `should never produce a price with jitter exceeding 2 % of base` — sanity check that jitter never exceeds 2% of the base price
  - `should always return USDC at exactly 1.0` — USDC has no jitter
  - `should produce some price variation (not stuck at one value)` — confirms randomization actually varies output

- **`vitest.config.ts`**: Added `lib/prices/**/*.test.ts` to the `server-unit` project include list so these tests are discovered by vitest.

## Jitter Bounds Reference

| Asset | Base Price | Max Jitter (±) | Max % Deviation |
|-------|-----------|----------------|-----------------|
| XLM   | 0.1245    | 0.001          | ~0.8%           |
| USDC  | 1.0       | 0              | 0%              |
| BTC   | 67340.5   | 50             | ~0.07%          |
| ETH   | 3480.2    | 5              | ~0.14%          |

Closes #1168