### PR TITLE
fix(indexer): persist horizon cursor to postgres to survive restarts

### DIFF
--- a/lib/indexer/cursor.ts
+++ b/lib/indexer/cursor.ts
@@ -1,25 +1,46 @@
-// Mocking a database connection layer for indexer_cursors table tracking
+import { client } from '../db/index';
+
+// Ensures the table exists without relying on external migration scripts.
+const initDb = async () => {
+  await client`
+    CREATE TABLE IF NOT EXISTS indexer_cursors (
+      id TEXT PRIMARY KEY,
+      paging_token TEXT NOT NULL,
+      updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+  `;
+};
+initDb().catch(console.error);
+
 export interface IndexerCursor {
   id: string;
   pagingToken: string;
   updatedAt: Date;
 }
 
-// Global in-memory representation mimicking transactional storage behavior
-const dbMockStore = new Map<string, string>();
-
 export async function getLatestCursor(indexerId: string): Promise<string | null> {
-  return dbMockStore.get(indexerId) || null;
+  const result = await client`
+    SELECT paging_token FROM indexer_cursors WHERE id = ${indexerId}
+  `;
+  return result.length > 0 ? result[0].paging_token : null;
 }
 
 export async function saveCursorCheckpoint(indexerId: string, pagingToken: string): Promise<void> {
   if (!pagingToken) {
     throw new Error("Invalid paging token provided for checkpointing.");
   }
-  // Simulates a transactional upsert on the indexer_cursors table
-  dbMockStore.set(indexerId, pagingToken);
+  
+  await client`
+    INSERT INTO indexer_cursors (id, paging_token, updated_at)
+    VALUES (${indexerId}, ${pagingToken}, CURRENT_TIMESTAMP)
+    ON CONFLICT (id) DO UPDATE 
+    SET paging_token = EXCLUDED.paging_token, 
+        updated_at = CURRENT_TIMESTAMP;
+  `;
 }
 
-export function clearMockCursors(): void {
-  dbMockStore.clear();
+export async function clearMockCursors(): Promise<void> {
+  if (process.env.NODE_ENV === 'test' || typeof process.env.VITEST !== 'undefined') {
+    await client`TRUNCATE TABLE indexer_cursors;`;
+  }
 }

--- a/test/horizon-indexer.test.ts
+++ b/test/horizon-indexer.test.ts
@@ -1,15 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { clearMockCursors, getLatestCursor } from '../lib/indexer/cursor';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { clearMockCursors, getLatestCursor, saveCursorCheckpoint } from '../lib/indexer/cursor';
 import { HorizonIndexer, HorizonOperation } from '../lib/indexer/horizon';
 
 describe('Horizon Indexer Cursor Checkpointing & Resumability', () => {
-  beforeEach(() => {
-    clearMockCursors();
+  // Await the now-asynchronous database truncation
+  beforeEach(async () => {
+    await clearMockCursors();
   });
 
   it('should start with a null cursor and save the last paging token after ingestion', async () => {
     const indexer = new HorizonIndexer('lending-operations-indexer');
-    
+
     const mockBatch: HorizonOperation[] = [
       { id: 'op_1', paging_token: '1001', type: 'payment', transaction_successful: true },
       { id: 'op_2', paging_token: '1002', type: 'borrow', transaction_successful: true }
@@ -23,15 +24,13 @@ describe('Horizon Indexer Cursor Checkpointing & Resumability', () => {
     const processedCount = await indexer.fetchAndProcessBatch(mockFetcher);
     expect(processedCount).toBe(2);
 
-    // Verify checkpoint state update
     const finalCursor = await getLatestCursor('lending-operations-indexer');
     expect(finalCursor).toBe('1002');
   });
 
   it('should resume from the last saved cursor checkpoint state', async () => {
     const indexer = new HorizonIndexer('lending-operations-indexer');
-    
-    // Pre-seed the cursor store
+
     const mockBatch: HorizonOperation[] = [
       { id: 'op_3', paging_token: '2005', type: 'deposit', transaction_successful: true }
     ];
@@ -39,7 +38,6 @@ describe('Horizon Indexer Cursor Checkpointing & Resumability', () => {
     const mockFetcherFirst = async () => mockBatch;
     await indexer.fetchAndProcessBatch(mockFetcherFirst);
 
-    // Execute second batch tracking from the verified state
     const mockFetcherSecond = async (cursor: string | null) => {
       expect(cursor).toBe('2005');
       return [];
@@ -47,5 +45,20 @@ describe('Horizon Indexer Cursor Checkpointing & Resumability', () => {
 
     const count = await indexer.fetchAndProcessBatch(mockFetcherSecond);
     expect(count).toBe(0);
+  });
+
+  it('should survive a simulated process restart (Issue #1121)', async () => {
+    // 1. Write the cursor to the real database
+    await saveCursorCheckpoint('restart-test-indexer', 'token-9999');
+
+    // 2. Wipe the Vitest module cache (Simulates Node.js server restart and RAM flush)
+    vi.resetModules();
+
+    // 3. Dynamically re-import the module (like starting the server fresh)
+    const newCursorModule = await import('../lib/indexer/cursor');
+
+    // 4. Assert the cursor was read from Postgres, not RAM
+    const cursor = await newCursorModule.getLatestCursor('restart-test-indexer');
+    expect(cursor).toBe('token-9999');
   });
 });


### PR DESCRIPTION
**Fixes #1121**

## Description
This PR addresses the data loss issue where the Horizon indexer's resume cursor was being wiped during Node process restarts. The in-memory `Map` mock (`dbMockStore`) has been entirely replaced with a real Postgres persistence layer.

## Changes Made
*   **Database Integration:** Imported the existing Postgres `client` from `lib/db/index.ts`.
*   **Table Initialization:** Implemented an `initDb()` block in `lib/indexer/cursor.ts` to ensure the `indexer_cursors` table exists on module load, mirroring the SQLite pattern elsewhere in the codebase.
*   **Transactional Upsert:** Upgraded `saveCursorCheckpoint` to execute a raw Postgres `UPSERT` (Insert on conflict Update) to safely track the latest `paging_token`.
*   **State Retrieval:** Upgraded `getLatestCursor` to query the database directly.
*   **Integration Testing:** Added a dedicated test in `test/horizon-indexer.test.ts` utilizing `vi.resetModules()` to simulate a hard server restart and verify that the cursor successfully survives memory flushes.