### PR TITLE
fix: AlertBanner localStorage try/catch (#962)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,12 +5,15 @@ on:
     tags:
       - 'v*'
 
-environment: production
-
 jobs:
   deploy-production:
     runs-on: ubuntu-latest
-    
+    # `environment` must live on the job (not the workflow root). A top-level
+    # `environment:` key is invalid GHA schema and makes GitHub report
+    # "This run likely failed because of a workflow file issue" with 0 jobs
+    # on every push that re-evaluates workflows.
+    environment: production
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -54,14 +57,14 @@ jobs:
           release_name: Release ${{ github.ref }}
           body: |
             🚀 **Stellarlend Frontend Release ${{ github.ref }}**
-            
+
             **Changes in this Release:**
             ${{ github.event.head_commit.message }}
-            
+
             **Deployment:**
             - ✅ Production deployment successful
-            - 🔗 Live at: https://stellarlend.com
-            
+            - 🌐 Live at: https://stellarlend.com
+
             **What's New:**
             - Bug fixes and improvements
             - Performance optimizations

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,15 +45,3 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-args: '--env NEXT_PUBLIC_APP_ENV=staging'
-
-      - name: Comment PR with staging URL
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🚀 Staging deployment ready! Check it out at the Vercel preview URL.'
-            })

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,12 +4,16 @@ on:
   push:
     branches: [develop]
 
-environment: staging
-
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest
-    
+    # `environment` must live on the job (not the workflow root). A top-level
+    # `environment:` key is invalid GHA schema and makes GitHub report
+    # "This run likely failed because of a workflow file issue" with 0 jobs
+    # on every push/PR that re-evaluates workflows — even though this file
+    # only triggers on push to develop.
+    environment: staging
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,14 +1,17 @@
 name: Application Monitoring
 
 on:
-  schedule:
-    - cron: ''  # Every 5 minutes
+  # Previously: `cron: ''` which is invalid GitHub Actions syntax and caused
+  # "workflow file issue" failures (0 jobs) whenever workflows were
+  # re-evaluated on push/PR. Keep manual runs only until real health
+  # endpoints + SLACK_WEBHOOK_URL are provisioned; then restore a valid
+  # schedule such as: schedule: - cron: '*/5 * * * *'
   workflow_dispatch:
 
 jobs:
   health-check:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Check staging health
         id: staging-check
@@ -40,10 +43,10 @@ jobs:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           text: |
             🚨 **ALERT: Staging Environment Down**
-            
+
             The Stellarlend staging environment is not responding.
             URL: https://stellarlend-staging.vercel.app
-            
+
             Please investigate immediately.
 
       - name: Alert on production failure
@@ -54,10 +57,10 @@ jobs:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           text: |
             🚨 **CRITICAL ALERT: Production Environment Down**
-            
+
             The Stellarlend production environment is not responding.
             URL: https://stellarlend.com
-            
+
             **IMMEDIATE ACTION REQUIRED**
 
       - name: Performance monitoring
@@ -65,10 +68,10 @@ jobs:
           # Check response times
           staging_time=$(curl -o /dev/null -s -w "%{time_total}" https://stellarlend-staging.vercel.app || echo "0")
           production_time=$(curl -o /dev/null -s -w "%{time_total}" https://stellarlend.com || echo "0")
-          
+
           echo "Staging response time: ${staging_time}s"
           echo "Production response time: ${production_time}s"
-          
+
           # Alert if response time > 5 seconds
           if (( $(echo "$production_time > 5.0" | bc -l) )); then
             echo "Production response time is too slow: ${production_time}s"

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -5,7 +5,9 @@ on:
   # "workflow file issue" failures (0 jobs) whenever workflows were
   # re-evaluated on push/PR. Keep manual runs only until real health
   # endpoints + SLACK_WEBHOOK_URL are provisioned; then restore a valid
-  # schedule such as: schedule: - cron: '*/5 * * * *'
+  # schedule such as:
+  # schedule:
+  #   - cron: '*/5 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -38,11 +38,10 @@ jobs:
       # dedicated `bundle-size` job below, so no inline step is needed here.
       # Note: fork PRs receive a read-only GITHUB_TOKEN that cannot create
       # issue comments (403 "Resource not accessible by integration"), even
-      # with permissions.pull-requests: write on the job. Swallow that so the
-      # Performance Test check stays green — the real gate is bundle-size.
+      # with permissions.pull-requests: write on the job. Handle that expected
+      # denial while surfacing every other failure.
       - name: Comment PR with performance results
         if: github.event_name == 'pull_request'
-        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -64,10 +63,12 @@ jobs:
                 body: comment,
               });
             } catch (err) {
-              // Expected on PRs from forks: token cannot write comments.
-              core.warning(
-                `Skipping performance PR comment (${err.status || 'error'}): ${err.message}`,
-              );
+              if (err?.status === 403) {
+                // Expected on PRs from forks: token cannot write comments.
+                core.warning(`Skipping performance PR comment (403): ${err.message}`);
+                return;
+              }
+              throw err;
             }
 
   bundle-size:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -36,23 +36,39 @@ jobs:
       # Disabled until a real staging deployment (and the checkName it waits
       # on) exists in CI. Bundle size budgets are enforced separately by the
       # dedicated `bundle-size` job below, so no inline step is needed here.
+      # Note: fork PRs receive a read-only GITHUB_TOKEN that cannot create
+      # issue comments (403 "Resource not accessible by integration"), even
+      # with permissions.pull-requests: write on the job. Swallow that so the
+      # Performance Test check stays green — the real gate is bundle-size.
       - name: Comment PR with performance results
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            let comment = '## 📊 Performance Report\n\n';
-            comment += '📦 Bundle size analysis completed!\n\n';
-            comment += 'Check the full report in the Actions tab.\n\n';
-            comment += '_Lighthouse CI is currently disabled: it targets a staging deployment (stellarlend-staging.vercel.app) this repo does not have a working deploy pipeline for._';
+            const comment = [
+              '## 📊 Performance Report',
+              '',
+              '📦 Bundle size analysis completed!',
+              '',
+              'Check the full report in the Actions tab.',
+              '',
+              '_Lighthouse CI is currently disabled: it targets a staging deployment (stellarlend-staging.vercel.app) this repo does not have a working deploy pipeline for._',
+            ].join('\n');
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment,
+              });
+            } catch (err) {
+              // Expected on PRs from forks: token cannot write comments.
+              core.warning(
+                `Skipping performance PR comment (${err.status || 'error'}): ${err.message}`,
+              );
+            }
 
   bundle-size:
     name: Bundle Size Budgets

--- a/components/shared/common/AlertBanner.test.tsx
+++ b/components/shared/common/AlertBanner.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '@/test/test-utils';
-import { describe, it, beforeEach, expect } from 'vitest';
+import { render, screen, waitFor } from '@/test/test-utils';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import { AlertBanner } from './AlertBanner';
 
 /**
@@ -9,12 +9,17 @@ import { AlertBanner } from './AlertBanner';
  * - All severity variants (info, warning, error, critical, success)
  * - Dismiss button behavior and onDismiss callback
  * - Persistence via localStorage when a dismissKey is provided
+ * - Storage-blocked environments (SecurityError / DOMException)
  * - Accessibility semantics (role, aria-live, aria-labelledby, aria-describedby)
  */
 
 describe('AlertBanner', () => {
   beforeEach(() => {
     window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('renders an accessible region with a title and message', async () => {
@@ -24,7 +29,7 @@ describe('AlertBanner', () => {
         message="$250.00 due in 4 days"
         severity="info"
         dismissKey="test-alert"
-      />
+      />,
     );
 
     const region = await screen.findByRole('status');
@@ -38,7 +43,7 @@ describe('AlertBanner', () => {
         message="$250.00 due in 4 days"
         severity="info"
         dismissKey="info-test"
-      />
+      />,
     );
     const region = await screen.findByRole('status');
     expect(region).toBeInTheDocument();
@@ -48,20 +53,67 @@ describe('AlertBanner', () => {
     expect(screen.getByRole('button', { name: /dismiss alert/i })).toBeInTheDocument();
   });
 
-  it('persists dismissal state through localStorage', async () => {
+  it('persists dismissal state through localStorage under the dismissKey', async () => {
     render(
       <AlertBanner
         title="Action required"
         message="Your next payment is due in 1 day."
         severity="critical"
         dismissKey="dashboard-alert-test"
-      />
+      />,
     );
 
     const dismissButton = await screen.findByRole('button', { name: /dismiss alert/i });
     await userEvent.click(dismissButton);
 
-    expect(window.localStorage.getItem('dismissed-dashboard-alert-test')).toBe('true');
+    expect(window.localStorage.getItem('dashboard-alert-test')).toBe('dismissed');
+  });
+
+  it('still dismisses and calls onDismiss when localStorage.setItem throws', async () => {
+    const onDismiss = vi.fn();
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Access denied', 'SecurityError');
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <AlertBanner
+        title="Storage blocked"
+        message="Dismiss should still work"
+        severity="warning"
+        dismissKey="blocked-write"
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const dismissButton = await screen.findByRole('button', { name: /dismiss alert/i });
+    await userEvent.click(dismissButton);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+    expect(setItem).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('renders when localStorage.getItem throws (defaults to not dismissed)', async () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Access denied', 'SecurityError');
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <AlertBanner
+        title="Storage blocked on read"
+        message="Banner should still appear"
+        severity="info"
+        dismissKey="blocked-read"
+      />,
+    );
+
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('Storage blocked on read')).toBeInTheDocument();
   });
 
   it('renders error variant with alert role and assertive aria-live', async () => {
@@ -71,7 +123,7 @@ describe('AlertBanner', () => {
         message="Something went wrong."
         severity="error"
         dismissKey="error-test"
-      />
+      />,
     );
     const region = await screen.findByRole('alert');
     expect(region).toBeInTheDocument();
@@ -79,4 +131,3 @@ describe('AlertBanner', () => {
     expect(screen.getByText('Error')).toBeInTheDocument();
   });
 });
-

--- a/components/shared/common/AlertBanner.tsx
+++ b/components/shared/common/AlertBanner.tsx
@@ -64,14 +64,25 @@ export const AlertBanner: React.FC<AlertBannerProps> = ({
       return;
     }
 
-    const dismissed = window.localStorage.getItem(dismissKey) === "dismissed";
-    setIsDismissed(dismissed);
+    // Mirror SidebarContext: localStorage can throw (private mode, policies,
+    // embedded webviews). Default to "not dismissed" so the banner still shows.
+    try {
+      const dismissed = window.localStorage.getItem(dismissKey) === "dismissed";
+      setIsDismissed(dismissed);
+    } catch (error) {
+      console.warn("Failed to read alert dismiss state from localStorage:", error);
+      setIsDismissed(false);
+    }
     setIsReady(true);
   }, [dismissKey]);
 
   const handleDismiss = () => {
     if (dismissKey) {
-      window.localStorage.setItem(dismissKey, "dismissed");
+      try {
+        window.localStorage.setItem(dismissKey, "dismissed");
+      } catch (error) {
+        console.warn("Failed to persist alert dismiss state to localStorage:", error);
+      }
     }
     setIsDismissed(true);
     onDismiss?.();


### PR DESCRIPTION
## Summary
Closes #962.

### AlertBanner fix
- Wrap `localStorage.getItem` / `setItem` in try/catch (SidebarContext pattern)
- Default to not-dismissed when storage is blocked
- Keep dismiss behavior and `onDismiss` working when `setItem` throws
- Add tests for blocked read/write environments

### CI workflow changes also included in this branch
- Correct invalid deploy/monitor workflow schema inherited by the branch
- Handle only the expected fork-token 403 when posting performance comments; unexpected failures are rethrown
- Remove the unreachable staging PR-comment step from the push-only staging workflow
- Correct the commented monitor schedule example so it can be safely restored later

## Test plan
- [x] `npm test -- --run components/shared/common/AlertBanner.test.tsx` — 6/6 pass
- [x] Parse the changed workflow YAML files successfully