### PR TITLE
fix: log Sentry initialization failures

### DIFF
--- a/instrumentation.test.ts
+++ b/instrumentation.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const initSentry = vi.fn();
+vi.mock('@/lib/telemetry/sentry', () => ({ initSentry }));
+
+describe('instrumentation register', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.NEXT_RUNTIME = 'nodejs';
+  });
+
+  it('logs an unexpected Sentry initialization error', async () => {
+    const error = new Error('invalid Sentry configuration');
+    initSentry.mockImplementationOnce(() => { throw error; });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const { register } = await import('./instrumentation');
+    await register();
+
+    expect(consoleError).toHaveBeenCalledWith('Failed to initialize Sentry', error);
+  });
+});

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,12 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     const { initSentry } = await import('@/lib/telemetry/sentry');
-    try { initSentry(); } catch { /* Sentry DSN not configured */ }
+    try {
+      initSentry();
+    } catch (error) {
+      // Do not use Sentry to report an initialization failure: it may be the
+      // failing dependency. The provider already handles a missing DSN.
+      console.error('Failed to initialize Sentry', error);
+    }
   }
 }


### PR DESCRIPTION
## Description
Logs unexpected errors thrown by `initSentry()` instead of silently swallowing them. A missing DSN remains handled in `initSentry()` itself.

## Tests
- Added regression coverage asserting an `Sentry.init` failure is logged via `console.error`.
- Not run locally: dependencies are not installed (`vitest: not found`).

Closes #1180.