### PR TITLE
Added integration tests for the app/api/account/delete challenge route

### DIFF
--- a/.kilo/kilo.jsonc
+++ b/.kilo/kilo.jsonc
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://app.kilo.ai/config.json",
   "snapshot": false
 }

--- a/app/api/account/delete/CHALLENGE_TESTS.md
+++ b/app/api/account/delete/CHALLENGE_TESTS.md
@@ -1,0 +1,42 @@
+# Account Deletion Challenge Tests
+
+This document outlines the test plan for the account deletion challenge flow:
+challenge issuance (`GET /api/account/delete/challenge`) and the challenge
+verification gate (`DELETE /api/account/delete`).
+
+## Test Scopes
+
+### `GET /api/account/delete/challenge` — Challenge issuance
+
+| # | Test | Expected |
+|---|------|----------|
+| 1 | Unauthenticated request | `401` |
+| 2 | Invalid / malformed token | `401` |
+| 3 | Authenticated request returns a 64-hex challenge token | `200` + `challenge`, `expiresAt`, `message` in body |
+| 4 | Challenge is single-use (immediate verify + re-verify via `verifyDeletionChallenge`) | First `true`, second `false` |
+| 5 | Audit event `auth.challenge.issued` is emitted | Event present with `challengeType: 'account_deletion'` |
+
+### `DELETE /api/account/delete` — Challenge verification gate
+
+| # | Test | Expected |
+|---|------|----------|
+| 6 | Unauthenticated request | `401` |
+| 7 | Missing `challenge` in body | `400` with `'Missing deletion challenge'` |
+| 8 | Malformed JSON body | `400` |
+| 9 | Nonexistent challenge string | `401` with `'Invalid or expired'` |
+| 10 | Challenge issued for a different user | `401` |
+| 11 | Valid challenge accepted; `deleteAccount` called | `200` with `'Account deletion initiated'` |
+| 12 | Replay of an already consumed challenge | `401` with `'Invalid or expired'` |
+| 13 | Expired challenge (TTL window passed) | `401` with `'Invalid or expired'` |
+
+## Implementation notes
+
+- **File**: `app/api/account/delete/challenge/route.test.ts`
+- The challenge store is the real in-memory implementation (not mocked) so that the
+  full challenge lifecycle is exercised at the route level.
+- `@/lib/account/delete` is mocked because the focus is on the verification gate;
+  full deletion integration (profile anonymization, notification removal, cleanup
+  jobs) is covered in `__tests__/api/account/delete.test.ts`.
+- Rate-limit 429 behaviour is tested separately in
+  `app/api/account/delete/challenge/route.ratelimit.test.ts`.
+- Fake timers (`vi.useFakeTimers`) are used for the expired-challenge edge case.

--- a/app/api/account/delete/challenge/route.test.ts
+++ b/app/api/account/delete/challenge/route.test.ts
@@ -1,0 +1,243 @@
+import { vi, describe, expect, test, beforeEach, afterEach } from 'vitest';
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/account/delete', () => ({
+  deleteAccount: vi.fn().mockResolvedValue({
+    success: true,
+    userId: 'challenge-test-user',
+    anonymizedAt: new Date().toISOString(),
+    notificationsRemoved: 0,
+    cleanupJobsEnqueued: [],
+    auditEventId: 'audit-1',
+  }),
+}));
+
+import { NextRequest } from 'next/server';
+import { GET as ChallengeGET } from './route';
+import { DELETE as DeleteDELETE } from '@/app/api/account/delete/route';
+import { signToken } from '@/lib/auth';
+import {
+  clearChallengeStore,
+  verifyDeletionChallenge,
+} from '@/lib/account/challenge-store';
+import { clearAuditLog, getAuditEvents } from '@/lib/audit/events';
+import { clearAccountBucketCache } from '@/lib/rate-limit/account-bucket';
+import { deleteAccount } from '@/lib/account/delete';
+
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
+const USER = { id: 'challenge-test-user', email: 'challenge@test.com' };
+const ALT_USER = { id: 'other-user', email: 'other@test.com' };
+
+function makeRequest(
+  method: 'GET' | 'DELETE',
+  url: string,
+  opts: { token?: string; body?: unknown } = {},
+): NextRequest {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
+  return new NextRequest(url, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+}
+
+function validToken(user = USER) {
+  return signToken(user);
+}
+
+beforeEach(() => {
+  clearChallengeStore();
+  clearAuditLog();
+  clearAccountBucketCache();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GET /api/account/delete/challenge — challenge issuance', () => {
+  test('returns 401 when unauthenticated', async () => {
+    const res = await ChallengeGET(
+      makeRequest('GET', 'http://localhost/api/account/delete/challenge'),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 401 for invalid token', async () => {
+    const res = await ChallengeGET(
+      makeRequest('GET', 'http://localhost/api/account/delete/challenge', {
+        token: 'invalid-token',
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test('returns a single-use challenge token bound to the user', async () => {
+    const token = validToken();
+    const res = await ChallengeGET(
+      makeRequest('GET', 'http://localhost/api/account/delete/challenge', { token }),
+    );
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.challenge).toBeDefined();
+    expect(json.challenge.length).toBe(64);
+    expect(json.expiresAt).toBeDefined();
+    expect(json.message).toContain('Sign this challenge');
+
+    const valid = verifyDeletionChallenge(json.challenge, USER.id);
+    expect(valid).toBe(true);
+
+    const replayed = verifyDeletionChallenge(json.challenge, USER.id);
+    expect(replayed).toBe(false);
+  });
+
+  test('emits auth.challenge.issued audit event', async () => {
+    const token = validToken();
+    await ChallengeGET(
+      makeRequest('GET', 'http://localhost/api/account/delete/challenge', { token }),
+    );
+
+    const events = getAuditEvents({ userId: USER.id, type: 'auth.challenge.issued' });
+    expect(events.length).toBe(1);
+    expect(events[0].metadata.challengeType).toBe('account_deletion');
+  });
+});
+
+describe('DELETE /api/account/delete — challenge verification gate', () => {
+  test('returns 401 when unauthenticated', async () => {
+    const res = await DeleteDELETE(
+      makeRequest('DELETE', 'http://localhost/api/account/delete', {
+        body: { challenge: 'some-challenge' },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 400 when challenge is missing', async () => {
+    const token = validToken();
+    const res = await DeleteDELETE(
+      makeRequest('DELETE', 'http://localhost/api/account/delete', { token, body: {} }),
+    );
+    expect(res.status).toBe(400);
+
+    const json = await res.json();
+    expect(json.error).toContain('Missing deletion challenge');
+  });
+
+  test('returns 400 for malformed JSON body', async () => {
+    const token = validToken();
+    const req = new NextRequest('http://localhost/api/account/delete', {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: '{ invalid json',
+    });
+    const res = await DeleteDELETE(req);
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 401 for an invalid (nonexistent) challenge', async () => {
+    const token = validToken();
+    const res = await DeleteDELETE(
+      makeRequest('DELETE', 'http://localhost/api/account/delete', {
+        token,
+        body: { challenge: 'nonexistent-challenge' },
+      }),
+    );
+    expect(res.status).toBe(401);
+
+    const json = await res.json();
+    expect(json.error).toContain('Invalid or expired');
+  });
+
+  test('returns 401 when challenge belongs to a different user', async () => {
+    const altToken = validToken(ALT_USER);
+    const challengeRes = await ChallengeGET(
+      makeRequest('GET', 'http://localhost/api/account/delete/challenge', { token: altToken }),
+    );
+    const { challenge } = await challengeRes.json();
+
+    const token = validToken(USER);
+    const res = await DeleteDELETE(
+      makeRequest('DELETE', 'http://localhost/api/account/delete', {
+        token,
+        body: { challenge },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test('accepts a valid challenge and proceeds to delete the account', async () => {
+    const token = validToken();
+    const challengeRes = await ChallengeGET(
+      makeRequest('GET', 'http://localhost/api/account/delete/challenge', { token }),
+    );
+    const { challenge } = await challengeRes.json();
+
+    const res = await DeleteDELETE(
+      makeRequest('DELETE', 'http://localhost/api/account/delete', {
+        token,
+        body: { challenge },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(deleteAccount).toHaveBeenCalledWith(USER.id);
+
+    const json = await res.json();
+    expect(json.message).toBe('Account deletion initiated');
+  });
+
+  test('rejects a replayed (already consumed) challenge', async () => {
+    const token = validToken();
+    const challengeRes = await ChallengeGET(
+      makeRequest('GET', 'http://localhost/api/account/delete/challenge', { token }),
+    );
+    const { challenge } = await challengeRes.json();
+
+    const first = await DeleteDELETE(
+      makeRequest('DELETE', 'http://localhost/api/account/delete', {
+        token,
+        body: { challenge },
+      }),
+    );
+    expect(first.status).toBe(200);
+
+    const second = await DeleteDELETE(
+      makeRequest('DELETE', 'http://localhost/api/account/delete', {
+        token,
+        body: { challenge },
+      }),
+    );
+    expect(second.status).toBe(401);
+
+    const json = await second.json();
+    expect(json.error).toContain('Invalid or expired');
+  });
+
+  test('rejects an expired challenge', async () => {
+    vi.useFakeTimers();
+
+    const token = validToken();
+    const challengeRes = await ChallengeGET(
+      makeRequest('GET', 'http://localhost/api/account/delete/challenge', { token }),
+    );
+    const { challenge } = await challengeRes.json();
+
+    vi.advanceTimersByTime(CHALLENGE_TTL_MS + 1000);
+
+    const res = await DeleteDELETE(
+      makeRequest('DELETE', 'http://localhost/api/account/delete', {
+        token,
+        body: { challenge },
+      }),
+    );
+    expect(res.status).toBe(401);
+
+    const json = await res.json();
+    expect(json.error).toContain('Invalid or expired');
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
The app/api/account/delete/challenge route issues the deletion challenge but has no test file. Challenge issuance and consumption are untested at the route level.
Closes #638

Closes #638