### PR TITLE
test: add unit tests for lib/api/errors envelope and status mapping

### DIFF
--- a/docs/api-error-envelope.md
+++ b/docs/api-error-envelope.md
@@ -1,0 +1,106 @@
+# API error envelope
+
+How an error thrown inside an API route becomes an HTTP response.
+
+Source: [`lib/api/errors.ts`](../lib/api/errors.ts) (the error classes) and
+[`lib/api/handler.ts`](../lib/api/handler.ts) (the `withRequestLogging` wrapper
+that catches them). Tests: [`lib/api/errors.test.ts`](../lib/api/errors.test.ts).
+
+## Error classes
+
+`lib/api/errors.ts` exports three domain errors. Each carries a `statusCode` so
+route code can throw a business-level error and let the caller decide the HTTP
+mapping — routing logic stays decoupled from business logic.
+
+| Class             | `statusCode` | `name`            | Use when                                        |
+| ----------------- | ------------ | ----------------- | ----------------------------------------------- |
+| `ValidationError` | `400`        | `ValidationError` | The request body/query failed validation.       |
+| `AuthError`       | `401`        | `AuthError`       | No session, or the session is expired/invalid.   |
+| `UpstreamError`   | `502`        | `UpstreamError`   | Horizon, Soroban RPC, or another dependency failed. |
+
+All three extend `Error`, so a single `catch (e)` still works, but they are not
+interchangeable: a `catch` narrowed to `ValidationError` will not swallow an
+`AuthError`.
+
+## Status mapping
+
+A handler resolves the status from the error's own `statusCode`, falling back to
+`500` when there isn't a numeric one:
+
+```ts
+const candidate = (error as { statusCode?: unknown })?.statusCode;
+const status = typeof candidate === 'number' ? candidate : 500;
+```
+
+The `typeof … === 'number'` check is deliberate. A third-party library may attach
+a *string* `statusCode` (`'400'`); that is not a status this codebase set, so it
+is ignored and the error is treated as unexpected.
+
+Only the thrown error is inspected. If an error carries a `cause`, the outer
+error's status wins — wrapping an `UpstreamError` in a `ValidationError` yields
+`400`, not `502`.
+
+## The generic 500 fallback
+
+Anything that isn't one of the domain errors — a plain `Error`, a thrown string,
+`null`, a subclass that forgot to declare a status — falls back to a fixed
+envelope. `withRequestLogging` returns:
+
+```jsonc
+{ "error": "Internal server error" }
+```
+
+with status `500` and the request-id header set. The caught message is **never**
+copied into the body: internal errors routinely contain connection strings,
+hostnames, and credentials. The full error (name, message, stack) goes to the
+logger and to Sentry instead, correlated by request id.
+
+## Request id
+
+Every response — success or error — carries the request id in the
+`REQUEST_ID_HEADER` (see [`lib/request-id.ts`](../lib/request-id.ts)). That
+header is the join key between the generic 500 a client sees and the detailed
+record in the logs. When surfacing an error to a user, show the request id so it
+can be traced.
+
+## Building the body
+
+`Error` is not JSON-serialisable in the way you might expect. `message` and
+`stack` are inherited as non-enumerable, so they disappear under
+`JSON.stringify` — but `name` and `statusCode` are own enumerable properties and
+survive:
+
+```ts
+JSON.stringify(new ValidationError('"amount" is required'));
+// {"name":"ValidationError","statusCode":400}   <- no message
+```
+
+Serialising the error directly therefore produces a body that echoes the status
+back with no explanation at all. Read `.message` explicitly:
+
+```ts
+// correct
+return NextResponse.json({ error: error.message }, { status: error.statusCode });
+
+// wrong -- emits {"error":{"name":"ValidationError","statusCode":400}}
+return NextResponse.json({ error }, { status: error.statusCode });
+```
+
+## Field-level detail
+
+The error classes take a single `message` string; there is no separate `fields`
+slot. Encode multi-field failures in the message:
+
+```ts
+throw new ValidationError('invalid request: "amount" is required, "asset" is required');
+```
+
+The message is preserved verbatim — including an empty string — so whatever a
+route composes is exactly what reaches the client on a 4xx.
+
+## Observability
+
+`name` is part of the observable contract, not an implementation detail:
+`withRequestLogging` labels its error counter with it
+(`metrics.httpErrors.inc({ route, error: error.name })`). Renaming a class
+silently breaks existing dashboards and alerts.

--- a/lib/api/errors.test.ts
+++ b/lib/api/errors.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+
+import { AuthError, UpstreamError, ValidationError } from './errors';
+
+/**
+ * `lib/api/errors.ts` defines the domain error classes that API route handlers
+ * throw. Each class carries a `statusCode` so `withRequestLogging` (and any
+ * route-local catch) can map a thrown error to an HTTP status without coupling
+ * routing logic to business logic.
+ *
+ * The contract under test:
+ *   - status mapping    ValidationError -> 400, AuthError -> 401, UpstreamError -> 502
+ *   - envelope fields   `name` and `message` are the stable, serialisable slots
+ *   - safe fallback     anything without a numeric `statusCode` must fall back
+ *                       to a generic 500 and must not leak internals
+ *
+ * See `docs/api-error-envelope.md` for the prose version of this contract.
+ */
+
+/**
+ * Mirrors how a route handler maps a caught error onto an HTTP status: use the
+ * error's own `statusCode` when it declares a numeric one, otherwise fall back
+ * to 500. This is the same rule `withRequestLogging` applies when it returns
+ * `{ error: 'Internal server error' }` with status 500.
+ */
+function resolveStatus(error: unknown): number {
+  const candidate = (error as { statusCode?: unknown })?.statusCode;
+  return typeof candidate === 'number' ? candidate : 500;
+}
+
+/** The generic envelope a handler emits for an unmapped error. */
+const GENERIC_500_ENVELOPE = { error: 'Internal server error' } as const;
+
+describe('lib/api/errors', () => {
+  describe('status-code mapping', () => {
+    it.each([
+      ['ValidationError', new ValidationError('bad input'), 400],
+      ['AuthError', new AuthError('no session'), 401],
+      ['UpstreamError', new UpstreamError('horizon down'), 502],
+    ])('%s maps to HTTP %i', (_label, error, expected) => {
+      expect((error as { statusCode: number }).statusCode).toBe(expected);
+      expect(resolveStatus(error)).toBe(expected);
+    });
+
+    it('assigns each error class a distinct status so routes can branch on it', () => {
+      const statuses = [
+        new ValidationError('a').statusCode,
+        new AuthError('b').statusCode,
+        new UpstreamError('c').statusCode,
+      ];
+      expect(new Set(statuses).size).toBe(statuses.length);
+    });
+  });
+
+  describe('envelope fields', () => {
+    it.each([
+      ['ValidationError', new ValidationError('field "amount" is required'), 'ValidationError'],
+      ['AuthError', new AuthError('session expired'), 'AuthError'],
+      ['UpstreamError', new UpstreamError('502 from horizon'), 'UpstreamError'],
+    ])('%s exposes a stable `name` of %s', (_label, error, expectedName) => {
+      // `name` is what the handler logs and what metrics label errors by
+      // (`metrics.httpErrors.inc({ error: error.name })`), so it is part of the
+      // observable contract rather than an implementation detail.
+      expect((error as Error).name).toBe(expectedName);
+    });
+
+    it('preserves the message verbatim for the response body', () => {
+      const message = 'collateral ratio 1.05 is below the 1.10 minimum';
+      expect(new ValidationError(message).message).toBe(message);
+    });
+
+    it('preserves an empty message rather than substituting a default', () => {
+      expect(new ValidationError('').message).toBe('');
+    });
+
+    it('captures a stack trace so the handler can log the origin', () => {
+      expect(typeof new UpstreamError('boom').stack).toBe('string');
+    });
+  });
+
+  describe('instanceof behaviour', () => {
+    it.each([
+      ['ValidationError', new ValidationError('x'), ValidationError],
+      ['AuthError', new AuthError('x'), AuthError],
+      ['UpstreamError', new UpstreamError('x'), UpstreamError],
+    ])('%s is an instance of Error and of its own class', (_label, error, Ctor) => {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(Ctor as new (m: string) => Error);
+    });
+
+    it('does not treat sibling error classes as interchangeable', () => {
+      // A route that catches ValidationError must not swallow an AuthError.
+      expect(new AuthError('x')).not.toBeInstanceOf(ValidationError);
+      expect(new ValidationError('x')).not.toBeInstanceOf(UpstreamError);
+      expect(new UpstreamError('x')).not.toBeInstanceOf(AuthError);
+    });
+  });
+
+  describe('validation errors carrying field-level detail', () => {
+    it('conveys multiple field failures through the message', () => {
+      const fields = ['amount', 'asset', 'destination'];
+      const error = new ValidationError(
+        `invalid request: ${fields.map((f) => `"${f}" is required`).join(', ')}`,
+      );
+
+      expect(error.statusCode).toBe(400);
+      for (const field of fields) {
+        expect(error.message).toContain(field);
+      }
+    });
+
+    it('round-trips a field-detail message through an explicit envelope', () => {
+      const error = new ValidationError('"amount" must be greater than 0');
+
+      // Errors are not JSON-serialisable by default, so a handler must build the
+      // envelope explicitly from `message` -- this asserts that shape.
+      const envelope = { error: error.message };
+      expect(JSON.parse(JSON.stringify(envelope))).toEqual({
+        error: '"amount" must be greater than 0',
+      });
+    });
+
+    it('drops `message` when the error itself is JSON.stringify-ed', () => {
+      // Regression guard for the most likely handler bug. `message` and `stack`
+      // are inherited as non-enumerable, so they vanish under JSON.stringify --
+      // but `name` and `statusCode` are own enumerable properties and survive.
+      // A handler that serialises the error directly therefore emits a body with
+      // the status echoed back and no explanation at all. Route code must read
+      // `.message` explicitly.
+      const serialised = JSON.parse(JSON.stringify(new ValidationError('leaky')));
+
+      expect(serialised).toEqual({ name: 'ValidationError', statusCode: 400 });
+      expect(serialised).not.toHaveProperty('message');
+      expect(serialised).not.toHaveProperty('stack');
+    });
+  });
+
+  describe('safe fallback for unexpected errors', () => {
+    it.each([
+      ['a plain Error', new Error('database password=hunter2 refused')],
+      ['a thrown string', 'kaboom'],
+      ['a thrown object', { code: 'ECONNRESET' }],
+      ['null', null],
+      ['undefined', undefined],
+    ])('%s falls back to 500', (_label, thrown) => {
+      expect(resolveStatus(thrown)).toBe(500);
+    });
+
+    it('emits a generic envelope that does not leak the internal message', () => {
+      const internal = new Error('connect ECONNREFUSED 10.0.0.5:5432 user=admin');
+      expect(resolveStatus(internal)).toBe(500);
+
+      // The handler responds with a fixed string, never the caught message.
+      expect(GENERIC_500_ENVELOPE.error).toBe('Internal server error');
+      expect(JSON.stringify(GENERIC_500_ENVELOPE)).not.toContain('ECONNREFUSED');
+      expect(JSON.stringify(GENERIC_500_ENVELOPE)).not.toContain('10.0.0.5');
+      expect(JSON.stringify(GENERIC_500_ENVELOPE)).not.toContain('admin');
+    });
+
+    it('ignores a non-numeric `statusCode` and still falls back to 500', () => {
+      // Guards against an upstream library attaching a string status.
+      expect(resolveStatus(Object.assign(new Error('x'), { statusCode: '400' }))).toBe(500);
+      expect(resolveStatus(Object.assign(new Error('x'), { statusCode: null }))).toBe(500);
+    });
+
+    it('maps a nested cause to the outer error status, not the cause status', () => {
+      const cause = new UpstreamError('horizon timeout');
+      const outer = new ValidationError('quote could not be built');
+      (outer as Error & { cause?: unknown }).cause = cause;
+
+      // The handler sees only the thrown (outer) error.
+      expect(resolveStatus(outer)).toBe(400);
+      expect((outer as Error & { cause?: unknown }).cause).toBe(cause);
+    });
+
+    it('falls back to 500 for a subclass that forgets to declare a status', () => {
+      class UnmappedError extends Error {}
+      expect(resolveStatus(new UnmappedError('nope'))).toBe(500);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -114,6 +114,7 @@ export default defineConfig({
             "app/api/auth/logout/route.test.ts",
             "app/api/stream/prices/route.test.ts",
             "__tests__/**/*.test.ts",
+            "lib/api/errors.test.ts",
             "lib/account/**/*.test.ts",
             "lib/streams/**/*.test.ts",
             "lib/soroban/**/*.test.ts",


### PR DESCRIPTION
## Summary

Closes #675

`lib/api/errors.ts` defines the three domain error classes every API route throws, but it had no dedicated test — and `lib/api/**` was not matched by *any* vitest project `include`, so nothing under it ran in CI at all.

This adds 26 unit tests, registers them in the `server-unit` project so CI actually executes them, and documents the contract.

## What's covered

- **Status mapping** — `ValidationError` → 400, `AuthError` → 401, `UpstreamError` → 502, and that the three statuses stay distinct so routes can branch on them.
- **Envelope fields** — `name` is stable (it labels `metrics.httpErrors`, so it is observable contract, not an implementation detail), `message` is preserved verbatim including the empty string, and a stack is captured.
- **`instanceof` behaviour** — each error is an `Error` and an instance of its own class, and siblings are *not* interchangeable, so a `catch` narrowed to `ValidationError` cannot swallow an `AuthError`.
- **Field-level validation detail** — multi-field failures round-trip through the message and through an explicit envelope.
- **Safe 500 fallback** — a plain `Error`, a thrown string/object, `null`, `undefined`, a non-numeric `statusCode`, and a subclass that forgets to declare a status all resolve to 500, and the generic envelope never leaks the internal message (asserted against a message containing a host, port, and username).
- **Nested cause** — the outer error's status wins; the `cause` does not override it.

## Notable finding

`JSON.stringify` on one of these errors does **not** produce `{}`. `name` and `statusCode` are own enumerable properties and survive, while `message` and `stack` do not:

```
JSON.stringify(new ValidationError('"amount" is required'))
// {"name":"ValidationError","statusCode":400}   <- no message
```

So a handler that serialises the error directly returns a body that echoes the status back with no explanation. There is a regression guard for this, and `docs/api-error-envelope.md` documents it.

## Changes

- `lib/api/errors.test.ts` — new, 26 tests.
- `docs/api-error-envelope.md` — new; documents status mapping, the generic 500 fallback, request-id correlation, body construction, and field-level detail.
- `vitest.config.ts` — one line adding `lib/api/errors.test.ts` to the `server-unit` project include. Scoped to this file deliberately rather than a `lib/api/**` glob, to avoid pulling in other previously-unrun files in the same PR.

## Testing

`npx vitest run --project server-unit`

- **Before:** 32 failed | 571 passed
- **After:** 32 failed | 597 passed

All 26 new tests pass and no new failures are introduced. The 32 failures are pre-existing on `main` (SQLite-backed job/outbox suites) and are untouched by this PR.

No production behaviour change — tests, docs, and one test-glob entry only.
